### PR TITLE
Fix: ignoring attributes on template argument

### DIFF
--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -597,7 +597,7 @@ template <typename T> inline void Check3( T minVal, T maxVal, T a)
   CHECK( ( a > maxVal ) || ( a < minVal ), "ERROR: Range check " << minVal << " >= " << a << " <= " << maxVal << " failed" );
 }  ///< general min/max clip
 
-extern std::function<void( int, const char*, va_list )> g_msgFnc;
+extern std::function<void( int, const char*, char* )> g_msgFnc;
 
 inline void msg( int level, const char* fmt, ... )
 {

--- a/source/Lib/CommonLib/Rom.cpp
+++ b/source/Lib/CommonLib/Rom.cpp
@@ -81,7 +81,7 @@ StatCounters::StatCounter2DSet<int64_t> g_cuCounters1D( std::vector<std::string>
 StatCounters::StatCounter2DSet<int64_t> g_cuCounters2D( std::vector<std::string> { g_cuCounterIdNames, std::end( g_cuCounterIdNames ) }, MAX_CU_SIZE_IDX, MAX_CU_SIZE_IDX );
 #endif
 
-std::function<void( int, const char*, va_list )> g_msgFnc = nullptr;
+std::function<void( int, const char*, char* )> g_msgFnc = nullptr;
 
 // ====================================================================================================================
 // LFNST Tables


### PR DESCRIPTION
```
CommonDef.h:600:55: warning: ignoring attributes on template argument 'void(int, const char*, va_list)' {aka 'void(int, const char*, char*)'} [-Wignored-attributes]
  600 | extern std::function<void( int, const char*, va_list )> g_msgFnc;
      |                                                       ^
```