### PR TITLE
Prepend apputils to vvenc_ADD_SUBDIRECTORIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if( NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   endif()
 
   # vvenc embedded by superproject, always include source/Lib/vvenc  as first component
-  list( PREPEND ${PROJECT_NAME}_ADD_SUBDIRECTORIES "source/Lib/vvenc" )
+  list( PREPEND ${PROJECT_NAME}_ADD_SUBDIRECTORIES "source/Lib/vvenc;source/Lib/apputils" )
   list( REMOVE_DUPLICATES ${PROJECT_NAME}_ADD_SUBDIRECTORIES )
   message( STATUS "${CMAKE_CURRENT_SOURCE_DIR}: ${PROJECT_NAME} embedded, subdirectories to be added: ${${PROJECT_NAME}_ADD_SUBDIRECTORIES}" )
   # add subdirectories the superproject asked for


### PR DESCRIPTION
Sorry for bothering you again, but when building VVenC v0.3.1.0 as a sub-project like this:

```cmake
fetchcontent_declare(VVENC
  GIT_REPOSITORY "https://github.com/fraunhoferhhi/vvenc.git"
  GIT_TAG "v0.3.1.0"
  GIT_PROGRESS TRUE)
set(vvenc_ADD_SUBDIRECTORIES "source/App/vvencFFapp")
fetchcontent_makeavailable(VVENC)
```

I get a linker error that `-lapputils` is missing. This pull request fixes that.

If in your opinion this should be part of the client code, then I could change the second-last line in above snippet to explicitly ask for `source/Lib/apputils`, but I just want to build and use `vvencFFapp`.