### PR TITLE
Add Github Actions to build static versions

### DIFF
--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -1,0 +1,27 @@
+name: Build executables for Linux
+on:
+  push:
+    branches: [ master, develop, build ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Gather build version
+      run: |
+        make install-release
+
+    - name: Upload standalone executable artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: vvenc
+        path: |
+          install/vvencapp
+          install/vvencFFapp
+          LICENSE.txt

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -17,12 +17,16 @@ jobs:
       run: |
         make install-release
 
+    - name: Run tests
+      run: |
+        chmod +x dist/FastFlix
+        bin/release-static/vvenclibtest
+
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
-        name: vvenc
+        name: vvenc_linux
         path: |
           bin/release-static/vvencapp
           bin/release-static/vvencFFapp
-          bin/release-static/vvenclibtest
           LICENSE.txt

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -14,19 +14,23 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build vvenc
+      run: make install-release
+
+    - name: Move executables to root directory
       run: |
-        make install-release
+        cp bin/release-static/* .
+        chmod +x ./vvencapp
+        chmod +x ./vvencFFapp
+        chmod +x ./vvenclibtest
 
     - name: Run tests
-      run: |
-        chmod +x dist/FastFlix
-        bin/release-static/vvenclibtest
+      run: ./vvenclibtest
 
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
         name: vvenc_linux
         path: |
-          bin/release-static/vvencapp
-          bin/release-static/vvencFFapp
+          vvencapp
+          vvencFFapp
           LICENSE.txt

--- a/.github/workflows/build_linux.yaml
+++ b/.github/workflows/build_linux.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Gather build version
+    - name: Build vvenc
       run: |
         make install-release
 
@@ -22,6 +22,7 @@ jobs:
       with:
         name: vvenc
         path: |
-          install/vvencapp
-          install/vvencFFapp
+          bin/release-static/vvencapp
+          bin/release-static/vvencFFapp
+          bin/release-static/vvenclibtest
           LICENSE.txt

--- a/.github/workflows/build_mac.yaml
+++ b/.github/workflows/build_mac.yaml
@@ -14,19 +14,23 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build vvenc
+      run: make install-release
+
+    - name: Move executables to root directory
       run: |
-        make install-release
+        cp bin/release-static/* .
+        chmod +x ./vvencapp
+        chmod +x ./vvencFFapp
+        chmod +x ./vvenclibtest
 
     - name: Run tests
-      run: |
-        chmod +x dist/FastFlix
-        bin/release-static/vvenclibtest
+      run: ./vvenclibtest
 
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
         name: vvenc_macos
         path: |
-          bin/release-static/vvencapp
-          bin/release-static/vvencFFapp
+          vvencapp
+          vvencFFapp
           LICENSE.txt

--- a/.github/workflows/build_mac.yaml
+++ b/.github/workflows/build_mac.yaml
@@ -1,4 +1,4 @@
-name: Build executables for Windows
+name: Build executables for Mac
 on:
   push:
     branches: [ master, develop, build ]
@@ -8,13 +8,12 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2019
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Build vvenc
-      shell: cmd
       run: |
         make install-release
 
@@ -23,7 +22,7 @@ jobs:
       with:
         name: vvenc
         path: |
-          bin/release-static/vvencapp.exe
-          bin/release-static/vvencFFapp.exe
-          bin/release-static/vvenclibtest.exe
+          bin/release-static/vvencapp
+          bin/release-static/vvencFFapp
+          bin/release-static/vvenclibtest
           LICENSE.txt

--- a/.github/workflows/build_mac.yaml
+++ b/.github/workflows/build_mac.yaml
@@ -17,12 +17,16 @@ jobs:
       run: |
         make install-release
 
+    - name: Run tests
+      run: |
+        chmod +x dist/FastFlix
+        bin/release-static/vvenclibtest
+
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
-        name: vvenc
+        name: vvenc_macos
         path: |
           bin/release-static/vvencapp
           bin/release-static/vvencFFapp
-          bin/release-static/vvenclibtest
           LICENSE.txt

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -15,19 +15,21 @@ jobs:
 
     - name: Build vvenc
       shell: cmd
-      run: |
-        make install-release
+      run: make install-release
+
+    - name: Move executables to root directory
+      shell: cmd
+      run: move bin\release-static\*.exe .
 
     - name: Run tests
       shell: cmd
-      run: |
-        bin/release-static/vvenclibtest.exe
+      run: vvenclibtest.exe
 
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
         name: vvenc_win64
         path: |
-          bin/release-static/vvencapp.exe
-          bin/release-static/vvencFFapp.exe
+          vvencapp.exe
+          vvencFFapp.exe
           LICENSE.txt

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -1,0 +1,28 @@
+name: Build executables for Windows
+on:
+  push:
+    branches: [ master, develop, build ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Gather build version
+      shell: cmd
+      run: |
+        make install-release
+
+    - name: Upload standalone executable artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: vvenc
+        path: |
+          install/vvencapp
+          install/vvencFFapp
+          LICENSE.txt

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -18,12 +18,16 @@ jobs:
       run: |
         make install-release
 
+    - name: Run tests
+      shell: cmd
+      run: |
+        bin/release-static/vvenclibtest.exe
+
     - name: Upload standalone executable artifact
       uses: actions/upload-artifact@v2
       with:
-        name: vvenc
+        name: vvenc_win64
         path: |
           bin/release-static/vvencapp.exe
           bin/release-static/vvencFFapp.exe
-          bin/release-static/vvenclibtest.exe
           LICENSE.txt


### PR DESCRIPTION
Here are three very basic scripts that will build the static releases, as outlined in the readme.  

They will each run the `vvenclibtest` to make sure it compiled correctly and then zip up the `vvencapp`, `vvencFFapp` and `LICNESE.txt`.

Example runs at https://github.com/cdgriffith/vvenc/actions

They currently do NOT include version number in the zip name, nor try to automatically attach to release.