### PR TITLE
Remove check for empty input to fix stdin piping

### DIFF
--- a/source/Lib/apputils/YuvFileIO.cpp
+++ b/source/Lib/apputils/YuvFileIO.cpp
@@ -512,15 +512,7 @@ int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fil
   {
     if( fileName.empty() )
     {
-      if( ( fseek(stdin, 0, SEEK_END), ftell(stdin)) > 0 )
-      {
-        rewind( stdin );
-      }
-      else
-      {
-        m_lastError = "\nERROR: stdin is empty, check input!";
-        return -1;
-      }
+      rewind( stdin );
 
       m_readStdin = true;
       return 0;

--- a/source/Lib/apputils/YuvFileIO.cpp
+++ b/source/Lib/apputils/YuvFileIO.cpp
@@ -512,8 +512,6 @@ int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fil
   {
     if( fileName.empty() )
     {
-      rewind( stdin );
-
       m_readStdin = true;
       return 0;
     }


### PR DESCRIPTION
This check always failed, seems to encode fine without it though. Should fix #47