### PR TITLE
Avoid std::unary_function

### DIFF
--- a/source/Lib/CommonLib/Mv.h
+++ b/source/Lib/CommonLib/Mv.h
@@ -295,7 +295,7 @@ void roundAffineMv( int& mvx, int& mvy, int nShift );
 namespace std
 {
   template <>
-  struct hash<vvenc::Mv> : public std::unary_function<vvenc::Mv, uint64_t>
+  struct hash<vvenc::Mv>
   {
     uint64_t operator()(const vvenc::Mv& value) const
     {


### PR DESCRIPTION
`std::unary_function` is deprecated in C++11 and removed in C++17.

This pull request relates to #29 