### PR TITLE
Fix for CCALF AVX2 to SSE42 dispatch for non multiple of 8 widths

### DIFF
--- a/source/Lib/CommonLib/x86/AdaptiveLoopFilterX86.h
+++ b/source/Lib/CommonLib/x86/AdaptiveLoopFilterX86.h
@@ -1299,6 +1299,7 @@ void simdFilterBlkCcAlf<AVX2>( const PelBuf &dstBuf, const CPelUnitBuf &recSrc, 
   if( blkDst.width & 7 )
   {
     simdFilterBlkCcAlf<SSE42>( dstBuf, recSrc, blkDst, blkSrc, compId, filterCoeff, clpRngs, cs, vbCTUHeight, vbPos );
+    return;
   }
 
   CHECK( 1 << floorLog2( vbCTUHeight ) != vbCTUHeight, "Not a power of 2" );


### PR DESCRIPTION
Fix for CCALF AVX2 to SSE42 dispatch for non multiple of 8 widths