### PR TITLE
fix include TARGET_SIMD_X86

### DIFF
--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -104,7 +104,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define SIMD_PREFETCH_T0(_s)
 #endif //ENABLE_SIMD_OPT
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && !defined( __MINGW32__ )
 # include <intrin.h>
 #else
 # include <x86intrin.h>

--- a/source/Lib/CommonLib/DepQuant.cpp
+++ b/source/Lib/CommonLib/DepQuant.cpp
@@ -48,7 +48,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "TrQuant.h"
 #include "CodingStructure.h"
 #include "UnitTools.h"
-#include "CommonDefX86.h"
+#ifdef TARGET_SIMD_X86
+#include "x86/CommonDefX86.h"
+#endif
 
 #include <bitset>
 

--- a/source/Lib/CommonLib/IntraPrediction.cpp
+++ b/source/Lib/CommonLib/IntraPrediction.cpp
@@ -492,7 +492,9 @@ void IntraPrediction::initPredIntraParams(const CodingUnit& cu, const CompArea a
   }
 }
 
-#include "CommonDefX86.h"
+#ifdef TARGET_SIMD_X86
+#include "x86/CommonDefX86.h"
+#endif
 
 
 /** Function for deriving the simplified angular intra predictions.

--- a/source/Lib/CommonLib/LoopFilter.cpp
+++ b/source/Lib/CommonLib/LoopFilter.cpp
@@ -61,7 +61,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "Quant.h"
 
 #ifdef TARGET_SIMD_X86
-#include "CommonDefX86.h"
+#include "x86/CommonDefX86.h"
 #endif
 
 namespace vvenc {

--- a/source/Lib/CommonLib/x86/CommonDefX86.h
+++ b/source/Lib/CommonLib/x86/CommonDefX86.h
@@ -52,9 +52,10 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef TARGET_SIMD_X86
 
-#include <immintrin.h>
 #if defined _MSC_VER
 #include <tmmintrin.h>
+#else
+#include <immintrin.h>
 #endif
 
 //! \ingroup CommonLib

--- a/source/Lib/CommonLib/x86/CommonDefX86.h
+++ b/source/Lib/CommonLib/x86/CommonDefX86.h
@@ -52,10 +52,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef TARGET_SIMD_X86
 
+#include <immintrin.h>
 #if defined _MSC_VER
 #include <tmmintrin.h>
-#else
-#include <immintrin.h>
 #endif
 
 //! \ingroup CommonLib

--- a/source/Lib/EncoderLib/EncPicture.cpp
+++ b/source/Lib/EncoderLib/EncPicture.cpp
@@ -51,7 +51,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "EncPicture.h"
 #include "EncGOP.h"
-#include "UnitTools.h"
+#include "CommonLib/UnitTools.h"
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/dtrace_buffer.h"
 #include "CommonLib/dtrace_codingstruct.h"


### PR DESCRIPTION
```
c:\msys1200\lib\gcc\x86_64-w64-mingw32\12.0.0\include\cpuid.h:335:1: error: 'void __cpuidex(int*, int, int)' redeclared inline without 'gnu_inline' attribute
  335 | __cpuidex (int __cpuid_info[4], int __leaf, int __subleaf)
      | ^~~~~~~~~
In file included from c:\msys1200\x86_64-w64-mingw32\include\intrin.h:41,
                 from ../CommonDef.h:109,
                 from CommonDefX86.h:51,
                 from CommonDefX86.cpp:54:
c:\msys1200\x86_64-w64-mingw32\include\psdk_inc\intrin-impl.h:1865:6: note: 'void __cpuidex(int*, int, int)' previously defined here
 1865 | void __cpuidex(int CPUInfo[4], int function_id, int subfunction_id) {
      |      ^~~~~~~~~
```