### PR TITLE
Remove global variables for the logging callback

### DIFF
--- a/include/vvenc/vvenc.h
+++ b/include/vvenc/vvenc.h
@@ -379,13 +379,14 @@ VVENC_DECL int vvenc_print_summary( vvencEncoder * );
 VVENC_DECL const char* vvenc_get_error_msg( int nRet );
 
 /* vvenc_set_logging_callback
- This method registers a log message callback function to the encoder library.
+ This method registers a log message callback function to the encoder instance.
  If no such function has been registered, the library will omit all messages.
+ \param[in]  vvencEncoder pointer to opaque handler
  \param[in]  ctx pointer of the caller, if not needed set it to null
  \paramin]   Log message callback function.
  \retval     int VVENC_ERR_INITIALIZE indicates the encoder was not successfully initialized in advance, otherwise the return value VVENC_OK indicates success.
 */
-VVENC_DECL int vvenc_set_logging_callback( void * ctx, vvencLoggingCallback callback );
+VVENC_DECL int vvenc_set_logging_callback( vvencEncoder * , void * ctx, vvencLoggingCallback callback );
 
 /* vvenc_get_compile_info_string
  creates compile info string containing OS, Compiler and Bit-depth (e.g. 32 or 64 bit).

--- a/source/App/vvencFFapp/EncApp.cpp
+++ b/source/App/vvencFFapp/EncApp.cpp
@@ -125,6 +125,8 @@ int EncApp::encode()
     return -1;
   }
 
+  vvenc_set_logging_callback( m_encCtx, nullptr, &::msgFnc );
+
   int iRet = vvenc_encoder_open( m_encCtx, &vvencCfg);
   if( 0 != iRet )
   {

--- a/source/App/vvencFFapp/encmain.cpp
+++ b/source/App/vvencFFapp/encmain.cpp
@@ -69,8 +69,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 int main(int argc, char* argv[])
 {
-  vvenc_set_logging_callback( nullptr, msgFnc );
-
   std::string simdOpt;
   apputils::df::program_options_lite::Options opts;
   opts.addOptions()

--- a/source/App/vvencapp/vvencapp.cpp
+++ b/source/App/vvencapp/vvencapp.cpp
@@ -131,8 +131,6 @@ int main( int argc, char* argv[] )
     cAppname = cAppname.substr(iPos+1 );
   }
 
-  vvenc_set_logging_callback( nullptr, msgFnc );
-
   // default encoder configuration
   apputils::VVEncAppCfg vvencappCfg;
   vvenc_init_default( &vvencappCfg, 1920, 1080, 60, 0, 32, vvencPresetMode::VVENC_MEDIUM );
@@ -161,6 +159,8 @@ int main( int argc, char* argv[] )
   {
     return -1;
   }
+
+  vvenc_set_logging_callback( enc, nullptr, msgFnc );
 
   int iRet = vvenc_encoder_open( enc, &vvencappCfg );
   if( 0 != iRet )

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -586,21 +586,6 @@ template <typename T> inline void Check3( T minVal, T maxVal, T a)
   CHECK( ( a > maxVal ) || ( a < minVal ), "ERROR: Range check " << minVal << " >= " << a << " <= " << maxVal << " failed" );
 }  ///< general min/max clip
 
-extern std::function<void( void*, int, const char*, va_list )> g_msgFnc;
-extern void * m_msgFncCtx;
-
-inline void msg( int level, const char* fmt, ... )
-{
-  if ( g_msgFnc )
-  {
-    static std::mutex _msgMutex;
-    std::unique_lock<std::mutex> _lock( _msgMutex );
-    va_list args;
-    va_start( args, fmt );
-    g_msgFnc( m_msgFncCtx, level, fmt, args );
-    va_end( args );
-  }
-}
 
 inline std::string print( const char* fmt, ...)
 {

--- a/source/Lib/CommonLib/PicYuvMD5.cpp
+++ b/source/Lib/CommonLib/PicYuvMD5.cpp
@@ -296,11 +296,14 @@ int calcAndPrintHashStatus(const CPelUnitBuf& pic, const SEIDecodedPictureHash* 
     }
   }
 
-  msg( msgl, "[%s:%s,%s] ", hashType, hashToString(recon_digest, numChar).c_str(), ok);
+  (void)numChar;
+  (void)ok;
+  (void)hashType;
+  //msg( msgl, "[%s:%s,%s] ", hashType, hashToString(recon_digest, numChar).c_str(), ok);
 
   if (mismatch)
   {
-    msg( msgl, "[rx%s:%s] ", hashType, hashToString(pictureHashSEI->pictureHash, numChar).c_str());
+    //msg( msgl, "[rx%s:%s] ", hashType, hashToString(pictureHashSEI->pictureHash, numChar).c_str());
   }
   return mismatch;
 }

--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -311,9 +311,9 @@ void Picture::finalInit( const VPS& _vps, const SPS& sps, const PPS& pps, PicHea
   sliceDataNumBins = 0;
 }
 
-Slice* Picture::allocateNewSlice()
+Slice* Picture::allocateNewSlice( Logger* logger )
 {
-  slices.push_back( new Slice );
+  slices.push_back( new Slice( logger ) );
   Slice& slice = *slices.back();
 
   slice.pic     = this;

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -265,7 +265,7 @@ public:
   std::vector<uint8_t>          m_alfCtuAlternative[ MAX_NUM_COMP ];
 
 public:
-  Slice*          allocateNewSlice();
+  Slice*          allocateNewSlice( Logger* logger );
   Slice*          swapSliceObject( Slice* p, uint32_t i );
 
   SAOBlkParam    *getSAO    (int id = 0)                     { return &m_sao[id][0]; };

--- a/source/Lib/CommonLib/Rom.cpp
+++ b/source/Lib/CommonLib/Rom.cpp
@@ -81,9 +81,6 @@ StatCounters::StatCounter2DSet<int64_t> g_cuCounters1D( std::vector<std::string>
 StatCounters::StatCounter2DSet<int64_t> g_cuCounters2D( std::vector<std::string> { g_cuCounterIdNames, std::end( g_cuCounterIdNames ) }, MAX_CU_SIZE_IDX, MAX_CU_SIZE_IDX );
 #endif
 
-std::function<void( void*, int, const char*, va_list )> g_msgFnc = nullptr;
-void * m_msgFncCtx = nullptr;
-
 // ====================================================================================================================
 // LFNST Tables
 // ====================================================================================================================

--- a/source/Lib/CommonLib/Slice.cpp
+++ b/source/Lib/CommonLib/Slice.cpp
@@ -61,7 +61,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace vvenc {
 
-Slice::Slice()
+Slice::Slice( Logger *logger )
   : ppsId                               ( -1 )
 //  , picOutputFlag                       ( true )
   , poc                                 ( 0 )
@@ -117,6 +117,7 @@ Slice::Slice()
   , tileGroupCcAlfCrApsId               ( -1 )
   , disableSATDForRd                    ( 0 )
   , isLossless                          ( false )
+  , m_logger                            ( logger )
 {
   ::memset( saoEnabled,              0, sizeof( saoEnabled ) );
   ::memset( numRefIdx,               0, sizeof( numRefIdx ) );
@@ -1036,7 +1037,7 @@ int Slice::checkThatAllRefPicsAreAvailable(PicList& rcListPic, const ReferencePi
     {
       if (printErrors)
       {
-        msg(VVENC_ERROR, "\nCurrent picture: %d Long-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", poc, notPresentPoc);
+        m_logger->log(VVENC_ERROR, "\nCurrent picture: %d Long-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", poc, notPresentPoc);
       }
       return notPresentPoc;
     }
@@ -1067,7 +1068,7 @@ int Slice::checkThatAllRefPicsAreAvailable(PicList& rcListPic, const ReferencePi
     {
       if (printErrors)
       {
-        msg(VVENC_ERROR, "\nCurrent picture: %d Short-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", poc, notPresentPoc);
+        m_logger->log(VVENC_ERROR, "\nCurrent picture: %d Short-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", poc, notPresentPoc);
       }
       return notPresentPoc;
     }
@@ -1993,7 +1994,7 @@ bool ParameterSetManager::activatePPS(int ppsId, bool isIRAP)
     int spsId = pps->spsId;
     if (!isIRAP && (spsId != m_activeSPSId ))
     {
-      msg( VVENC_WARNING, "Warning: tried to activate PPS referring to a inactive SPS at non-IDR.");
+      //msg( VVENC_WARNING, "Warning: tried to activate PPS referring to a inactive SPS at non-IDR.");
     }
     else
     {
@@ -2003,7 +2004,7 @@ bool ParameterSetManager::activatePPS(int ppsId, bool isIRAP)
         int dciId = sps->dciId;
         if ((m_activeDCIId!=-1) && (dciId != m_activeDCIId ))
         {
-          msg( VVENC_WARNING, "Warning: tried to activate DCI with different ID than the currently active DCI. This should not happen within the same bitstream!");
+          //msg( VVENC_WARNING, "Warning: tried to activate DCI with different ID than the currently active DCI. This should not happen within the same bitstream!");
         }
         else
         {
@@ -2017,7 +2018,7 @@ bool ParameterSetManager::activatePPS(int ppsId, bool isIRAP)
             }
             else
             {
-              msg( VVENC_WARNING, "Warning: tried to activate PPS that refers to a non-existing DCI.");
+              //msg( VVENC_WARNING, "Warning: tried to activate PPS that refers to a non-existing DCI.");
             }
           }
           else
@@ -2037,13 +2038,13 @@ bool ParameterSetManager::activatePPS(int ppsId, bool isIRAP)
       }
       else
       {
-        msg( VVENC_WARNING, "Warning: tried to activate a PPS that refers to a non-existing SPS.");
+        //msg( VVENC_WARNING, "Warning: tried to activate a PPS that refers to a non-existing SPS.");
       }
     }
   }
   else
   {
-    msg( VVENC_WARNING, "Warning: tried to activate non-existing PPS.");
+    //msg( VVENC_WARNING, "Warning: tried to activate non-existing PPS.");
   }
 
   // Failed to activate if reach here.
@@ -2062,7 +2063,7 @@ bool ParameterSetManager::activateAPS(int apsId, int apsType)
   }
   else
   {
-    msg(VVENC_WARNING, "Warning: tried to activate non-existing APS.");
+    //msg(VVENC_WARNING, "Warning: tried to activate non-existing APS.");
   }
   return false;
 }

--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -55,6 +55,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "Common.h"
 #include "MotionInfo.h"
 #include "HRD.h"
+#include "Utilities/Logger.h"
 
 #include "vvenc/vvencCfg.h"
 
@@ -1188,7 +1189,7 @@ struct PicHeader
 class Slice
 {
 
-  public:
+public:
   //  Bitstream writing
   bool                        saoEnabled[MAX_NUM_CH];
   int                         ppsId;               ///< picture parameter set ID
@@ -1274,7 +1275,7 @@ class Slice
   uint8_t*                    ccAlfFilterControl[2];
 
 public:
-                              Slice();
+                              Slice( Logger *logger = nullptr );
   virtual                     ~Slice();
   void                        resetSlicePart();
   void                        constructRefPicList(PicList& rcListPic, bool extBorder);
@@ -1330,6 +1331,8 @@ public:
   void                        setAlfApsIds( const std::vector<int>& ApsIDs);
 private:
   Picture*                    xGetLongTermRefPic(PicList& rcListPic, int poc, bool pocHasMsb);
+
+  Logger*                     m_logger;
 };// END CLASS DEFINITION Slice
 
 void calculateParameterSetChangedFlag(bool& bChanged, const std::vector<uint8_t>* pOldData, const std::vector<uint8_t>* pNewData);

--- a/source/Lib/CommonLib/dtrace_next.h
+++ b/source/Lib/CommonLib/dtrace_next.h
@@ -262,13 +262,13 @@ inline CDTrace* tracing_init( const std::string& sTracingFile, const std::string
 
   if( !sTracingFile.empty() || !sTracingRule.empty() )
   {
-    msg( VVENC_VERBOSE, "\nTracing is enabled: %s : %s\n", sTracingFile.c_str(), sTracingRule.c_str() );
+    //msg( VVENC_VERBOSE, "\nTracing is enabled: %s : %s\n", sTracingFile.c_str(), sTracingRule.c_str() );
   }
 
   CDTrace *pDtrace = new CDTrace( sTracingFile, sTracingRule, channels );
   if( pDtrace->getLastError() )
   {
-    msg( VVENC_WARNING, "%s\n", pDtrace->getErrMessage().c_str() );
+    //msg( VVENC_WARNING, "%s\n", pDtrace->getErrMessage().c_str() );
     //return NULL;
   }
 

--- a/source/Lib/DecoderLib/DecLib.cpp
+++ b/source/Lib/DecoderLib/DecLib.cpp
@@ -100,7 +100,7 @@ bool tryDecodePicture( Picture* pcEncPic, const int expectedPoc, const std::stri
       ffwdDecoder.pcDecLib->setDecodedPictureHashSEIEnabled( true );
       if(apsMap) ffwdDecoder.pcDecLib->setAPSMapEnc        ( apsMap );
 
-      msg( VVENC_INFO, "start to decode %s \n", bitstreamFileName.c_str() );
+      //msg( VVENC_INFO, "start to decode %s \n", bitstreamFileName.c_str() );
     }
 
     bool goOn = true;
@@ -132,7 +132,7 @@ bool tryDecodePicture( Picture* pcEncPic, const int expectedPoc, const std::stri
            *  - two back-to-back start_code_prefixes
            *  - start_code_prefix immediately followed by EOF
            */
-          msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n" );
+          //msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n" );
         }
         else
         {
@@ -638,19 +638,19 @@ void DecLib::finishPicture(int& poc, PicList*& rpcListPic, vvencMsgLevel msgl )
   if (slice->isDRAP) c = 'D';
 
   //-- For time output for each slice
-  msg( msgl, "POC %4d TId: %1d ( %c-SLICE, QP%3d ) ", slice->poc,
-         slice->TLayer,
-         c,
-         slice->sliceQp );
+  // msg( msgl, "POC %4d TId: %1d ( %c-SLICE, QP%3d ) ", slice->poc,
+  //        slice->TLayer,
+  //        c,
+  //        slice->sliceQp );
 
   for (int iRefList = 0; iRefList < 2; iRefList++)
   {
-    msg( msgl, "[L%d ", iRefList);
+    //msg( msgl, "[L%d ", iRefList);
     for (int iRefIndex = 0; iRefIndex < slice->numRefIdx[ iRefList ]; iRefIndex++)
     {
-      msg( msgl, "%d ", slice->getRefPOC(RefPicList(iRefList), iRefIndex));
+      //msg( msgl, "%d ", slice->getRefPOC(RefPicList(iRefList), iRefIndex));
     }
-    msg( msgl, "] ");
+    //msg( msgl, "] ");
   }
   if (m_decodedPictureHashSEIEnabled)
   {
@@ -658,12 +658,12 @@ void DecLib::finishPicture(int& poc, PicList*& rpcListPic, vvencMsgLevel msgl )
     const SEIDecodedPictureHash *hash = ( pictureHashes.size() > 0 ) ? (SEIDecodedPictureHash*) *(pictureHashes.begin()) : NULL;
     if (pictureHashes.size() > 1)
     {
-      msg( VVENC_WARNING, "Warning: Got multiple decoded picture hash SEI messages. Using first.");
+      //msg( VVENC_WARNING, "Warning: Got multiple decoded picture hash SEI messages. Using first.");
     }
     m_numberOfChecksumErrorsDetected += calcAndPrintHashStatus(((const Picture*) m_pic)->getRecoBuf(), hash, slice->sps->bitDepths, msgl);
   }
 
-  msg( msgl, "\n");
+  //msg( msgl, "\n");
 
   m_pic->isNeededForOutput = slice->picHeader->picOutputFlag;
   m_pic->isReconstructed   = true;
@@ -717,7 +717,7 @@ void DecLib::xUpdateRasInit(Slice* slice)
 
 void DecLib::xCreateLostPicture( int iLostPoc, const int layerId )
 {
-  msg( VVENC_INFO, "\ninserting lost poc : %d\n",iLostPoc);
+  //msg( VVENC_INFO, "\ninserting lost poc : %d\n",iLostPoc);
   Picture *cFillPic = xGetNewPicBuffer(*(m_parameterSetManager.getFirstSPS()), *(m_parameterSetManager.getFirstPPS()), 0, layerId);
 
   CHECK( !cFillPic->slices.size(), "No slices in picture" );
@@ -740,7 +740,7 @@ void DecLib::xCreateLostPicture( int iLostPoc, const int layerId )
     Picture *pic = *(iterPic++);
     if(abs(pic->getPOC() -iLostPoc)==closestPoc&&pic->getPOC()!=m_apcSlicePilot->poc)
     {
-      msg( VVENC_INFO, "copying picture %d to %d (%d)\n",pic->getPOC() ,iLostPoc,m_apcSlicePilot->poc);
+      //msg( VVENC_INFO, "copying picture %d to %d (%d)\n",pic->getPOC() ,iLostPoc,m_apcSlicePilot->poc);
       cFillPic->getRecoBuf().copyFrom( pic->getRecoBuf() );
       break;
     }
@@ -1017,7 +1017,7 @@ void DecLib::xActivateParameterSets( const int layerId)
     m_pic->cs->createTempBuffers( true );
     m_pic->cs->initStructData( MAX_INT, false, nullptr, true );
 
-    m_pic->allocateNewSlice();
+    //m_pic->allocateNewSlice();
     // make the slice-pilot a real slice, and set up the slice-pilot for the next slice
     CHECK(m_pic->slices.size() != (m_uiSliceSegmentIdx + 1), "Invalid number of slices");
     m_apcSlicePilot = m_pic->swapSliceObject(m_apcSlicePilot, m_uiSliceSegmentIdx);
@@ -1077,7 +1077,7 @@ void DecLib::xActivateParameterSets( const int layerId)
   else
   {
     // make the slice-pilot a real slice, and set up the slice-pilot for the next slice
-    m_pic->allocateNewSlice();
+    //m_pic->allocateNewSlice();
     CHECK(m_pic->slices.size() != (size_t)(m_uiSliceSegmentIdx + 1), "Invalid number of slices");
     m_apcSlicePilot = m_pic->swapSliceObject(m_apcSlicePilot, m_uiSliceSegmentIdx);
 
@@ -1247,7 +1247,7 @@ void DecLib::xParsePrefixSEIsForUnknownVCLNal()
   while (!m_prefixSEINALUs.empty())
   {
     // do nothing?
-    msg( VVENC_NOTICE, "Discarding Prefix SEI associated with unknown VCL NAL unit.\n");
+    //msg( VVENC_NOTICE, "Discarding Prefix SEI associated with unknown VCL NAL unit.\n");
     delete m_prefixSEINALUs.front();
   }
   // TODO: discard following suffix SEIs as well?
@@ -1435,7 +1435,7 @@ bool DecLib::xDecodeSlice(InputNALUnit &nalu, int& iSkipFrame, int iPOCLastDispl
   //we should only get a different poc for a new picture (with CTU address==0)
   if(m_apcSlicePilot->poc != m_prevPOC && !m_bFirstSliceInSequence && (m_apcSlicePilot->sliceMap.ctuAddrInSlice[0] != 0))
   {
-    msg( VVENC_WARNING, "Warning, the first slice of a picture might have been lost!\n");
+    //msg( VVENC_WARNING, "Warning, the first slice of a picture might have been lost!\n");
   }
   m_prevLayerID = nalu.m_nuhLayerId;
 
@@ -1696,7 +1696,7 @@ bool DecLib::decode(InputNALUnit& nalu, int& iSkipFrame, int& iPOCLastDisplay, i
       }
       else
       {
-        msg( VVENC_NOTICE, "Note: received suffix SEI but no picture currently active.\n");
+        //msg( VVENC_NOTICE, "Note: received suffix SEI but no picture currently active.\n");
       }
       return false;
 
@@ -1735,7 +1735,7 @@ bool DecLib::decode(InputNALUnit& nalu, int& iSkipFrame, int& iPOCLastDisplay, i
 
     case VVENC_NAL_UNIT_RESERVED_IRAP_VCL_11:
     case VVENC_NAL_UNIT_RESERVED_IRAP_VCL_12:
-      msg( VVENC_NOTICE, "Note: found reserved VCL NAL unit.\n");
+      //msg( VVENC_NOTICE, "Note: found reserved VCL NAL unit.\n");
       xParsePrefixSEIsForUnknownVCLNal();
       return false;
     case VVENC_NAL_UNIT_RESERVED_VCL_4:
@@ -1743,13 +1743,13 @@ bool DecLib::decode(InputNALUnit& nalu, int& iSkipFrame, int& iPOCLastDisplay, i
     case VVENC_NAL_UNIT_RESERVED_VCL_6:
     case VVENC_NAL_UNIT_RESERVED_NVCL_26:
     case VVENC_NAL_UNIT_RESERVED_NVCL_27:
-      msg( VVENC_NOTICE, "Note: found reserved NAL unit.\n");
+      //msg( VVENC_NOTICE, "Note: found reserved NAL unit.\n");
       return false;
     case VVENC_NAL_UNIT_UNSPECIFIED_28:
     case VVENC_NAL_UNIT_UNSPECIFIED_29:
     case VVENC_NAL_UNIT_UNSPECIFIED_30:
     case VVENC_NAL_UNIT_UNSPECIFIED_31:
-      msg( VVENC_NOTICE, "Note: found unspecified NAL unit.\n");
+      //msg( VVENC_NOTICE, "Note: found unspecified NAL unit.\n");
       return false;
     default:
       THROW( "Invalid NAL unit type" );
@@ -1791,7 +1791,7 @@ bool DecLib::isRandomAccessSkipPicture( int& iSkipFrame, int& iPOCLastDisplay )
     {
       if(!m_warningMessageSkipPicture)
       {
-        msg( VVENC_WARNING, "\nWarning: this is not a valid random access point and the data is discarded until the first CRA picture");
+        //msg( VVENC_WARNING, "\nWarning: this is not a valid random access point and the data is discarded until the first CRA picture");
         m_warningMessageSkipPicture = true;
       }
       return true;
@@ -1877,7 +1877,7 @@ bool DecLib::isNewPicture(std::ifstream *bitstreamFile, class InputByteStream *b
     byteStreamNALUnit(*bytestream, nalu.getBitstream().getFifo(), stats);
     if (nalu.getBitstream().getFifo().empty())
     {
-      msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n");
+      //msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n");
     }
     else
     {
@@ -1973,7 +1973,7 @@ bool DecLib::isNewAccessUnit( bool newPicture, std::ifstream *bitstreamFile, cla
     byteStreamNALUnit(*bytestream, nalu.getBitstream().getFifo(), stats);
     if (nalu.getBitstream().getFifo().empty())
     {
-      msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n");
+      //msg( VVENC_ERROR, "Warning: Attempt to decode an empty NAL unit\n");
     }
     else
     {

--- a/source/Lib/DecoderLib/NALread.cpp
+++ b/source/Lib/DecoderLib/NALread.cpp
@@ -106,7 +106,7 @@ static void convertPayloadToRBSP(std::vector<uint8_t>& nalUnitBuf, InputBitstrea
 
     if (n > 0)
     {
-      msg( VVENC_NOTICE, "\nDetected %d instances of cabac_zero_word\n", n/2);
+      //msg( VVENC_NOTICE, "\nDetected %d instances of cabac_zero_word\n", n/2);
     }
   }
 

--- a/source/Lib/DecoderLib/SEIread.cpp
+++ b/source/Lib/DecoderLib/SEIread.cpp
@@ -199,7 +199,7 @@ void SEIReader::xReadSEImessage(SEIMessages& seis, const vvencNalUnitType nalUni
       bp = &hrd.bufferingPeriodSEI;
       if (!bp)
       {
-        msg( VVENC_WARNING, "Warning: Found Decoding unit information SEI message, but no active buffering period is available. Ignoring.");
+        //msg( VVENC_WARNING, "Warning: Found Decoding unit information SEI message, but no active buffering period is available. Ignoring.");
       }
       else
       {
@@ -217,7 +217,7 @@ void SEIReader::xReadSEImessage(SEIMessages& seis, const vvencNalUnitType nalUni
         bp = &hrd.bufferingPeriodSEI;
         if (!bp)
         {
-          msg( VVENC_WARNING, "Warning: Found Picture timing SEI message, but no active buffering period is available. Ignoring.");
+          //msg( VVENC_WARNING, "Warning: Found Picture timing SEI message, but no active buffering period is available. Ignoring.");
         }
         else
         {
@@ -310,7 +310,7 @@ void SEIReader::xReadSEImessage(SEIMessages& seis, const vvencNalUnitType nalUni
         uint32_t seiByte;
         sei_read_code (NULL, 8, seiByte, "unknown prefix SEI payload byte");
       }
-      msg( VVENC_WARNING, "Unknown prefix SEI message (payloadType = %d) was found!\n", payloadType);
+      //msg( VVENC_WARNING, "Unknown prefix SEI message (payloadType = %d) was found!\n", payloadType);
       if (pDecodedMessageOutputStream)
       {
         (*pDecodedMessageOutputStream) << "Unknown prefix SEI message (payloadType = " << payloadType << ") was found!\n";
@@ -340,7 +340,7 @@ void SEIReader::xReadSEImessage(SEIMessages& seis, const vvencNalUnitType nalUni
           uint32_t seiByte;
           sei_read_code( NULL, 8, seiByte, "unknown suffix SEI payload byte");
         }
-        msg( VVENC_WARNING, "Unknown suffix SEI message (payloadType = %d) was found!\n", payloadType);
+        //msg( VVENC_WARNING, "Unknown suffix SEI message (payloadType = %d) was found!\n", payloadType);
         if (pDecodedMessageOutputStream)
         {
           (*pDecodedMessageOutputStream) << "Unknown suffix SEI message (payloadType = " << payloadType << ") was found!\n";

--- a/source/Lib/DecoderLib/VLCReader.cpp
+++ b/source/Lib/DecoderLib/VLCReader.cpp
@@ -3493,7 +3493,7 @@ void HLSyntaxReader::parseRemainingBytes( bool noTrailingBytesExpected )
       uint32_t trailingNullByte=m_pcBitstream->readByte();
       if (trailingNullByte!=0)
       {
-        msg( VVENC_ERROR, "Trailing byte should be 0, but has value %02x\n", trailingNullByte);
+        //msg( VVENC_ERROR, "Trailing byte should be 0, but has value %02x\n", trailingNullByte);
         THROW("Invalid trailing '0' byte");
       }
     }

--- a/source/Lib/EncoderLib/Analyze.h
+++ b/source/Lib/EncoderLib/Analyze.h
@@ -75,10 +75,20 @@ private:
   uint32_t  m_uiNumPic;
   double    m_dFrmRate; //--CFG_KDY
   double    m_MSEyuvframe[MAX_NUM_COMP]; // sum of MSEs
+  Logger*   m_logger;
 
 public:
   virtual ~Analyze()  {}
-  Analyze() { clear(); }
+  Analyze() 
+  { 
+    m_logger = nullptr;
+    clear(); 
+  }
+
+  void setLogger( Logger* logger )
+  {
+    m_logger = logger;
+  }
 
   void  addResult( double psnr[MAX_NUM_COMP], double bits, const double MSEyuvframe[MAX_NUM_COMP]
     , bool isEncodeLtRef
@@ -180,24 +190,24 @@ public:
       case CHROMA_400:
         if (printMSEBasedSNR)
         {
-          msg( e_msg_level, "         \tTotal Frames |   "   "Bitrate     "  "Y-PSNR" );
+          m_logger->log( e_msg_level, "         \tTotal Frames |   "   "Bitrate     "  "Y-PSNR" );
 
           if (printHexPsnr)
           {
-            msg(e_msg_level, "xY-PSNR           ");
+            m_logger->log(e_msg_level, "xY-PSNR           ");
           }
 
           if (printSequenceMSE)
           {
-            msg( e_msg_level, "    Y-MSE\n" );
+            m_logger->log( e_msg_level, "    Y-MSE\n" );
           }
           else
           {
-            msg( e_msg_level, "\n");
+            m_logger->log( e_msg_level, "\n");
           }
 
-          //msg( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
-          msg( e_msg_level, "Average: \t %8d    %c "          "%12.4lf  "    "%8.4lf",
+          //m_logger->log( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
+          m_logger->log( e_msg_level, "Average: \t %8d    %c "          "%12.4lf  "    "%8.4lf",
                  getNumPic(), cDelim,
                  getBits() * dScale,
                  getPsnr(COMP_Y) / (double)getNumPic() );
@@ -212,43 +222,43 @@ public:
               reinterpret_cast<uint8_t *>(&dPsnr) + sizeof(dPsnr),
               reinterpret_cast<uint8_t *>(&xPsnr));
 
-            msg(e_msg_level, "   %16" PRIx64 " ", xPsnr);
+            m_logger->log(e_msg_level, "   %16" PRIx64 " ", xPsnr);
           }
 
           if (printSequenceMSE)
           {
-            msg( e_msg_level, "  %8.4lf\n", m_MSEyuvframe[COMP_Y] / (double)getNumPic() );
+            m_logger->log( e_msg_level, "  %8.4lf\n", m_MSEyuvframe[COMP_Y] / (double)getNumPic() );
           }
           else
           {
-            msg( e_msg_level, "\n");
+            m_logger->log( e_msg_level, "\n");
           }
 
-          msg( e_msg_level, "From MSE:\t %8d    %c "          "%12.4lf  "    "%8.4lf\n",
+          m_logger->log( e_msg_level, "From MSE:\t %8d    %c "          "%12.4lf  "    "%8.4lf\n",
                  getNumPic(), cDelim,
                  getBits() * dScale,
                  MSEBasedSNR[COMP_Y] );
         }
         else
         {
-          msg( e_msg_level, "\tTotal Frames |   "   "Bitrate     "  "Y-PSNR" );
+          m_logger->log( e_msg_level, "\tTotal Frames |   "   "Bitrate     "  "Y-PSNR" );
 
           if (printHexPsnr)
           {
-            msg(e_msg_level, "xY-PSNR           ");
+            m_logger->log(e_msg_level, "xY-PSNR           ");
           }
 
           if (printSequenceMSE)
           {
-            msg( e_msg_level, "    Y-MSE\n" );
+            m_logger->log( e_msg_level, "    Y-MSE\n" );
           }
           else
           {
-            msg( e_msg_level, "\n");
+            m_logger->log( e_msg_level, "\n");
           }
 
-          //msg( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
-          msg( e_msg_level, "\t %8d    %c "          "%12.4lf  "    "%8.4lf",
+          //m_logger->log( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
+          m_logger->log( e_msg_level, "\t %8d    %c "          "%12.4lf  "    "%8.4lf",
                  getNumPic(), cDelim,
                  getBits() * dScale,
                  getPsnr(COMP_Y) / (double)getNumPic() );
@@ -263,16 +273,16 @@ public:
               reinterpret_cast<uint8_t *>(&dPsnr) + sizeof(dPsnr),
               reinterpret_cast<uint8_t *>(&xPsnr));
 
-            msg(e_msg_level, "   %16" PRIx64 " ", xPsnr);
+            m_logger->log(e_msg_level, "   %16" PRIx64 " ", xPsnr);
           }
 
           if (printSequenceMSE)
           {
-            msg( e_msg_level, "  %8.4lf\n", m_MSEyuvframe[COMP_Y] / (double)getNumPic() );
+            m_logger->log( e_msg_level, "  %8.4lf\n", m_MSEyuvframe[COMP_Y] / (double)getNumPic() );
           }
           else
           {
-            msg( e_msg_level, "\n");
+            m_logger->log( e_msg_level, "\n");
           }
         }
         break;
@@ -287,24 +297,24 @@ public:
 
           if (printMSEBasedSNR)
           {
-            msg( e_msg_level, "         \tTotal Frames |   "   "Bitrate     "  "Y-PSNR    "  "U-PSNR    "  "V-PSNR    "  "YUV-PSNR " );
+            m_logger->log( e_msg_level, "         \tTotal Frames |   "   "Bitrate     "  "Y-PSNR    "  "U-PSNR    "  "V-PSNR    "  "YUV-PSNR " );
 
             if (printHexPsnr)
             {
-              msg(e_msg_level, "xY-PSNR           "  "xU-PSNR           "  "xV-PSNR           ");
+              m_logger->log(e_msg_level, "xY-PSNR           "  "xU-PSNR           "  "xV-PSNR           ");
             }
 
             if (printSequenceMSE)
             {
-              msg( e_msg_level, " Y-MSE     "  "U-MSE     "  "V-MSE    "  "YUV-MSE \n" );
+              m_logger->log( e_msg_level, " Y-MSE     "  "U-MSE     "  "V-MSE    "  "YUV-MSE \n" );
             }
             else
             {
-              msg( e_msg_level, "\n");
+              m_logger->log( e_msg_level, "\n");
             }
 
-            //msg( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
-            msg( e_msg_level, "Average: \t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf",
+            //m_logger->log( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
+            m_logger->log( e_msg_level, "Average: \t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf",
                    getNumPic(), cDelim,
                    getBits() * dScale,
                    getPsnr(COMP_Y ) / (double)getNumPic(),
@@ -324,12 +334,12 @@ public:
                   reinterpret_cast<uint8_t *>(&dPsnr[i]) + sizeof(dPsnr[i]),
                   reinterpret_cast<uint8_t *>(&xPsnr[i]));
               }
-              msg(e_msg_level, "   %16" PRIx64 "  %16" PRIx64 "  %16" PRIx64, xPsnr[COMP_Y], xPsnr[COMP_Cb], xPsnr[COMP_Cr]);
+              m_logger->log(e_msg_level, "   %16" PRIx64 "  %16" PRIx64 "  %16" PRIx64, xPsnr[COMP_Y], xPsnr[COMP_Cb], xPsnr[COMP_Cr]);
             }
 
             if (printSequenceMSE)
             {
-              msg( e_msg_level, "  %8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
+              m_logger->log( e_msg_level, "  %8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
                      m_MSEyuvframe[COMP_Y ] / (double)getNumPic(),
                      m_MSEyuvframe[COMP_Cb] / (double)getNumPic(),
                      m_MSEyuvframe[COMP_Cr] / (double)getNumPic(),
@@ -337,10 +347,10 @@ public:
             }
             else
             {
-              msg( e_msg_level, "\n");
+              m_logger->log( e_msg_level, "\n");
             }
 
-            msg( e_msg_level, "From MSE:\t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
+            m_logger->log( e_msg_level, "From MSE:\t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
                    getNumPic(), cDelim,
                    getBits() * dScale,
                    MSEBasedSNR[COMP_Y ],
@@ -350,23 +360,23 @@ public:
           }
           else
           {
-            msg( e_msg_level, "\tTotal Frames |   "   "Bitrate     "  "Y-PSNR    "  "U-PSNR    "  "V-PSNR    "  "YUV-PSNR   " );
+            m_logger->log( e_msg_level, "\tTotal Frames |   "   "Bitrate     "  "Y-PSNR    "  "U-PSNR    "  "V-PSNR    "  "YUV-PSNR   " );
 
             if (printHexPsnr)
             {
-              msg(e_msg_level, "xY-PSNR           "  "xU-PSNR           "  "xV-PSNR           ");
+              m_logger->log(e_msg_level, "xY-PSNR           "  "xU-PSNR           "  "xV-PSNR           ");
             }
             if (printSequenceMSE)
             {
-              msg( e_msg_level, " Y-MSE     "  "U-MSE     "  "V-MSE    "  "YUV-MSE \n" );
+              m_logger->log( e_msg_level, " Y-MSE     "  "U-MSE     "  "V-MSE    "  "YUV-MSE \n" );
             }
             else
             {
-              msg( e_msg_level, "\n");
+              m_logger->log( e_msg_level, "\n");
             }
 
-            //msg( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
-            msg( e_msg_level, "\t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf",
+            //m_logger->log( e_msg_level, "\t------------ "  " ----------"   " -------- "  " -------- "  " --------\n" );
+            m_logger->log( e_msg_level, "\t %8d    %c "          "%12.4lf  "    "%8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf",
                    getNumPic(), cDelim,
                    getBits() * dScale,
                    getPsnr(COMP_Y ) / (double)getNumPic(),
@@ -387,11 +397,11 @@ public:
                   reinterpret_cast<uint8_t *>(&dPsnr[i]) + sizeof(dPsnr[i]),
                   reinterpret_cast<uint8_t *>(&xPsnr[i]));
               }
-              msg(e_msg_level, "   %16" PRIx64 "  %16" PRIx64 "  %16" PRIx64 , xPsnr[COMP_Y], xPsnr[COMP_Cb], xPsnr[COMP_Cr]);
+              m_logger->log(e_msg_level, "   %16" PRIx64 "  %16" PRIx64 "  %16" PRIx64 , xPsnr[COMP_Y], xPsnr[COMP_Cb], xPsnr[COMP_Cr]);
             }
             if (printSequenceMSE)
             {
-              msg( e_msg_level, "  %8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
+              m_logger->log( e_msg_level, "  %8.4lf  "   "%8.4lf  "    "%8.4lf  "   "%8.4lf\n",
                      m_MSEyuvframe[COMP_Y ] / (double)getNumPic(),
                      m_MSEyuvframe[COMP_Cb] / (double)getNumPic(),
                      m_MSEyuvframe[COMP_Cr] / (double)getNumPic(),
@@ -399,13 +409,13 @@ public:
             }
             else
             {
-              msg( e_msg_level, "\n");
+              m_logger->log( e_msg_level, "\n");
             }
           }
         }
         break;
       default:
-        msg( VVENC_ERROR, "Unknown format during print out\n");
+        m_logger->log( VVENC_ERROR, "Unknown format during print out\n");
         exit(1);
         break;
     }
@@ -458,7 +468,7 @@ public:
         }
 
       default:
-          msg( VVENC_ERROR, "Unknown format during print out\n");
+          m_logger->log( VVENC_ERROR, "Unknown format during print out\n");
           exit(1);
           break;
     }

--- a/source/Lib/EncoderLib/EncGOP.cpp
+++ b/source/Lib/EncoderLib/EncGOP.cpp
@@ -250,6 +250,7 @@ EncGOP::EncGOP()
   , m_pcRateCtrl         ( nullptr )
   , m_pcEncHRD           ( nullptr )
   , m_gopApsMap          ( MAX_NUM_APS * MAX_NUM_APS_TYPE )
+  , m_Logger             ( nullptr )
   , m_threadPool         ( nullptr )
 {
 }
@@ -275,12 +276,18 @@ EncGOP::~EncGOP()
 }
 
 
-void EncGOP::init( const VVEncCfg& encCfg, const SPS& sps, const PPS& pps, RateCtrl& rateCtrl, EncHRD& encHrd, NoMallocThreadPool* threadPool )
+void EncGOP::init( const VVEncCfg& encCfg, const SPS& sps, const PPS& pps, RateCtrl& rateCtrl, EncHRD& encHrd, NoMallocThreadPool* threadPool, Logger* logger )
 {
   m_pcEncCfg   = &encCfg;
   m_pcRateCtrl = &rateCtrl;
   m_pcEncHRD   = &encHrd;
   m_threadPool = threadPool;
+  m_Logger     = logger;
+  
+  m_AnalyzeAll.setLogger(logger);
+  m_AnalyzeI.setLogger(logger);
+  m_AnalyzeP.setLogger(logger);
+  m_AnalyzeB.setLogger(logger);
 
   if( m_pcEncCfg->m_DecodingRefreshType == 4 )
   {
@@ -521,17 +528,17 @@ void EncGOP::printOutSummary( int numAllPicCoded, const bool printMSEBasedSNR, c
   const ChromaFormat chFmt = m_pcEncCfg->m_internChromaFormat;
 
   //-- all
-  msg( VVENC_INFO, "\n" );
-  msg( VVENC_DETAILS,"\nSUMMARY --------------------------------------------------------\n" );
+  m_Logger->log( VVENC_INFO, "\n" );
+  m_Logger->log( VVENC_DETAILS,"\nSUMMARY --------------------------------------------------------\n" );
   m_AnalyzeAll.printOut('a', chFmt, printMSEBasedSNR, printSequenceMSE, printHexPsnr, bitDepths
                           );
-  msg( VVENC_DETAILS,"\n\nI Slices--------------------------------------------------------\n" );
+  m_Logger->log( VVENC_DETAILS,"\n\nI Slices--------------------------------------------------------\n" );
   m_AnalyzeI.printOut('i', chFmt, printMSEBasedSNR, printSequenceMSE, printHexPsnr, bitDepths);
 
-  msg( VVENC_DETAILS,"\n\nP Slices--------------------------------------------------------\n" );
+  m_Logger->log( VVENC_DETAILS,"\n\nP Slices--------------------------------------------------------\n" );
   m_AnalyzeP.printOut('p', chFmt, printMSEBasedSNR, printSequenceMSE, printHexPsnr, bitDepths);
 
-  msg( VVENC_DETAILS,"\n\nB Slices--------------------------------------------------------\n" );
+  m_Logger->log( VVENC_DETAILS,"\n\nB Slices--------------------------------------------------------\n" );
   m_AnalyzeB.printOut('b', chFmt, printMSEBasedSNR, printSequenceMSE, printHexPsnr, bitDepths);
 
   if (m_pcEncCfg->m_summaryOutFilename[0] != '\0' )
@@ -753,7 +760,7 @@ void EncGOP::xInitFirstSlice( Picture& pic, PicList& picList, bool isEncodeLtRef
   const int gopId       = pic.gopId;
   const int depth       = xGetSliceDepth( curPoc );
   memset( pic.cs->alfAps, 0, sizeof(pic.cs->alfAps));
-  Slice* slice          = pic.allocateNewSlice();
+  Slice* slice          = pic.allocateNewSlice( m_Logger );
   pic.cs->picHeader     = new PicHeader;
   const SPS& sps        = *(slice->sps);
   const int drtIPoffset = m_pcEncCfg->m_DecodingRefreshType == 4 ? 1 + (m_pcEncCfg->m_IntraPeriod - m_pcEncCfg->m_GOPSize) : 0;
@@ -1730,11 +1737,11 @@ void EncGOP::xCabacZeroWordPadding( const Picture& pic, const Slice* slice, uint
           zeroBytesPadding[ i * 3 + 2 ] = 3;  // 00 00 03
         }
         nalUnitData.write( reinterpret_cast<const char*>(&(zeroBytesPadding[ 0 ])), numberOfAdditionalCabacZeroBytes );
-        msg( VVENC_NOTICE, "Adding %d bytes of padding\n", numberOfAdditionalCabacZeroWords * 3 );
+        m_Logger->log( VVENC_NOTICE, "Adding %d bytes of padding\n", numberOfAdditionalCabacZeroWords * 3 );
       }
       else
       {
-        msg( VVENC_NOTICE, "Standard would normally require adding %d bytes of padding\n", numberOfAdditionalCabacZeroWords * 3 );
+        m_Logger->log( VVENC_NOTICE, "Standard would normally require adding %d bytes of padding\n", numberOfAdditionalCabacZeroWords * 3 );
       }
     }
   }
@@ -1802,7 +1809,7 @@ void EncGOP::xCalculateAddPSNR( const Picture* pic, CPelUnitBuf cPicD, AccessUni
     uint32_t numRBSPBytes_nal = uint32_t((*it)->m_nalUnitData.str().size());
     if (m_pcEncCfg->m_summaryVerboseness > 0)
     {
-      msg( VVENC_NOTICE, "*** %s numBytesInNALunit: %u\n", nalUnitTypeToString((*it)->m_nalUnitType), numRBSPBytes_nal);
+      m_Logger->log( VVENC_NOTICE, "*** %s numBytesInNALunit: %u\n", nalUnitTypeToString((*it)->m_nalUnitType), numRBSPBytes_nal);
     }
     if( ( *it )->m_nalUnitType != VVENC_NAL_UNIT_PREFIX_SEI && ( *it )->m_nalUnitType != VVENC_NAL_UNIT_SUFFIX_SEI )
     {
@@ -1870,7 +1877,7 @@ void EncGOP::xCalculateAddPSNR( const Picture* pic, CPelUnitBuf cPicD, AccessUni
 
           accessUnit.InfoString.append( cInfo );
 
-          msg( VVENC_NOTICE, cInfo.c_str() );
+          m_Logger->log( VVENC_NOTICE, cInfo.c_str() );
     }
     else
     {
@@ -1887,8 +1894,8 @@ void EncGOP::xCalculateAddPSNR( const Picture* pic, CPelUnitBuf cPicD, AccessUni
       accessUnit.InfoString.append( cInfo );
       accessUnit.InfoString.append( cPSNR );
 
-      msg( VVENC_NOTICE, cInfo.c_str() );
-      msg( VVENC_NOTICE, cPSNR.c_str() );
+      m_Logger->log( VVENC_NOTICE, cInfo.c_str() );
+      m_Logger->log( VVENC_NOTICE, cPSNR.c_str() );
 
 
       if ( m_pcEncCfg->m_printHexPsnr )
@@ -1904,19 +1911,19 @@ void EncGOP::xCalculateAddPSNR( const Picture* pic, CPelUnitBuf cPicD, AccessUni
         std::string cPSNRHex = print(" [xY %16" PRIx64 " xU %16" PRIx64 " xV %16" PRIx64 "]", xPsnr[COMP_Y], xPsnr[COMP_Cb], xPsnr[COMP_Cr]);
 
         accessUnit.InfoString.append( cPSNRHex );
-        msg(VVENC_NOTICE, cPSNRHex.c_str() );
+        m_Logger->log(VVENC_NOTICE, cPSNRHex.c_str() );
       }
 
       if( printFrameMSE )
       {
         std::string cFrameMSE = print( " [Y MSE %6.4lf  U MSE %6.4lf  V MSE %6.4lf]", MSEyuvframe[COMP_Y], MSEyuvframe[COMP_Cb], MSEyuvframe[COMP_Cr]);
         accessUnit.InfoString.append( cFrameMSE );
-        msg(VVENC_NOTICE, cFrameMSE.c_str() );
+        m_Logger->log(VVENC_NOTICE, cFrameMSE.c_str() );
       }
 
       std::string cEncTime = print(" [ET %5d ]", pic->encTime.getTimerInSec() );
       accessUnit.InfoString.append( cEncTime );
-      msg(VVENC_NOTICE, cEncTime.c_str() );
+      m_Logger->log(VVENC_NOTICE, cEncTime.c_str() );
 
       std::string cRefPics;
       for( int iRefList = 0; iRefList < 2; iRefList++ )
@@ -1931,7 +1938,7 @@ void EncGOP::xCalculateAddPSNR( const Picture* pic, CPelUnitBuf cPicD, AccessUni
         cRefPics.append( "]" );
       }
       accessUnit.InfoString.append( cRefPics );
-      msg(VVENC_NOTICE, cRefPics.c_str() );
+      m_Logger->log(VVENC_NOTICE, cRefPics.c_str() );
     }
   }
 }
@@ -2006,16 +2013,16 @@ void EncGOP::xPrintPictureInfo( const Picture& pic, AccessUnitList& accessUnit, 
     {
       if ( digestStr.empty() )
       {
-        msg( VVENC_NOTICE, " [%s:%s]", modeName.c_str(), "?" );
+        m_Logger->log( VVENC_NOTICE, " [%s:%s]", modeName.c_str(), "?" );
       }
       else
       {
-        msg( VVENC_NOTICE, " [%s:%s]", modeName.c_str(), digestStr.c_str() );
+        m_Logger->log( VVENC_NOTICE, " [%s:%s]", modeName.c_str(), digestStr.c_str() );
       }
     }
   }
 
-  msg( VVENC_NOTICE, "\n" );
+  m_Logger->log( VVENC_NOTICE, "\n" );
   fflush( stdout );
 }
 

--- a/source/Lib/EncoderLib/EncGOP.h
+++ b/source/Lib/EncoderLib/EncGOP.h
@@ -59,7 +59,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/Picture.h"
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/Nal.h"
-#include "LegacyRateCtrl.h"
+#include "RateCtrl.h"
+#include "Utilities/Logger.h"
 
 #include <vector>
 #include <list>
@@ -146,6 +147,7 @@ private:
   RateCtrl*                 m_pcRateCtrl;
   EncHRD*                   m_pcEncHRD;
   ParameterSetMap<APS>      m_gopApsMap;
+  Logger*                   m_Logger;
 
   std::list<EncPicture*>    m_freePicEncoderList;
   std::list<Picture*>       m_gopEncListInput;
@@ -163,7 +165,7 @@ public:
   EncGOP();
   virtual ~EncGOP();
 
-  void init               ( const VVEncCfg& encCfg, const SPS& sps, const PPS& pps, RateCtrl& rateCtrl, EncHRD& encHrd, NoMallocThreadPool* threadPool );
+  void init               ( const VVEncCfg& encCfg, const SPS& sps, const PPS& pps, RateCtrl& rateCtrl, EncHRD& encHrd, NoMallocThreadPool* threadPool, Logger* logger );
   void encodePictures     ( const std::vector<Picture*>& encList, PicList& picList, AccessUnitList& au, bool isEncodeLtRef );
   void printOutSummary    ( int numAllPicCoded, const bool printMSEBasedSNR, const bool printSequenceMSE, const bool printHexPsnr, const BitDepths &bitDepths );
   void picInitRateControl ( Picture& pic, Slice* slice, EncPicture *picEncoder );

--- a/source/Lib/EncoderLib/EncLib.cpp
+++ b/source/Lib/EncoderLib/EncLib.cpp
@@ -55,6 +55,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/TimeProfiler.h"
 #include "CommonLib/Rom.h"
+#include "LegacyRateCtrl.h"
 #include "Utilities/NoMallocThreadPool.h"
 
 //! \ingroup EncoderLib
@@ -69,6 +70,7 @@ namespace vvenc {
 EncLib::EncLib()
   : m_cEncCfg       ()
   , m_cGOPEncoder   ( nullptr )
+  , m_logger        ( nullptr )
   , m_RecYUVBufferCallback     ( nullptr )
   , m_RecYUVBufferCallbackCtx  ( nullptr )
   , m_threadPool    ( nullptr )
@@ -77,6 +79,7 @@ EncLib::EncLib()
   , m_ppsMap        ( MAX_NUM_PPS )
 {
   xResetLib();
+  m_pcRateCtrl->setLogger( m_logger );
 }
 
 EncLib::~EncLib()
@@ -110,7 +113,7 @@ void EncLib::initEncoderLib( const VVEncCfg& encCfg )
   {
     std::string sChannelsList;
     g_trace_ctx->getChannelsList( sChannelsList );
-    msg( VVENC_INFO, "\n Using tracing channels:\n\n%s\n", sChannelsList.c_str() );
+    //msg( VVENC_INFO, "\n Using tracing channels:\n\n%s\n", sChannelsList.c_str() );
   }
 #endif
 
@@ -273,7 +276,7 @@ void EncLib::initPass( int pass, const char* statsFName )
 
   CHECK( m_cGOPEncoder != nullptr, "encoder library already initialised" );
   m_cGOPEncoder = new EncGOP;
-  m_cGOPEncoder->init( m_cEncCfg, sps0, pps0, *m_pcRateCtrl, m_cEncHRD, m_threadPool );
+  m_cGOPEncoder->init( m_cEncCfg, sps0, pps0, *m_pcRateCtrl, m_cEncHRD, m_threadPool, m_logger );
 
   m_pocToGopId.resize( m_cEncCfg.m_GOPSize, -1 );
   m_nextPocOffset.resize( m_cEncCfg.m_GOPSize, 0 );
@@ -327,6 +330,11 @@ void EncLib::initPass( int pass, const char* statsFName )
   }
 
   m_numPassInitialized = pass;
+}
+
+void EncLib::setLogger( Logger *logger )
+{
+  m_logger = logger;
 }
 
 void EncLib::setRecYUVBufferCallback( void *ctx, vvencRecYUVBufferCallback callback )

--- a/source/Lib/EncoderLib/EncLib.h
+++ b/source/Lib/EncoderLib/EncLib.h
@@ -54,6 +54,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/MCTF.h"
 #include "CommonLib/Nal.h"
 #include "vvenc/vvencCfg.h"
+#include "Utilities/Logger.h"
 
 #include <mutex>
 
@@ -88,6 +89,7 @@ private:
   EncHRD                    m_cEncHRD;
   MCTF                      m_MCTF;
   PicList                   m_cListPic;
+  Logger*                   m_logger;
 
   std::function<void( void*, vvencYUVBuffer* )> m_RecYUVBufferCallback;
   void*                     m_RecYUVBufferCallbackCtx;
@@ -112,6 +114,7 @@ public:
 
   void     initEncoderLib      ( const VVEncCfg& encCfg );
   void     initPass            ( int pass, const char* statsFName );
+  void     setLogger           ( Logger *logger );
   void     encodePicture       ( bool flush, const vvencYUVBuffer* yuvInBuf, AccessUnitList& au, bool& isQueueEmpty );
   void     uninitEncoderLib    ();
   void     printSummary        ();

--- a/source/Lib/EncoderLib/LegacyRateCtrl.cpp
+++ b/source/Lib/EncoderLib/LegacyRateCtrl.cpp
@@ -14,7 +14,7 @@ Einsteinufer 37
 www.hhi.fraunhofer.de/vvc
 vvc@hhi.fraunhofer.de
 
-Copyright (c) 2019-2021, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+Copyright (c) 2019-2021, Fraunhofer-Gesellschaft zur Fï¿½rderung der angewandten Forschung e.V.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -1233,7 +1233,7 @@ namespace vvenc {
     }
     else
     {
-      msg( VVENC_WARNING, "\n hierarchical bit allocation is not currently supported for the specified coding structure.\n" );
+      m_logger->log( VVENC_WARNING, "\n hierarchical bit allocation is not currently supported for the specified coding structure.\n" );
     }
 
     int* GOPID2Level = new int[ m_pcEncCfg->m_GOPSize ];

--- a/source/Lib/EncoderLib/RateCtrl.cpp
+++ b/source/Lib/EncoderLib/RateCtrl.cpp
@@ -293,6 +293,7 @@ void EncRCPic::updateAfterPicture( int actualTotalBits, double averageQP, bool i
 
 RateCtrl::RateCtrl()
 {
+  m_logger      = nullptr;
   m_pcEncCfg    = nullptr;
   encRCSeq      = NULL;
   encRCPic      = NULL;
@@ -330,6 +331,11 @@ void RateCtrl::destroy()
   }
   m_pqpaStatsWritten = 0;
 #endif
+}
+
+void RateCtrl::setLogger(Logger* logger)
+{
+  m_logger = logger;
 }
 
 void RateCtrl::init( const VVEncCfg& encCfg )
@@ -423,12 +429,12 @@ void RateCtrl::readStatsHeader()
   {
     THROW( "header line in rate control statistics file not recognized" );
   }
-  if( header[ "version" ]      != VVENC_VERSION )              msg( VVENC_WARNING, "WARNING: wrong version in rate control statistics file\n" );
-  if( header[ "SourceWidth" ]  != m_pcEncCfg->m_SourceWidth )  msg( VVENC_WARNING, "WARNING: wrong frame width in rate control statistics file\n" );
-  if( header[ "SourceHeight" ] != m_pcEncCfg->m_SourceHeight ) msg( VVENC_WARNING, "WARNING: wrong frame height in rate control statistics file\n" );
-  if( header[ "CTUSize" ]      != m_pcEncCfg->m_CTUSize )      msg( VVENC_WARNING, "WARNING: wrong CTU size in rate control statistics file\n" );
-  if( header[ "GOPSize" ]      != m_pcEncCfg->m_GOPSize )      msg( VVENC_WARNING, "WARNING: wrong GOP size in rate control statistics file\n" );
-  if( header[ "IntraPeriod" ]  != m_pcEncCfg->m_IntraPeriod )  msg( VVENC_WARNING, "WARNING: wrong intra period in rate control statistics file\n" );
+  if( header[ "version" ]      != VVENC_VERSION )              m_logger->log( VVENC_WARNING, "WARNING: wrong version in rate control statistics file\n" );
+  if( header[ "SourceWidth" ]  != m_pcEncCfg->m_SourceWidth )  m_logger->log( VVENC_WARNING, "WARNING: wrong frame width in rate control statistics file\n" );
+  if( header[ "SourceHeight" ] != m_pcEncCfg->m_SourceHeight ) m_logger->log( VVENC_WARNING, "WARNING: wrong frame height in rate control statistics file\n" );
+  if( header[ "CTUSize" ]      != m_pcEncCfg->m_CTUSize )      m_logger->log( VVENC_WARNING, "WARNING: wrong CTU size in rate control statistics file\n" );
+  if( header[ "GOPSize" ]      != m_pcEncCfg->m_GOPSize )      m_logger->log( VVENC_WARNING, "WARNING: wrong GOP size in rate control statistics file\n" );
+  if( header[ "IntraPeriod" ]  != m_pcEncCfg->m_IntraPeriod )  m_logger->log( VVENC_WARNING, "WARNING: wrong intra period in rate control statistics file\n" );
 }
 #endif
 

--- a/source/Lib/EncoderLib/RateCtrl.h
+++ b/source/Lib/EncoderLib/RateCtrl.h
@@ -53,6 +53,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "CommonLib/CommonDef.h"
+#include "Utilities/Logger.h"
 
 #include "vvenc/vvencCfg.h"
 
@@ -154,6 +155,7 @@ namespace vvenc {
     RateCtrl();
     virtual ~RateCtrl();
 
+    void setLogger(Logger* logger);
     virtual void init( const VVEncCfg& encCfg );
     virtual void destroy();
     void setRCPass (const VVEncCfg& encCfg, const int pass, const char* statsFName);
@@ -187,6 +189,7 @@ namespace vvenc {
     const VVEncCfg*         m_pcEncCfg;
 
   protected:
+    Logger*                 m_logger;
     void storeStatsData( const TRCPassStats& statsData );
 #ifdef VVENC_ENABLE_THIRDPARTY_JSON
     void openStatsFile( const std::string& name );

--- a/source/Lib/Utilities/Logger.h
+++ b/source/Lib/Utilities/Logger.h
@@ -1,0 +1,89 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software,
+especially patent licenses, a separate Agreement needs to be closed. 
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2019-2021, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+/**
+  \file    Logger.h
+  \brief   A very simple logger for the logging callback function
+*/
+
+#pragma once
+
+#include <functional>
+#include <stdarg.h>
+#include <mutex>
+
+#include "vvenc/vvenc.h"
+
+namespace vvenc {
+
+class Logger
+{
+public:
+  void setCallback( void *ctx, vvencLoggingCallback callback )
+  {
+    m_msgFncCtx = ctx;
+    m_msgFnc = callback;
+  }
+
+  void log( int level, const char* fmt, ... )
+  {
+    if ( this->m_msgFnc )
+    {
+      std::unique_lock<std::mutex> _lock( m_msgMutex );
+      va_list args;
+      va_start( args, fmt );
+      m_msgFnc( m_msgFncCtx, level, fmt, args );
+      va_end( args );
+    }
+}
+
+private:
+  std::function<void( void*, int, const char*, va_list )> m_msgFnc{};
+  void *m_msgFncCtx{};
+
+  std::mutex m_msgMutex;
+};
+
+} // namespace vvenc

--- a/source/Lib/vvenc/vvenc.cpp
+++ b/source/Lib/vvenc/vvenc.cpp
@@ -181,7 +181,6 @@ VVENC_DECL vvencEncoder* vvenc_encoder_create()
   vvenc::VVEncImpl* encCtx = new vvenc::VVEncImpl();
   if (!encCtx)
   {
-    vvenc::msg( VVENC_ERROR, "cannot allocate memory for VVdeC decoder\n" );
     return nullptr;
   }
 
@@ -191,23 +190,23 @@ VVENC_DECL vvencEncoder* vvenc_encoder_create()
 
 VVENC_DECL int vvenc_encoder_open( vvencEncoder *enc, vvenc_config* config )
 {
-  if (nullptr == config)
-  {
-    vvenc::msg( VVENC_ERROR, "vvenc_config is null\n" );
-    return VVENC_ERR_PARAMETER;
-  }
-
   auto d = (vvenc::VVEncImpl*)enc;
   if (!d)
   {
     return VVENC_ERR_INITIALIZE;
   }
 
+  if (nullptr == config)
+  {
+    d->getLogger()->log( VVENC_ERROR, "vvenc_config is null\n" );
+    return VVENC_ERR_PARAMETER;
+  }
+
   int ret = d->init( *config );
   if (ret != 0)
   {
     // Error initializing the decoder
-    vvenc::msg( VVENC_ERROR, "cannot init the VVenC encoder\n" );
+    d->getLogger()->log( VVENC_ERROR, "cannot init the VVenC encoder\n" );
     return VVENC_ERR_INITIALIZE;
   }
 
@@ -364,10 +363,15 @@ VVENC_DECL const char* vvenc_get_error_msg( int nRet )
 }
 
 
-VVENC_DECL int vvenc_set_logging_callback( void * ctx, vvencLoggingCallback callback )
+VVENC_DECL int vvenc_set_logging_callback( vvencEncoder *enc, void *ctx, vvencLoggingCallback callback )
 {
-  vvenc::VVEncImpl::registerMsgCbf ( ctx, callback );
-  return VVENC_OK;
+  auto d = (vvenc::VVEncImpl*)enc;
+  if (!d)
+  {
+    return VVENC_ERR_UNSPECIFIED;
+  }
+
+  return d->registerMsgCbf( ctx, callback );
 }
 
 

--- a/source/Lib/vvenc/vvencCfg.cpp
+++ b/source/Lib/vvenc/vvencCfg.cpp
@@ -674,7 +674,7 @@ static bool vvenc_confirmParameter ( vvenc_config *c, bool bflag, const char* me
 {
   if ( ! bflag )
     return false;
-  vvenc::msg( VVENC_ERROR, "Parameter Check Error: %s\n", message );
+  //vvenc::msg( VVENC_ERROR, "Parameter Check Error: %s\n", message );
   c->m_confirmFailed = true;
   return true;
 }
@@ -1061,11 +1061,11 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
       // conformance
       if ((c->m_confWinLeft == 0) && (c->m_confWinRight == 0) && (c->m_confWinTop == 0) && (c->m_confWinBottom == 0))
       {
-        vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, but all conformance window parameters set to zero\n");
+        //vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, but all conformance window parameters set to zero\n");
       }
       if ((c->m_aiPad[1] != 0) || (c->m_aiPad[0]!=0))
       {
-        vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, padding parameters will be ignored\n");
+        //vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, padding parameters will be ignored\n");
       }
       c->m_aiPad[1] = c->m_aiPad[0] = 0;
       break;
@@ -1206,7 +1206,7 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
 
   if ( c->m_vvencMCTF.MCTF && c->m_QP < 17 )
   {
-    vvenc::msg( VVENC_WARNING, "disable MCTF for QP < 17\n");
+    //vvenc::msg( VVENC_WARNING, "disable MCTF for QP < 17\n");
     c->m_vvencMCTF.MCTF = 0;
   }
   if( c->m_vvencMCTF.MCTF )
@@ -1700,7 +1700,7 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
     int curPOC = ((checkGOP - 1) / c->m_GOPSize)*c->m_GOPSize * multipleFactor + c->m_RPLList0[curGOP].m_POC;
     if (c->m_RPLList0[curGOP].m_POC < 0 || c->m_RPLList1[curGOP].m_POC < 0)
     {
-      vvenc::msg(VVENC_WARNING, "\nError: found fewer Reference Picture Sets than GOPSize\n");
+      //vvenc::msg(VVENC_WARNING, "\nError: found fewer Reference Picture Sets than GOPSize\n");
       errorGOP = true;
     }
     else
@@ -1736,7 +1736,7 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
           }
           if (!found)
           {
-            vvenc::msg(VVENC_WARNING, "\nError: ref pic %d is not available for GOP frame %d\n", c->m_RPLList0[curGOP].m_deltaRefPics[i], curGOP + 1);
+            //vvenc::msg(VVENC_WARNING, "\nError: ref pic %d is not available for GOP frame %d\n", c->m_RPLList0[curGOP].m_deltaRefPics[i], curGOP + 1);
             errorGOP = true;
           }
         }
@@ -2014,7 +2014,7 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
 
   if ( ! c->m_MMVD && c->m_allowDisFracMMVD )
   {
-    vvenc::msg( VVENC_WARNING, "MMVD disabled, thus disable AllowDisFracMMVD too\n" );
+    //vvenc::msg( VVENC_WARNING, "MMVD disabled, thus disable AllowDisFracMMVD too\n" );
     c->m_allowDisFracMMVD = false;
   }
 
@@ -2095,11 +2095,11 @@ static bool checkCfgParameter( vvenc_config *c )
       // conformance
       if ((c->m_confWinLeft == 0) && (c->m_confWinRight == 0) && (c->m_confWinTop == 0) && (c->m_confWinBottom == 0))
       {
-        vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, but all conformance window parameters set to zero\n");
+        //vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, but all conformance window parameters set to zero\n");
       }
       if ((c->m_aiPad[1] != 0) || (c->m_aiPad[0]!=0))
       {
-        vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, padding parameters will be ignored\n");
+        //vvenc::msg( VVENC_ERROR, "Warning: Conformance window enabled, padding parameters will be ignored\n");
       }
       break;
   }
@@ -2338,9 +2338,9 @@ static bool checkCfgParameter( vvenc_config *c )
 
   if (c->m_usePerceptQPA && c->m_dualITree && (c->m_internChromaFormat != VVENC_CHROMA_400) && (c->m_chromaCbQpOffsetDualTree != 0 || c->m_chromaCrQpOffsetDualTree != 0 || c->m_chromaCbCrQpOffsetDualTree != 0))
   {
-    vvenc::msg(VVENC_WARNING, "***************************************************************************\n");
-    vvenc::msg(VVENC_WARNING, "** WARNING: chroma QPA on, ignoring nonzero dual-tree chroma QP offsets! **\n");
-    vvenc::msg(VVENC_WARNING, "***************************************************************************\n");
+    //vvenc::msg(VVENC_WARNING, "***************************************************************************\n");
+    //vvenc::msg(VVENC_WARNING, "** WARNING: chroma QPA on, ignoring nonzero dual-tree chroma QP offsets! **\n");
+    //vvenc::msg(VVENC_WARNING, "***************************************************************************\n");
   }
 
   vvenc_confirmParameter(c, c->m_usePerceptQPATempFiltISlice > 2,                                                    "PerceptQPATempFiltIPic out of range, must be 2 or less" );
@@ -2498,7 +2498,7 @@ static bool checkCfgParameter( vvenc_config *c )
     int curPOC = ((checkGOP - 1) / c->m_GOPSize)*c->m_GOPSize * multipleFactor + c->m_RPLList0[curGOP].m_POC;
     if (c->m_RPLList0[curGOP].m_POC < 0 || c->m_RPLList1[curGOP].m_POC < 0)
     {
-      vvenc::msg(VVENC_WARNING, "\nError: found fewer Reference Picture Sets than GOPSize\n");
+      //vvenc::msg(VVENC_WARNING, "\nError: found fewer Reference Picture Sets than GOPSize\n");
       errorGOP = true;
     }
     else
@@ -2524,7 +2524,7 @@ static bool checkCfgParameter( vvenc_config *c )
           }
           if (!found)
           {
-            vvenc::msg(VVENC_WARNING, "\nError: ref pic %d is not available for GOP frame %d\n", c->m_RPLList0[curGOP].m_deltaRefPics[i], curGOP + 1);
+            //vvenc::msg(VVENC_WARNING, "\nError: ref pic %d is not available for GOP frame %d\n", c->m_RPLList0[curGOP].m_deltaRefPics[i], curGOP + 1);
             errorGOP = true;
           }
         }
@@ -2684,7 +2684,7 @@ static bool checkCfgParameter( vvenc_config *c )
   {
     if( c->m_vvencMCTF.MCTFFrames[0] == 0 )
     {
-      vvenc::msg( VVENC_WARNING, "no MCTF frames selected, MCTF will be inactive!\n");
+      //vvenc::msg( VVENC_WARNING, "no MCTF frames selected, MCTF will be inactive!\n");
     }
 
     vvenc_confirmParameter(c, c->m_vvencMCTF.numFrames != c->m_vvencMCTF.numStrength, "MCTFFrames and MCTFStrengths do not match");
@@ -2692,8 +2692,8 @@ static bool checkCfgParameter( vvenc_config *c )
 
   if( c->m_fastForwardToPOC != -1 )
   {
-    if( c->m_cabacInitPresent )  { vvenc::msg( VVENC_WARNING, "WARNING usage of FastForwardToPOC and CabacInitPresent might cause different behaviour\n\n" ); }
-    if( c->m_alf )               { vvenc::msg( VVENC_WARNING, "WARNING usage of FastForwardToPOC and ALF might cause different behaviour\n\n" ); }
+    if( c->m_cabacInitPresent )  { /* vvenc::msg( VVENC_WARNING, "WARNING usage of FastForwardToPOC and CabacInitPresent might cause different behaviour\n\n" ); */ }
+    if( c->m_alf )               { /* vvenc::msg( VVENC_WARNING, "WARNING usage of FastForwardToPOC and ALF might cause different behaviour\n\n" ); */ }
   }
 
   if( c->m_picPartitionFlag )

--- a/source/Lib/vvenc/vvencimpl.h
+++ b/source/Lib/vvenc/vvencimpl.h
@@ -54,6 +54,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "vvenc/vvencCfg.h"
 #include "vvenc/vvenc.h"
 #include "EncoderLib/EncLib.h"
+#include "Utilities/Logger.h"
 
 namespace vvenc {
 
@@ -122,10 +123,12 @@ public:
 
   const char* getLastError() const;
 
+  int     registerMsgCbf( void * ctx, vvencLoggingCallback msgFnc );
+  Logger* getLogger() { return &m_logger; }
+
   static const char* getErrorMsg( int nRet );
   static const char* getVersionNumber();
 
-  static void        registerMsgCbf( void * ctx, vvencLoggingCallback msgFnc );            ///< set message output function for encoder lib. if not set, no messages will be printed.
   static const char* setSIMDExtension( const char* simdId );                               ///< tries to set given simd extensions used. if not supported by cpu, highest possible extension level will be set and returned.
   static const char* getCompileInfoString();
   static int         decodeBitstream( const char* FileName, const char* trcFile, const char* trcRule);
@@ -146,6 +149,8 @@ private:
   std::string            m_sEncoderCapabilities;
 
   EncLib*                m_pEncLib = nullptr;
+
+  Logger                 m_logger;
 };
 
 

--- a/test/vvencinterfacetest/vvencinterfacetest.c
+++ b/test/vvencinterfacetest/vvencinterfacetest.c
@@ -73,8 +73,6 @@ int main( int argc, char* argv[] )
 
   int maxFrames = 8;  // max frames to encode
 
-  vvenc_set_logging_callback( NULL, msgFnc );
-
   // init default settings
   vvenc_config vvencCfg;
   vvenc_init_default( &vvencCfg, 1920, 1080, 60, 0, 32, VVENC_MEDIUM );
@@ -86,6 +84,8 @@ int main( int argc, char* argv[] )
     printf("cannot create encoder\n");
     return -1;
   }
+
+  vvenc_set_logging_callback( enc, NULL, msgFnc );
 
   // initialize the encoder
   iRet = vvenc_encoder_open( enc, &vvencCfg );


### PR DESCRIPTION
Using many encoder instances at the same time causes problems if the logging callback uses global variables. 
This is my first attempt at setting a callback to each encoder instance. 
The problems still are: 
 - The decoder lib functions don't support the setting. Why are they even in this repo? This is the encoder and not a decoder? As far as I can see they are never actually used.
 - The tracing also does not have support for this yet. But this can be added
 - I don't understand why in `vvencCfg.h` you are exposing multiple undocumented functions on the config. These also use logging so this does not work yet.