### PR TITLE
AOCC compilation failed because of set but unused variable blockUncodedCost

### DIFF
--- a/source/Lib/CommonLib/QuantRDOQ.cpp
+++ b/source/Lib/CommonLib/QuantRDOQ.cpp
@@ -1184,7 +1184,6 @@ void QuantRDOQ::rateDistOptQuantTS( TransformUnit& tu, const ComponentID compID,
     transformShift = std::max<int>( 0, transformShift );
   }
 
-  //      double   blockUncodedCost                   = 0;
   const uint32_t maxNumCoeff                        = rect.area();
 
   CHECK( compID >= MAX_NUM_TBLOCKS, "Invalid component ID" );
@@ -1277,7 +1276,6 @@ void QuantRDOQ::rateDistOptQuantTS( TransformUnit& tu, const ComponentID compID,
       coeffLevelError[0] = dErr * dErr * errorScale;
 
       costCoeff0[scanPos] = coeffLevelError[0];
-      // blockUncodedCost   += costCoeff0[ scanPos ];
       dstCoeff[blkPos]    = coeffLevels[0];
 
       //===== coefficient level estimation =====
@@ -1406,7 +1404,6 @@ void QuantRDOQ::forwardRDPCM( TransformUnit& tu, const ComponentID compID, const
     transformShift = std::max<int>(0, transformShift);
   }
 
-  // double   blockUncodedCost = 0;
   const uint32_t maxNumCoeff = rect.area();
 
   CHECK(compID >= MAX_NUM_TBLOCKS, "Invalid component ID");
@@ -1497,7 +1494,6 @@ void QuantRDOQ::forwardRDPCM( TransformUnit& tu, const ComponentID compID, const
       coeffLevelError[0]  = dErr * dErr * errorScale;
 
       costCoeff0[scanPos] = coeffLevelError[0];
-      // blockUncodedCost   += costCoeff0[scanPos];
       dstCoeff[blkPos]    = coeffLevels[0];
 
       //===== coefficient level estimation =====

--- a/source/Lib/CommonLib/QuantRDOQ.cpp
+++ b/source/Lib/CommonLib/QuantRDOQ.cpp
@@ -1184,7 +1184,7 @@ void QuantRDOQ::rateDistOptQuantTS( TransformUnit& tu, const ComponentID compID,
     transformShift = std::max<int>( 0, transformShift );
   }
 
-        double   blockUncodedCost                   = 0;
+  //      double   blockUncodedCost                   = 0;
   const uint32_t maxNumCoeff                        = rect.area();
 
   CHECK( compID >= MAX_NUM_TBLOCKS, "Invalid component ID" );
@@ -1277,7 +1277,7 @@ void QuantRDOQ::rateDistOptQuantTS( TransformUnit& tu, const ComponentID compID,
       coeffLevelError[0] = dErr * dErr * errorScale;
 
       costCoeff0[scanPos] = coeffLevelError[0];
-      blockUncodedCost   += costCoeff0[ scanPos ];
+      // blockUncodedCost   += costCoeff0[ scanPos ];
       dstCoeff[blkPos]    = coeffLevels[0];
 
       //===== coefficient level estimation =====
@@ -1406,7 +1406,7 @@ void QuantRDOQ::forwardRDPCM( TransformUnit& tu, const ComponentID compID, const
     transformShift = std::max<int>(0, transformShift);
   }
 
-  double   blockUncodedCost = 0;
+  // double   blockUncodedCost = 0;
   const uint32_t maxNumCoeff = rect.area();
 
   CHECK(compID >= MAX_NUM_TBLOCKS, "Invalid component ID");
@@ -1497,7 +1497,7 @@ void QuantRDOQ::forwardRDPCM( TransformUnit& tu, const ComponentID compID, const
       coeffLevelError[0]  = dErr * dErr * errorScale;
 
       costCoeff0[scanPos] = coeffLevelError[0];
-      blockUncodedCost   += costCoeff0[scanPos];
+      // blockUncodedCost   += costCoeff0[scanPos];
       dstCoeff[blkPos]    = coeffLevels[0];
 
       //===== coefficient level estimation =====


### PR DESCRIPTION
AMD clang version 13.0.0 (CLANG: AOCC_3.2.0-Build#128 2021_11_12) (based on LLVM Mirror.Version.13.0.0)

Please review whether the variable is needed at all.

Error message was:

/usr/src/github.com/1div0/vvenc/source/Lib/CommonLib/QuantRDOQ.cpp:1187:18: error: variable 'blockUncodedCost' set but not used [-Werror,-Wunused-but-set-variable]
        double   blockUncodedCost                   = 0;
                 ^
/usr/src/github.com/1div0/vvenc/source/Lib/CommonLib/QuantRDOQ.cpp:1409:12: error: variable 'blockUncodedCost' set but not used [-Werror,-Wunused-but-set-variable]
  double   blockUncodedCost = 0;
           ^
2 errors generated.
make[2]: *** [source/Lib/vvenc/CMakeFiles/vvenc.dir/build.make:342: source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/QuantRDOQ.cpp.o] Error 1
