### PR TITLE
add support for y4m input

### DIFF
--- a/include/apputils/VVEncAppCfg.h
+++ b/include/apputils/VVEncAppCfg.h
@@ -81,6 +81,7 @@ public:
   bool         m_bClipOutputVideoToRec709Range = false;
   bool         m_packedYUVInput                = false;        ///< If true, packed 10-bit YUV ( 4 samples packed into 5-bytes consecutively )
   bool         m_packedYUVOutput               = false;        ///< If true, output 10-bit and 12-bit YUV data as 5-byte and 3-byte (respectively) packed YUV data
+  bool         m_forceY4mInput                 = false;        ///< If true, y4m input file syntax is forced (only needed for input via std::cin)
   bool         m_decode                        = false;
   bool         m_showVersion                   = false;
   bool         m_showHelp                      = false;

--- a/include/apputils/YuvFileIO.h
+++ b/include/apputils/YuvFileIO.h
@@ -62,6 +62,8 @@ struct vvencYUVBuffer;
 
 namespace apputils {
 
+class VVEncAppCfg;
+
 // ====================================================================================================================
 
 class APPUTILS_DECL YuvFileIO
@@ -77,10 +79,11 @@ private:
   bool                m_clipToRec709        = false;            ///< clip data according to Recom.709
   bool                m_packedYUVMode       = false;            ///< used packed buffer file format
   bool                m_readStdin           = false;            ///< read input from stdin
+  bool                m_y4mMode             = false;            ///< use/force y4m file format
 
 public:
   int   open( const std::string &fileName, bool bWriteMode, int fileBitDepth, int MSBExtendedBitDepth, int internalBitDepth, 
-              vvencChromaFormat fileChrFmt, vvencChromaFormat bufferChrFmt, bool clipToRec709, bool packedYUVMode );
+              vvencChromaFormat fileChrFmt, vvencChromaFormat bufferChrFmt, bool clipToRec709, bool packedYUVMode, bool y4mMode );
   void  close();
   bool  isOpen();
   bool  isEof();
@@ -89,6 +92,9 @@ public:
   int   readYuvBuf   ( vvencYUVBuffer& yuvInBuf, bool& eof );
   bool  writeYuvBuf  ( const vvencYUVBuffer& yuvOutBuf );
   std::string getLastError() const { return m_lastError; }   
+
+  static int parseY4mHeader( const std::string &fileName, vvenc_config& config, VVEncAppCfg& appconfig );
+  static bool isY4mInputFilename( std::string fileName );
 };
 
 } // namespace apputils

--- a/source/App/vvencFFapp/EncApp.cpp
+++ b/source/App/vvencFFapp/EncApp.cpp
@@ -265,7 +265,8 @@ int EncApp::encode()
     // open input YUV
 
     if( m_yuvInputFile.open( appCfg.m_inputFileName, false, vvencCfg.m_inputBitDepth[0], vvencCfg.m_MSBExtendedBitDepth[0], vvencCfg.m_internalBitDepth[0],
-                             appCfg.m_inputFileChromaFormat, vvencCfg.m_internChromaFormat, appCfg.m_bClipInputVideoToRec709Range, appCfg.m_packedYUVInput ))
+                             appCfg.m_inputFileChromaFormat, vvencCfg.m_internChromaFormat, appCfg.m_bClipInputVideoToRec709Range, appCfg.m_packedYUVInput,
+                             appCfg.m_forceY4mInput ))
     {
       msgApp( VVENC_ERROR, "open input file failed: %s\n", m_yuvInputFile.getLastError().c_str() );
       vvenc_encoder_close( m_encCtx );
@@ -403,7 +404,7 @@ bool EncApp::openFileIO()
   if( ! m_cEncAppCfg.m_reconFileName.empty() )
   {
     if( m_yuvReconFile.open( m_cEncAppCfg.m_reconFileName, true, m_vvenc_config.m_outputBitDepth[0], m_vvenc_config.m_outputBitDepth[0], m_vvenc_config.m_internalBitDepth[0],
-                             m_vvenc_config.m_internChromaFormat, m_vvenc_config.m_internChromaFormat, m_cEncAppCfg.m_bClipOutputVideoToRec709Range, m_cEncAppCfg.m_packedYUVOutput ))
+                             m_vvenc_config.m_internChromaFormat, m_vvenc_config.m_internChromaFormat, m_cEncAppCfg.m_bClipOutputVideoToRec709Range, m_cEncAppCfg.m_packedYUVOutput, false ))
     {
       msgApp( VVENC_ERROR, "open reconstruction file failed: %s\n", m_yuvReconFile.getLastError().c_str() );
       return false;

--- a/source/App/vvencapp/vvencapp.cpp
+++ b/source/App/vvencapp/vvencapp.cpp
@@ -309,7 +309,8 @@ int main( int argc, char* argv[] )
     // open the input file
     apputils::YuvFileIO cYuvFileInput;
     if( 0 != cYuvFileInput.open( vvencappCfg.m_inputFileName, false, vvenccfg.m_inputBitDepth[0], vvenccfg.m_MSBExtendedBitDepth[0], vvenccfg.m_internalBitDepth[0],
-                                 vvencappCfg.m_inputFileChromaFormat, vvenccfg.m_internChromaFormat, vvencappCfg.m_bClipOutputVideoToRec709Range, vvencappCfg.m_packedYUVInput ) )
+                                 vvencappCfg.m_inputFileChromaFormat, vvenccfg.m_internChromaFormat, vvencappCfg.m_bClipOutputVideoToRec709Range, vvencappCfg.m_packedYUVInput,
+                                 vvencappCfg.m_forceY4mInput ) )
     {
       msgApp( nullptr, VVENC_ERROR, "vvencapp [error]: failed to open input file %s\n", vvencappCfg.m_inputFileName.c_str() );
       vvenc_YUVBuffer_free_buffer( &cYUVInputBuffer );

--- a/source/Lib/apputils/VVEncAppCfg.cpp
+++ b/source/Lib/apputils/VVEncAppCfg.cpp
@@ -60,6 +60,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "apputils/IStreamIO.h"
 #include "apputils/ParseArg.h"
 #include "apputils/VVEncAppCfg.h"
+#include "apputils/YuvFileIO.h"
 #include "vvenc/vvenc.h"
 
 #define MACRO_TO_STRING_HELPER(val) #val
@@ -615,6 +616,11 @@ int VVEncAppCfg::parse( int argc, char* argv[], vvenc_config* c, std::ostream& r
   ("additional",                                        m_additionalSettings,                               "additional options as string (e.g: \"bitrate=1000000 passes=1\")")
   ;
 
+  opts.setSubSection("Input Options");
+  opts.addOptions()
+  ("y4m",                                             m_forceY4mInput,                                     "force y4m input (only needed for input pipe, else enabled by .y4m file extension)")
+  ;
+
   if( !m_easyMode )
   {
     opts.setSubSection("General Options");
@@ -1091,6 +1097,16 @@ int VVEncAppCfg::parse( int argc, char* argv[], vvenc_config* c, std::ostream& r
     if ( m_showVersion )
     {
       return 1;
+    }
+
+    // check for y4m input
+    if ( m_forceY4mInput || apputils::YuvFileIO::isY4mInputFilename( m_inputFileName ) )
+    {
+      if( 0 > apputils::YuvFileIO::parseY4mHeader( m_inputFileName, *c, *this ))
+      {
+        rcOstr << "cannot parse 4ym metadata\n";
+        ret = -1;
+      }
     }
 
     for( auto& a : argv_unhandled )

--- a/source/Lib/apputils/VVEncAppCfg.cpp
+++ b/source/Lib/apputils/VVEncAppCfg.cpp
@@ -1104,7 +1104,7 @@ int VVEncAppCfg::parse( int argc, char* argv[], vvenc_config* c, std::ostream& r
     {
       if( 0 > apputils::YuvFileIO::parseY4mHeader( m_inputFileName, *c, *this ))
       {
-        rcOstr << "cannot parse 4ym metadata\n";
+        rcOstr << "cannot parse y4m metadata\n";
         ret = -1;
       }
     }

--- a/source/Lib/apputils/YuvFileIO.cpp
+++ b/source/Lib/apputils/YuvFileIO.cpp
@@ -539,7 +539,7 @@ int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fil
 
   if ( m_y4mMode && bWriteMode )
   {
-    m_lastError =  "\nERROR: Cannot handle y4m yuv ouput (only support for y4m input)";
+    m_lastError =  "\nERROR: Cannot handle y4m yuv output (only support for y4m input)";
     return -1;
   }
 

--- a/source/Lib/apputils/YuvFileIO.cpp
+++ b/source/Lib/apputils/YuvFileIO.cpp
@@ -50,11 +50,14 @@ THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "apputils/YuvFileIO.h"
+#include "apputils/VVEncAppCfg.h"
+
 #include "vvenc/vvenc.h"
 
 #include <algorithm>
 #include <iostream>
 #include <vector>
+#include <regex>
 
 #if defined (_WIN32) || defined (WIN32) || defined (_WIN64) || defined (WIN64)
 #include <io.h>
@@ -509,17 +512,18 @@ void scaleYuvPlane( vvencYUVPlane& yuvPlaneOut, const vvencYUVPlane& yuvPlaneIn,
 
 int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fileBitDepth, const int MSBExtendedBitDepth,
                      const int internalBitDepth, vvencChromaFormat fileChrFmt, vvencChromaFormat bufferChrFmt,
-                     bool clipToRec709, bool packedYUVMode )
+                     bool clipToRec709, bool packedYUVMode, bool y4mMode )
 {
   //NOTE: files cannot have bit depth greater than 16
   m_fileBitdepth        = std::min<unsigned>( fileBitDepth, 16 );
   m_MSBExtendedBitDepth = MSBExtendedBitDepth;
   m_bitdepthShift       = internalBitDepth - m_MSBExtendedBitDepth;
-  m_fileChrFmt          = fileChrFmt; 
-  m_bufferChrFmt        = bufferChrFmt; 
+  m_fileChrFmt          = fileChrFmt;
+  m_bufferChrFmt        = bufferChrFmt;
   m_clipToRec709        = clipToRec709;
   m_packedYUVMode       = packedYUVMode;
   m_readStdin           = false;
+  m_y4mMode             = y4mMode;
 
   if( m_packedYUVMode && !bWriteMode && m_fileBitdepth != 10 )
   {
@@ -530,6 +534,12 @@ int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fil
   if ( m_fileBitdepth > 16 )
   {
     m_lastError =  "\nERROR: Cannot handle a yuv file of bit depth greater than 16";
+    return -1;
+  }
+
+  if ( m_y4mMode && bWriteMode )
+  {
+    m_lastError =  "\nERROR: Cannot handle y4m yuv ouput (only support for y4m input)";
     return -1;
   }
 
@@ -564,6 +574,14 @@ int YuvFileIO::open( const std::string &fileName, bool bWriteMode, const int fil
     {
       m_lastError =  "\nFailed to open input YUV file:  " + fileName;
       return -1;
+    }
+
+    if ( m_y4mMode || isY4mInputFilename( fileName ) )
+    {
+      std::istream& inStream = m_cHandle;
+      std::string headerline;
+      getline(inStream, headerline);  // jump over y4m header
+      m_y4mMode   = true;
     }
   }
   return 0;
@@ -622,7 +640,14 @@ void YuvFileIO::skipYuvFrames( int numFrames, int width, int height  )
     frameSize *= wordsize;
   }
 
-  const std::streamoff offset = frameSize * numFrames;
+  std::streamoff offsetAdditional = 0;
+  if( m_y4mMode )
+  {
+    const char Y4MHeader[] = {'F','R','A','M','E'};
+    offsetAdditional = sizeof(Y4MHeader) + 1;  /* assume basic FRAME\n headers */
+  }
+
+  const std::streamoff offset = (frameSize * numFrames) + offsetAdditional;
 
   // attempt to seek
   if ( !! m_cHandle.seekg( offset, std::ios::cur ) )
@@ -678,22 +703,25 @@ int YuvFileIO::readYuvBuf( vvencYUVBuffer& yuvInBuf, bool& eof )
       yuvPlane.stride = yuvPlane.width;
     }
 
-    if( m_readStdin )
+    std::istream& inStream = m_readStdin ? std::cin : m_cHandle;
+
+    if( m_y4mMode && comp == 0 )
     {
-      if ( ! readYuvPlane( std::cin, yuvPlane, is16bit, m_fileBitdepth, m_packedYUVMode, comp, m_fileChrFmt, m_bufferChrFmt ) )
+      std::string y4mPrefix;
+      getline(inStream, y4mPrefix);   /* assume basic FRAME\n headers */
+      if( y4mPrefix != "FRAME")
       {
-        eof = true;
-        return 0;
+        m_lastError = "Source image does not contain valid y4m header (FRAME)";
+        return -1;
       }
     }
-    else
+
+    if ( ! readYuvPlane( inStream, yuvPlane, is16bit, m_fileBitdepth, m_packedYUVMode, comp, m_fileChrFmt, m_bufferChrFmt ) )
     {
-      if ( ! readYuvPlane( m_cHandle, yuvPlane, is16bit, m_fileBitdepth, m_packedYUVMode, comp, m_fileChrFmt, m_bufferChrFmt ) )
-      {
-        eof = true;
-        return 0;
-      }
+      eof = true;
+      return 0;
     }
+
     if ( m_bufferChrFmt == VVENC_CHROMA_400 && comp)
       continue;
 
@@ -746,6 +774,136 @@ bool YuvFileIO::writeYuvBuf( const vvencYUVBuffer& yuvOutBuf )
 
   return true;
 }
+
+bool YuvFileIO::isY4mInputFilename( std::string fileName )
+{
+  if(fileName.find_last_of(".") != std::string::npos)
+  {
+    std::string ext = fileName.substr(fileName.find_last_of(".")+1);
+    std::transform( ext.begin(), ext.end(), ext.begin(), ::tolower );
+    return ( "y4m" == ext );
+  }
+  return false;
+}
+
+int YuvFileIO::parseY4mHeader( const std::string &fileName, vvenc_config& cfg, VVEncAppCfg& appcfg )
+{
+  std::fstream cfHandle;
+
+  if( fileName == "-" )
+  {
+#if defined (_WIN32) || defined (WIN32) || defined (_WIN64) || defined (WIN64)
+    if( _setmode( _fileno( stdin ), _O_BINARY ) == -1 )
+    {
+      return -1;
+    }
+#endif
+  }
+  else
+  {
+    cfHandle.open( fileName, std::ios::binary | std::ios::in );
+    if( cfHandle.fail() )
+    {
+      return -1;
+    }
+  }
+
+  std::istream& inStream = ( fileName == "-" ) ? std::cin : cfHandle;
+
+  // y4m header syntax example
+  // YUV4MPEG2 W1920 H1080 F50:1 Ip A128:117 C420p10
+
+  // init y4m defaults (if not given in header)
+  cfg.m_inputBitDepth[0]         = 8;
+  appcfg.m_inputFileChromaFormat = VVENC_CHROMA_420;
+
+  std::string headerline;
+  getline(inStream, headerline);
+  if( headerline.empty() ){ return -1; }
+  std::transform( headerline.begin(), headerline.end(), headerline.begin(), ::toupper );
+
+  std::regex reg("\\s+"); // tokenize at spaces
+  std::sregex_token_iterator iter(headerline.begin(), headerline.end(), reg, -1);
+  std::sregex_token_iterator end;
+  std::vector<std::string> vec(iter, end);
+
+  bool valid=false;
+  for (auto &p : vec)
+  {
+    if( p == "YUV4MPEG2" ) // read file signature
+    { valid = true; }
+    else if( p[0] == 'W' ) // width
+      cfg.m_SourceWidth = atoi( p.substr( 1 ).c_str());
+    else if( p[0] == 'H' ) // height
+      cfg.m_SourceHeight = atoi( p.substr( 1 ).c_str());
+    else if( p[0] == 'F' )  // framerate,scale
+    {
+      size_t sep = p.find(":");
+      if( sep == std::string::npos ) return -1;
+      cfg.m_FrameRate  = atoi( p.substr( 1, sep-1 ).c_str());
+      cfg.m_FrameScale = atoi( p.substr( sep+1 ).c_str());
+    }
+    else if( p[0] == 'A' ) // aspcet ration
+    {
+      size_t sep = p.find(":");
+      if( sep == std::string::npos ) return -1;
+      cfg.m_sarWidth  = atoi( p.substr( 1, sep-1 ).c_str());
+      cfg.m_sarHeight = atoi( p.substr( sep+1 ).c_str());
+    }
+    else if( p[0] == 'C' ) // colorspace ( e.g. C420p10)
+    {
+      std::vector<std::string> ignores = {"JPEG", "MPEG2", "PALVD" }; // ignore some special cases
+      for( auto &i : ignores )
+      {
+        auto n = p.find( i );
+        if (n != std::string::npos) p.erase(n, i.length()); // remove from param string (e.g. 420PALVD)
+      }
+
+      size_t sep = p.find("P");
+      std::string chromatype;
+      if( sep != std::string::npos )
+      {
+        chromatype = ( p.substr( 1, sep-1 ).c_str());
+        cfg.m_inputBitDepth[0] = atoi( p.substr( sep+1 ).c_str());
+      }
+      else
+      {
+        sep = p.find("MONO");
+        if( sep != std::string::npos )
+        {
+          chromatype = "400";
+          if( p == "MONO") cfg.m_inputBitDepth[0] = 8;
+          else cfg.m_inputBitDepth[0] = atoi( p.substr( sep+5 ).c_str()); // e.g. mono10
+        }
+        else
+        {
+          chromatype = ( p.substr( 1 ).c_str());
+          cfg.m_inputBitDepth[0] = 8;
+        }
+      }
+
+      if( chromatype == "400" )      { appcfg.m_inputFileChromaFormat =  VVENC_CHROMA_400; }
+      else if( chromatype == "420" ) { appcfg.m_inputFileChromaFormat =  VVENC_CHROMA_420; }
+      else if( chromatype == "422" ) { appcfg.m_inputFileChromaFormat =  VVENC_CHROMA_422; }
+      else if( chromatype == "444" ) { appcfg.m_inputFileChromaFormat =  VVENC_CHROMA_444; }
+      else { return -1; } // unsupported chroma foramt}
+    }
+    else if( p[0] == 'I' ) // interlaced format (ignore it, because we cannot set it in any params
+    {}
+    else if( p[0] == 'X' ) // ignore comments
+    {}
+  }
+
+  if( fileName != "-" )
+  {
+    cfHandle.close();
+  }
+
+  if( !valid ) return -1;
+
+  return (int)headerline.length()+1;
+}
+
 
 
 } // namespace apputils


### PR DESCRIPTION
- add support for y4m file format
- y4m can be enabled by file extension .y4m or can be forced (e.g. for pipe input) using --y4m
- support for y4m file input and pipe input