### PR TITLE
y4m flush/eof bugfix

### DIFF
--- a/source/Lib/apputils/YuvFileIO.cpp
+++ b/source/Lib/apputils/YuvFileIO.cpp
@@ -675,7 +675,7 @@ int YuvFileIO::readYuvBuf( vvencYUVBuffer& yuvInBuf, bool& eof )
   {
     m_lastError = "end of file";
     eof = true;
-    return -1;
+    return 0;
   }
 
   if ( m_packedYUVMode &&  ( 0 != (yuvInBuf.planes[0].width >> 1) % 4 ) )
@@ -711,8 +711,9 @@ int YuvFileIO::readYuvBuf( vvencYUVBuffer& yuvInBuf, bool& eof )
       getline(inStream, y4mPrefix);   /* assume basic FRAME\n headers */
       if( y4mPrefix != "FRAME")
       {
-        m_lastError = "Source image does not contain valid y4m header (FRAME)";
-        return -1;
+        m_lastError = "Source image does not contain valid y4m header (FRAME) - end of stream";
+        eof = true;
+        return 0;
       }
     }
 


### PR DESCRIPTION
- bugfix for issue #129
- set eof (end of file), when y4m identifier (FRAME) cannot be found (e.g. input pipe is empty)