### PR TITLE
Update CMake link to HTTPS & the redirect target

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,4 +12,3 @@
 * Christian Stoffers, , Fraunhofer HHI
 * Gabriel Hege, , Fraunhofer HHI
 * Jens Güther, , Fraunhofer HHI
-* Kai Hollberg, @Schweinepriester,

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,3 +12,4 @@
 * Christian Stoffers, , Fraunhofer HHI
 * Gabriel Hege, , Fraunhofer HHI
 * Jens Güther, , Fraunhofer HHI
+* Kai Hollberg, @Schweinepriester,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the [Wiki-Page](https://github.com/fraunhoferhhi/vvenc/wiki) for more inform
 
 ## Build
 
-VVenC uses CMake to describe and manage the build process. A working [CMake](http://www.cmake.org/) installation is required to build the software. In the following, the basic build steps are described. Please refer to the [Wiki](https://github.com/fraunhoferhhi/vvenc/wiki/Build) for the description of all build options.
+VVenC uses CMake to describe and manage the build process. A working [CMake](https://cmake.org/) installation is required to build the software. In the following, the basic build steps are described. Please refer to the [Wiki](https://github.com/fraunhoferhhi/vvenc/wiki/Build) for the description of all build options.
 
 ### How to build using CMake?
 


### PR DESCRIPTION
Pretty much the title: http://www.cmake.org/ is being redirected to https://cmake.org/, so use HTTPS right away and skip the redirect.