### PR TITLE
bugfix: slice_address in codeSliceHeader()

### DIFF
--- a/source/Lib/EncoderLib/VLCWriter.cpp
+++ b/source/Lib/EncoderLib/VLCWriter.cpp
@@ -1759,7 +1759,7 @@ void HLSWriter::codeSliceHeader( const Slice* slice )
         numSlicesInPreviousSubPics += slice->pps->subPics[sp].numSlicesInSubPic;
       }
       int bitsSliceAddress = ceilLog2(currSubPic.numSlicesInSubPic);
-      WRITE_CODE( slice->sliceSubPicId - numSlicesInPreviousSubPics, bitsSliceAddress, "sh_slice_address");
+      WRITE_CODE( slice->sliceMap.sliceID - numSlicesInPreviousSubPics, bitsSliceAddress, "sh_slice_address");
     }
   }
 


### PR DESCRIPTION
bugfix: slice_address should refer to sliceMap.sliceID, not sliceSubPicId  (refer to vtm)