### PR TITLE
Ignore level rate restriction if target bitrate not set

### DIFF
--- a/source/Lib/CommonLib/ProfileLevelTier.cpp
+++ b/source/Lib/CommonLib/ProfileLevelTier.cpp
@@ -121,7 +121,7 @@ const ProfileFeatures *ProfileFeatures::getProfileFeatures(const vvencProfile p)
 vvencLevel LevelTierFeatures::getLevelForInput( uint32_t width, uint32_t height, bool tier, int temporalRate, int temporalScale, int bitrate )
 {
   uint64_t samplesPerSec = ((uint64_t)temporalRate*(uint64_t)width*(uint64_t)height)/temporalScale;
-  uint32_t br = bitrate ? (uint32_t)bitrate/1000 : std::min((uint32_t)320000,(uint32_t)(samplesPerSec/3000));  //assume a min compression factor of 36 in the case of fix qp
+  uint32_t br = ( uint32_t ) bitrate / 1000; // don't assume bitrate if not set, ignore the condition since usually always satisfied
 
   for (const auto& info: mainLevelTierInfo )
   {


### PR DESCRIPTION
Otherwise too restrictive, and not good approximation available