### PR TITLE
fixes for 1.7.0 rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,8 @@ tag 1.7.0-rc1
     - extended vvencHDRMode to also include SDR color spaces
     - vvenc_config: m_numRefPics, m_numRefPicsSCC, m_blockImportanceMapping, m_saoScc
     - vvenc_config: changed m_sliceTypeAdapt from bool to char
+  - changed library parameters:
+    - m_TicksPerSecond new default 27000000 (old: 90000) to support all NTSC frame rates
   - added support for ARM through SIMDe
   - allowing adaptive intra period (content adaptive placement of random access points)
   - ported block importance mapping from VTM

--- a/include/vvenc/vvencCfg.h
+++ b/include/vvenc/vvencCfg.h
@@ -421,7 +421,7 @@ typedef struct vvenc_config
   int                 m_SourceHeight;                                                    // source height in pixel (when interlaced = field height)
   int                 m_FrameRate;                                                       // source frame-rates (Hz) Numerator
   int                 m_FrameScale;                                                      // source frame-rates (Hz) Denominator
-  int                 m_TicksPerSecond;                                                  // ticks per second e.g. 90000 for dts generation (1..27000000, -1: ticks per frame=1)
+  int                 m_TicksPerSecond;                                                  // ticks per second for dts generation (default: 27000000, 1..27000000, -1: ticks per frame=1)
   int                 m_framesToBeEncoded;                                               // number of encoded frames (default: 0, all)
   int                 m_inputBitDepth[ 2 ];                                              // bit-depth of input pictures (2d array for luma,chroma)
 

--- a/source/Lib/CommonLib/MCTF.cpp
+++ b/source/Lib/CommonLib/MCTF.cpp
@@ -586,7 +586,7 @@ void MCTF::filter( const std::deque<Picture*>& picFifo, int filterIdx )
   const double overallStrength = mctfIdx >= 0 ? m_encCfg->m_vvencMCTF.MCTFStrengths[ mctfIdx ] : -1.0;
   bool  isFilterThisFrame      = mctfIdx >= 0;
 
-  int dropFrames = 0;
+  int dropFrames = ( m_encCfg->m_usePerceptQPA ? VVENC_MCTF_RANGE >> 1 : 0 );
   if( mctfIdx >= 0 )
   {
     const int idxTLayer = m_encCfg->m_vvencMCTF.numFrames - (mctfIdx + 1);
@@ -601,12 +601,12 @@ void MCTF::filter( const std::deque<Picture*>& picFifo, int filterIdx )
   int dropFramesFront = std::min( std::max(                                          filterIdx - filterFrames, 0 ), dropFrames );
   int dropFramesBack  = std::min( std::max( static_cast<int>( picFifo.size() ) - 1 - filterIdx - filterFrames, 0 ), dropFrames );
 
-  if( ( overallStrength <= 1.0 || !m_encCfg->m_usePerceptQPA ) && !pic->useScMCTF )
+  if( !pic->useScMCTF )
   {
     isFilterThisFrame = false;
   }
 
-  if ( isFilterThisFrame )
+  if ( isFilterThisFrame || ( pic->gopEntry->m_isStartOfGop && m_encCfg->m_usePerceptQPA ) )
   {
     const PelStorage& origBuf = pic->getOrigBuffer();
           PelStorage& fltrBuf = pic->getFilteredOrigBuffer();

--- a/source/Lib/EncoderLib/BitAllocation.cpp
+++ b/source/Lib/EncoderLib/BitAllocation.cpp
@@ -358,11 +358,11 @@ int BitAllocation::applyQPAdaptationSlice (const Slice* slice, const VVEncCfg* e
         pic->ctuQpaLambda[ctuRsAddr] = hpEner[1]; // temporary backup of CTU mean visual activity
         pic->ctuAdaptedQP[ctuRsAddr] = (int) pic->getOrigBuf (ctuArea).getAvg(); // and mean luma
 
-        if ((picOrig.buf == picPrv1.buf) && (encCfg->m_vvencMCTF.MCTF)) // replace temp. activity
+        if (picOrig.buf == picPrv1.buf) // replace temporal visual activity with min motion error
         {
-          hpEner[1] = 1.5 * pic->m_picShared->m_minNoiseLevels[pic->ctuAdaptedQP[ctuRsAddr] >> (bitDepth - 3)];
+          hpEner[1] = pic->m_picShared->m_minNoiseLevels[pic->ctuAdaptedQP[ctuRsAddr] >> (bitDepth - 3)] * (bitDepth == 10 ? 1.5 : 0.375);
 
-          if (hpEner[1] < 382.0) // level in first frame
+          if (hpEner[1] < 255.0 * (bitDepth == 10 ? 1.5 : 0.375)) // level in first frame
           {
             hpEner[comp] += hpEner[1] * double (ctuArea.width * ctuArea.height);
             pic->ctuQpaLambda[ctuRsAddr] += hpEner[1]; // add noise level to mean visual activity

--- a/source/Lib/EncoderLib/EncLib.cpp
+++ b/source/Lib/EncoderLib/EncLib.cpp
@@ -235,7 +235,7 @@ void EncLib::initPass( int pass, const char* statsFName )
   m_maxNumPicShared += 1;
 
   // MCTF
-  if( m_encCfg.m_vvencMCTF.MCTF )
+  if( m_encCfg.m_vvencMCTF.MCTF || m_encCfg.m_usePerceptQPA )
   {
     m_MCTF = new MCTF();
     const int leadFrames   = std::min( VVENC_MCTF_RANGE, m_encCfg.m_leadFrames );
@@ -498,7 +498,7 @@ PicShared* EncLib::xGetFreePicShared()
       return nullptr;
 
     picShared = new PicShared();
-    picShared->create( m_encCfg.m_framesToBeEncoded, m_encCfg.m_internChromaFormat, Size( m_encCfg.m_PadSourceWidth, m_encCfg.m_PadSourceHeight ), m_encCfg.m_vvencMCTF.MCTF );
+    picShared->create( m_encCfg.m_framesToBeEncoded, m_encCfg.m_internChromaFormat, Size( m_encCfg.m_PadSourceWidth, m_encCfg.m_PadSourceHeight ), m_encCfg.m_vvencMCTF.MCTF || m_encCfg.m_usePerceptQPA );
     m_picSharedList.push_back( picShared );
   }
   CHECK( picShared == nullptr, "out of memory" );

--- a/source/Lib/apputils/VVEncAppCfg.h
+++ b/source/Lib/apputils/VVEncAppCfg.h
@@ -1224,7 +1224,8 @@ int parse( int argc, char* argv[], vvenc_config* c, std::ostream& rcOstr )
 
     if( sdrMode != VVENC_HDR_OFF || hdrMode != VVENC_HDR_OFF )
     {
-      if( sdrMode != VVENC_HDR_OFF && hdrMode != VVENC_HDR_OFF )
+      // check if at least one mode has changed, but error when both changed
+      if( sdrMode != hdrMode && sdrMode != VVENC_HDR_OFF && hdrMode != VVENC_HDR_OFF )
       {
         err.error( "Dynamic range" ) << "cannot combine hdr and sdr mode. use one or another.\n";
       }

--- a/source/Lib/vvenc/vvencCfg.cpp
+++ b/source/Lib/vvenc/vvencCfg.cpp
@@ -331,7 +331,7 @@ VVENC_DECL void vvenc_config_default(vvenc_config *c )
   c->m_SourceHeight                            = 0;             ///< source height in pixel (when interlaced = field height)
   c->m_FrameRate                               = 0;             ///< source frame-rates (Hz) Numerator
   c->m_FrameScale                              = 1;             ///< source frame-rates (Hz) Denominator
-  c->m_TicksPerSecond                          = 90000;         ///< ticks per second e.g. 90000 for dts generation (1..27000000)
+  c->m_TicksPerSecond                          = 27000000;      ///< ticks per second for dts generation (default: 27000000, 1..27000000, -1: ticks per frame=1)
 
   c->m_framesToBeEncoded                       = 0;             ///< number of encoded frames
 
@@ -710,7 +710,7 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
   vvenc_confirmParameter( c, c->m_FrameRate <= 0,                                                        "Frame rate must be greater than 0" );
   vvenc_confirmParameter( c, c->m_FrameScale <= 0,                                                       "Frame scale must be greater than 0" );
   vvenc_confirmParameter( c, c->m_TicksPerSecond < -1 || c->m_TicksPerSecond == 0 || c->m_TicksPerSecond > 27000000, "TicksPerSecond must be in range from 1 to 27000000, or -1 for ticks per frame=1" );
-  vvenc_confirmParameter( c, ( c->m_TicksPerSecond > 0 ) && ((int64_t)c->m_TicksPerSecond*(int64_t)c->m_FrameScale)%c->m_FrameRate, "TicksPerSecond should be a multiple of FrameRate/Framscale" );
+  vvenc_confirmParameter( c, ( c->m_TicksPerSecond > 0 ) && ((int64_t)c->m_TicksPerSecond*(int64_t)c->m_FrameScale)%c->m_FrameRate, "TicksPerSecond should be a multiple of FrameRate/Framescale. Use 27000000 for NTSC content" );
 
   vvenc_confirmParameter( c, c->m_numThreads < -1 || c->m_numThreads > 256,                              "Number of threads out of range (-1 <= t <= 256)");
 
@@ -1258,8 +1258,8 @@ VVENC_DECL bool vvenc_init_config_parameter( vvenc_config *c )
   vvenc_confirmParameter( c, c->m_GOPSize <= 8 && c->m_sliceTypeAdapt > 0, "Slice type adaptation for GOPSize <= 8 not supported" );
 
   // set number of lead / trail frames in segment mode
-  const int staFrames  = c->m_sliceTypeAdapt ? c->m_GOPSize     : 0;
-  const int mctfFrames = c->m_vvencMCTF.MCTF ? VVENC_MCTF_RANGE : 0;
+  const int staFrames  = c->m_sliceTypeAdapt                       ? c->m_GOPSize     : 0;
+  const int mctfFrames = c->m_vvencMCTF.MCTF || c->m_usePerceptQPA ? VVENC_MCTF_RANGE : 0;
   switch( c->m_SegmentMode )
   {
     case VVENC_SEG_FIRST:
@@ -2292,7 +2292,7 @@ VVENC_DECL int vvenc_init_default( vvenc_config *c, int width, int height, int f
     default: break;
   }
 
-  c->m_TicksPerSecond      = 90000;                    // ticks per second e.g. 90000 for dts generation
+  c->m_TicksPerSecond      = 27000000;                 // ticks per second for dts generation
 
   c->m_inputBitDepth[0]    = 8;                        // input bitdepth
   c->m_internalBitDepth[0] = 10;                       // internal bitdepth

--- a/test/vvenclibtest/vvenclibtest.cpp
+++ b/test/vvenclibtest/vvenclibtest.cpp
@@ -1009,6 +1009,11 @@ int checkTimestampsDefault()
 
   framerates.clear();
   tickspersecVec.clear();
+  framerates.push_back(std::make_tuple( 25,1) );
+  framerates.push_back(std::make_tuple( 30,1) );
+  framerates.push_back(std::make_tuple( 50,1) );
+  framerates.push_back(std::make_tuple( 60,1) );
+  framerates.push_back(std::make_tuple( 120,1) );
   framerates.push_back(std::make_tuple( 25000,1001) );
   framerates.push_back(std::make_tuple( 30000,1001) );
   framerates.push_back(std::make_tuple( 60000,1001) );


### PR DESCRIPTION
- change default m_TicksPerSecond = 27000000 (solves first part of #228 )
- error hdr/sdr mix only, when different
- allow MCTF ME to improve QPA, even if MCTF is disabled