### PR TITLE
Fix build on big-endian

### DIFF
--- a/source/Lib/CommonLib/MD5.h
+++ b/source/Lib/CommonLib/MD5.h
@@ -57,11 +57,11 @@ static const uint32_t MD5_DIGEST_STRING_LENGTH=16;
 #ifndef __BIG_ENDIAN__
 # define byteReverse(buf, len)    /* Nothing */
 #else
-void byteReverse(uint32_t *buf, unsigned len);
+static void byteReverse(uint32_t *buf, unsigned len);
 /*
  * Note: this code is harmless on little-endian machines.
  */
-void byteReverse(uint32_t *buf, unsigned len)
+static void byteReverse(uint32_t *buf, unsigned len)
 {
   uint32_t t;
   do {


### PR DESCRIPTION
Add static to avoid duplicate symbol linking error:
```
ld: error: duplicate symbol: vvenc::byteReverse(unsigned int*, unsigned int)
>>> defined at PicYuvMD5.cpp
>>>            source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/PicYuvMD5.cpp.o:(vvenc::byteReverse(unsigned int*, unsigned int))
>>> defined at EncGOP.cpp
>>>            source/Lib/vvenc/CMakeFiles/vvenc.dir/__/EncoderLib/EncGOP.cpp.o:(.text+0x0)
```