### PR TITLE
cmake: Fix compiling if CFLAGS or CXXFLAGS are set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ if( VVENC_ENABLE_X86_SIMD )
     # when building for non-x86, but emulating simd using simd-everywhere (e.g. on ARM),
     # the x86-compiler flags are not understood by the compiler
     set_if_compiler_supports_flag( FLAG_msse41 -msse4.1 )
-    add_compile_options( ${FLAG_msse41} )
+    set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG_msse41}" )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG_msse41}" )
   endif()
 
   if( NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" )


### PR DESCRIPTION

    This fixes checking _mm_extract_epi64 intrinsic when CFLAGS or CXXFLAGS
    are set. The -msse4.1 option is appended with existing compiler flags.
    Otherwise, _mm_extract_epi64 check fails without the -msse4.1 option.
    For example, the issue has been seen with the following variables in
    mingw-w64 gcc 64-bit toolchain.

    export CPPFLAGS="-D_FORTIFY_SOURCE=0 -D__USE_MINGW_ANSI_STDIO=1"
    export CFLAGS="-mthreads -mtune=generic -O2 -pipe"
    export CXXFLAGS="-mthreads -mtune=generic -O2 -pipe"
    export LDFLAGS="-pipe -static-libgcc -static-libstdc++"

