### PR TITLE
Proper fix for sse 41 detection

### DIFF
--- a/cmake/modules/vvencCompilerSupport.cmake
+++ b/cmake/modules/vvencCompilerSupport.cmake
@@ -26,26 +26,26 @@ function( check_missing_intrinsics )
   _emscripten_enable_wasm_simd128()
 
   if( NOT MSVC )
-    set_if_compiler_supports_flag( FLAG_msse2 -msse2 )
-    set_if_compiler_supports_flag( FLAG_mavx  -mavx  )
+    set_if_compiler_supports_flag( FLAG_msse41 -msse4.1 )
+    set_if_compiler_supports_flag( FLAG_mavx   -mavx  )
   else()
-    set_if_compiler_supports_flag( FLAG_mavx  /arch:AVX2  )
+    set_if_compiler_supports_flag( FLAG_mavx   /arch:AVX2  )
   endif()
 
   # SSE2
-  _check_intrinsic( _mm_storeu_si16      "${FLAG_msse2}" "int16_t a = 0; _mm_storeu_si16( &a, _mm_setzero_si128() );"                )
-  _check_intrinsic( _mm_storeu_si32      "${FLAG_msse2}" "int32_t a = 0; _mm_storeu_si32( &a, _mm_setzero_si128() );"                )
-  _check_intrinsic( _mm_storeu_si64      "${FLAG_msse2}" "int64_t a = 0; _mm_storeu_si64( &a, _mm_setzero_si128() );"                )
-  _check_intrinsic( _mm_loadu_si32       "${FLAG_msse2}" "int32_t a = 0; __m128i x = _mm_loadu_si32( &a );"                          )
-  _check_intrinsic( _mm_loadu_si64       "${FLAG_msse2}" "int64_t a = 0; __m128i x = _mm_loadu_si64( &a );"                          )
-  _check_intrinsic( _mm_cvtsi128_si64    "${FLAG_msse2}" "int64_t a = 0; a = _mm_cvtsi128_si64( _mm_setzero_si128() );"              ) 
-  _check_intrinsic( _mm_extract_epi64    "${FLAG_msse2}" "int64_t a = 0; a = _mm_extract_epi64( _mm_setzero_si128(), 0 );"           )
+  _check_intrinsic( _mm_storeu_si16      "${FLAG_msse41}" "int16_t a = 0; _mm_storeu_si16( &a, _mm_setzero_si128() );"                )
+  _check_intrinsic( _mm_storeu_si32      "${FLAG_msse41}" "int32_t a = 0; _mm_storeu_si32( &a, _mm_setzero_si128() );"                )
+  _check_intrinsic( _mm_storeu_si64      "${FLAG_msse41}" "int64_t a = 0; _mm_storeu_si64( &a, _mm_setzero_si128() );"                )
+  _check_intrinsic( _mm_loadu_si32       "${FLAG_msse41}" "int32_t a = 0; __m128i x = _mm_loadu_si32( &a );"                          )
+  _check_intrinsic( _mm_loadu_si64       "${FLAG_msse41}" "int64_t a = 0; __m128i x = _mm_loadu_si64( &a );"                          )
+  _check_intrinsic( _mm_cvtsi128_si64    "${FLAG_msse41}" "int64_t a = 0; a = _mm_cvtsi128_si64( _mm_setzero_si128() );"              ) 
+  _check_intrinsic( _mm_extract_epi64    "${FLAG_msse41}" "int64_t a = 0; a = _mm_extract_epi64( _mm_setzero_si128(), 0 );"           )
 
   # AVX
-  _check_intrinsic( _mm256_zeroupper     "${FLAG_mavx}"  "_mm256_zeroupper();"                                                       )
-  _check_intrinsic( _mm256_loadu2_m128i  "${FLAG_mavx}"  "int a[4] = { 0, };                                                         \
-                                                         __m256i x = _mm256_loadu2_m128i( (const __m128i*)a, (const __m128i*)a );"   )
-  _check_intrinsic( _mm256_set_m128i     "${FLAG_mavx}"  "__m256i x = _mm256_set_m128i( _mm_setzero_si128(), _mm_setzero_si128() );" )
+  _check_intrinsic( _mm256_zeroupper     "${FLAG_mavx}"   "_mm256_zeroupper();"                                                       )
+  _check_intrinsic( _mm256_loadu2_m128i  "${FLAG_mavx}"   "int a[4] = { 0, };                                                         \
+                                                          __m256i x = _mm256_loadu2_m128i( (const __m128i*)a, (const __m128i*)a );"   )
+  _check_intrinsic( _mm256_set_m128i     "${FLAG_mavx}"   "__m256i x = _mm256_set_m128i( _mm_setzero_si128(), _mm_setzero_si128() );" )
 endfunction()
 
 function( _check_intrinsic symbol_name compiler_flags code )


### PR DESCRIPTION
`_mm_extract_epi64` is a SSE4.1 intrinsic, so the check needs to use an appropriate flag