### PR TITLE
Align the layout of first and other GOPs, improve MCTF, others...

### DIFF
--- a/.gitlab-ci-internal.yml
+++ b/.gitlab-ci-internal.yml
@@ -47,7 +47,7 @@ variables:
    script:
       - make osx-arch=${OSX_ARCH} disable-lto=1 all
       - make osx-arch=${OSX_ARCH} disable-lto=1 test
-      
+
 .build_test_msvc_template:
    extends: .build_test_template
    script:
@@ -184,16 +184,6 @@ build_mingw_ubuntu2004:
    extends: .build_only_ubuntu2004_mingw_template
    image: $CI_REGISTRY/pub/dockerimages/ubuntu_2004_full:latest
 
-build_vc191x:
-   extends: .build_only_template
-   tags:
-      - vc191x
-
-build_vc192x:
-   extends: .build_only_template
-   tags:
-      - vc192x
-
 test_ubuntu1804:
    extends: .build_test_template
    image: $CI_REGISTRY/pub/dockerimages/ubuntu_1804_full:latest
@@ -219,14 +209,14 @@ test_vc192x:
       MSVC_ARCH: x64
    tags:
       - vc192x
-      
+
 test_vc193x_Win32:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: Win32
   tags:
     - vc193x
-    
+
 test_vc193x:
   extends: .build_test_msvc_template
   variables:

--- a/cfg/experimental/lowdelay_fast.cfg
+++ b/cfg/experimental/lowdelay_fast.cfg
@@ -10,6 +10,7 @@ IntraPeriod                   : -1          # Period of I-Frame ( -1 = only firs
 DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
 STA                           : 0
+POC0IDR                       : 1
 
 IntraQPOffset                 : -1
 PicReordering                 : 0

--- a/cfg/experimental/lowdelay_faster.cfg
+++ b/cfg/experimental/lowdelay_faster.cfg
@@ -10,6 +10,7 @@ IntraPeriod                   : -1          # Period of I-Frame ( -1 = only firs
 DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
 STA                           : 0
+POC0IDR                       : 1
 
 IntraQPOffset                 : -1
 PicReordering                 : 0

--- a/cfg/experimental/lowdelay_medium.cfg
+++ b/cfg/experimental/lowdelay_medium.cfg
@@ -10,6 +10,7 @@ IntraPeriod                   : -1          # Period of I-Frame ( -1 = only firs
 DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
 STA                           : 0
+POC0IDR                       : 1
 
 IntraQPOffset                 : -1
 PicReordering                 : 0

--- a/cfg/experimental/lowdelay_slow.cfg
+++ b/cfg/experimental/lowdelay_slow.cfg
@@ -10,6 +10,7 @@ IntraPeriod                   : -1          # Period of I-Frame ( -1 = only firs
 DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
 STA                           : 0
+POC0IDR                       : 1
 
 IntraQPOffset                 : -1
 PicReordering                 : 0

--- a/cfg/experimental/lowdelay_slower.cfg
+++ b/cfg/experimental/lowdelay_slower.cfg
@@ -10,6 +10,7 @@ IntraPeriod                   : -1          # Period of I-Frame ( -1 = only firs
 DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
 STA                           : 0
+POC0IDR                       : 1
 
 IntraQPOffset                 : -1
 PicReordering                 : 0

--- a/include/vvenc/vvencCfg.h
+++ b/include/vvenc/vvencCfg.h
@@ -80,7 +80,7 @@ typedef void (*vvencLoggingCallback)(void*, int, const char*, va_list);
 #define VVENC_MAX_TLAYER                      7      // Explicit temporal layer QP offset - max number of temporal layer
 #define VVENC_MAX_NUM_CQP_MAPPING_TABLES      3      // Maximum number of chroma QP mapping tables (Cb, Cr and joint Cb-Cr)
 #define VVENC_MAX_NUM_ALF_ALTERNATIVES_CHROMA 8
-#define VVENC_MCTF_RANGE                      4      // max number of frames used for MCTF filtering in forward / backward direction
+#define VVENC_MCTF_RANGE                      6      // max number of frames used for MCTF filtering in forward / backward direction
 #define VVENC_MAX_NUM_COMP                    3      // max number of components
 #define VVENC_MAX_QP_VALS_CHROMA              8      // max number qp vals in array
 #define VVENC_MAX_MCTF_FRAMES                 16
@@ -196,7 +196,7 @@ typedef enum
   VVENC_DRT_CRA                = 1,
   VVENC_DRT_IDR                = 2,
   VVENC_DRT_RECOVERY_POINT_SEI = 3,
-  VVENC_DRT_IDR2               = 4,
+  VVENC_DRT_IDR2               = 4,             //deprecated
   VVENC_DRT_CRA_CRE            = 5,             //constrained RASL encoding
 }vvencDecodingRefreshType;
 
@@ -759,7 +759,8 @@ typedef struct vvenc_config
   int                 m_explicitAPSid;
 
   bool                m_picReordering;
-  bool                m_reservedFlag[2];
+  bool                m_reservedFlag;
+  bool                m_poc0idr;
   int8_t              m_fppLinesSynchro;
   bool                m_blockImportanceMapping;
   bool                m_saoScc;

--- a/source/Lib/CommonLib/CodingStructure.cpp
+++ b/source/Lib/CommonLib/CodingStructure.cpp
@@ -136,24 +136,6 @@ void CodingStructure::releaseIntermediateData()
   clearCUs();
 }
 
-const int CodingStructure::signalModeCons( const PartSplit split, Partitioner &partitioner, const ModeType modeTypeParent ) const
-{
-  if (CS::isDualITree(*this) || modeTypeParent != MODE_TYPE_ALL || partitioner.currArea().chromaFormat == CHROMA_444 || partitioner.currArea().chromaFormat == CHROMA_400 )
-    return LDT_MODE_TYPE_INHERIT;
-  int minLumaArea = partitioner.currArea().lumaSize().area();
-  if (split == CU_QUAD_SPLIT || split == CU_TRIH_SPLIT || split == CU_TRIV_SPLIT) // the area is split into 3 or 4 parts
-  {
-    minLumaArea = minLumaArea >> 2;
-  }
-  else if (split == CU_VERT_SPLIT || split == CU_HORZ_SPLIT) // the area is split into 2 parts
-  {
-    minLumaArea = minLumaArea >> 1;
-  }
-  int minChromaBlock = minLumaArea >> (getChannelTypeScaleX(CH_C, partitioner.currArea().chromaFormat) + getChannelTypeScaleY(CH_C, partitioner.currArea().chromaFormat));
-  bool is2xNChroma = (partitioner.currArea().chromaSize().width == 4 && split == CU_VERT_SPLIT) || (partitioner.currArea().chromaSize().width == 8 && split == CU_TRIV_SPLIT);
-  return minChromaBlock >= 16 && !is2xNChroma ? LDT_MODE_TYPE_INHERIT : ((minLumaArea < 32) || slice->isIntra()) ? LDT_MODE_TYPE_INFER : LDT_MODE_TYPE_SIGNAL;
-}
-
 CodingUnit* CodingStructure::getLumaCU( const Position& pos )
 {
   const ChannelType effChType = CH_L;

--- a/source/Lib/CommonLib/CodingStructure.h
+++ b/source/Lib/CommonLib/CodingStructure.h
@@ -167,7 +167,6 @@ public:
 
   void clearTUs( bool force = false );
   void clearCUs( bool force = false );
-  const int signalModeCons( const PartSplit split, Partitioner &partitioner, const ModeType modeTypeParent ) const;
 
   void createTempBuffers( const bool isTopLayer );
   void destroyTempBuffers();

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -501,6 +501,10 @@ static constexpr uint8_t MAX_TMP_BUFS = 6;
 
 static constexpr int QPA_MAX_NOISE_LEVELS = 8;
 
+static constexpr int FPPLS_ALF_DERIVE_LINES   = 1; ///< number of CTU lines for ALF filter derivation
+static constexpr int FPPLS_CCALF_DERIVE_LINES = 1; ///< number of CTU lines for CCALF filter derivation
+
+
 // ====================================================================================================================
 // Macro functions
 // ====================================================================================================================

--- a/source/Lib/CommonLib/InterPrediction.h
+++ b/source/Lib/CommonLib/InterPrediction.h
@@ -99,7 +99,7 @@ protected:
 protected:
   void xWeightedAverage       ( const CodingUnit& cu, const CPelUnitBuf& pcYuvSrc0, const CPelUnitBuf& pcYuvSrc1, PelUnitBuf& pcYuvDst, const bool bdofApplied, PelUnitBuf *yuvPredTmp = NULL );
   void xPredAffineBlk         ( const ComponentID compID, const CodingUnit& cu, const Picture* refPic, const Mv* _mv, PelUnitBuf& dstPic, const bool bi, const ClpRng& clpRng, const RefPicList refPicList = REF_PIC_LIST_X);
-  void xPredInterBlk          ( const ComponentID compID, const CodingUnit& cu, const Picture* refPic, const Mv& _mv, PelUnitBuf& dstPic, const bool bi, const ClpRng& clpRng
+  void xPredInterBlk( const ComponentID compID, const CodingUnit& cu, const Picture* refPic, const Mv& _mv, PelUnitBuf& dstPic, const bool bi, const ClpRng& clpRng
                               , const bool bdofApplied
                               , const bool isIBC
                               , const RefPicList refPicList = REF_PIC_LIST_X
@@ -120,6 +120,7 @@ public:
                             PelUnitBuf &predDst, PelUnitBuf &predSrc0, PelUnitBuf &predSrc1);
 
   static bool isSubblockVectorSpreadOverLimit(int a, int b, int c, int d, int predType);
+  bool xIsAffineMvInRangeFPP (const CodingUnit& cu, const Mv* _mv, const int fppLinesSynchro, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
 };
 
 class DMVR : public InterPredInterpolation

--- a/source/Lib/CommonLib/MCTF.h
+++ b/source/Lib/CommonLib/MCTF.h
@@ -112,7 +112,6 @@ struct TemporalFilterSourcePicInfo
   Array2D<MotionVector> mvs;
   int                   index;
 };
-
 // ====================================================================================================================
 // Class definition
 // ====================================================================================================================
@@ -159,7 +158,7 @@ private:
   static const int      m_padding;
   static const int16_t  m_interpolationFilter4[16][4];
   static const int16_t  m_interpolationFilter8[16][8];
-  static const double   m_refStrengths[3][4];
+  static const double   m_refStrengths[2][4];
   static const int      m_cuTreeThresh[4];
   static const double   m_cuTreeCenter;
 
@@ -188,6 +187,8 @@ private:
   void bilateralFilter  (const PelStorage &orgPic, std::deque<TemporalFilterSourcePicInfo> &srcFrameInfo, PelStorage &newOrgPic, double overallStrength) const;
 
   void xFinalizeBlkLine (const PelStorage &orgPic, std::deque<TemporalFilterSourcePicInfo> &srcFrameInfo, PelStorage &newOrgPic, int yStart, const double sigmaSqCh[MAX_NUM_CH], double overallStrenght) const;
+
+  void motionEstimationMCTF(Picture* curPic, std::deque<TemporalFilterSourcePicInfo>& srcFrameInfo, const PelStorage& origBuf, PelStorage& origSubsampled2, PelStorage& origSubsampled4, PelStorage& origSubsampled8, std::vector<double>& mvErr, double& minError, bool addLevel, bool calcErr);
 
 }; // END CLASS DEFINITION MCTF
 

--- a/source/Lib/CommonLib/Mv.cpp
+++ b/source/Lib/CommonLib/Mv.cpp
@@ -83,6 +83,19 @@ void clipMv( Mv& rcMv, const Position& pos, const struct Size& size, const PreCa
   rcMv.ver = ( std::min( iVerMax, std::max( iVerMin, rcMv.ver ) ) );
 }
 
+void clipMvHor( Mv& rcMv, const Position& pos, const struct Size& size, const PreCalcValues& pcv )
+{
+  if( pcv.wrapArround )
+  {
+    return;
+  }
+  int iMvShift = MV_FRACTIONAL_BITS_INTERNAL;
+  int iOffset = 8;
+  int iHorMax = ( pcv.lumaWidth + iOffset - ( int ) pos.x - 1 ) << iMvShift;
+  int iHorMin = ( -( int ) pcv.maxCUSize   - iOffset - ( int ) pos.x + 1 ) * (1 << iMvShift);
+  rcMv.hor = ( std::min( iHorMax, std::max( iHorMin, rcMv.hor ) ) );
+}
+
 void clipMv(Mv& rcMv, const Position& pos, const struct Size& size, const PreCalcValues& pcv, const PPS& pps, bool m_clipMvInSubPic)
 {
   if (pcv.wrapArround)

--- a/source/Lib/CommonLib/Mv.h
+++ b/source/Lib/CommonLib/Mv.h
@@ -224,6 +224,15 @@ public:
     roundToPrecision(MV_PRECISION_INTERNAL, m_amvrPrecision[amvr]);
   }
 
+  void roundTransPrecInternal2AmvrVertical(const int amvr)
+  {
+    const int shift = MV_PRECISION_INTERNAL - Mv::m_amvrPrecision[amvr];
+    const int rightShift = shift;
+    const int nOffset = 1 << (rightShift - 1);
+    ver = ver >= 0 ? (ver + nOffset - 1) >> rightShift : (ver + nOffset) >> rightShift;
+    ver = ver << shift;
+  }
+
   // affine MV
   void changeAffinePrecInternal2Amvr(const int amvr)
   {

--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -961,7 +961,7 @@ public:
 
     return tileRowResIdx + tileRowResIdxRest;
   }
-  bool                   canFilterCtuBdry( int ctuX, int ctuY, int offX, int offY ) const { return getTileIdx( ctuX, ctuY ) == getTileIdx( ctuX + offX, ctuY + offY ) || loopFilterAcrossTilesEnabled; }
+  bool                   canFilterCtuBdry( int ctuX, int ctuY, int offX, int offY ) const { return loopFilterAcrossTilesEnabled || getTileIdx( ctuX, ctuY ) == getTileIdx( ctuX + offX, ctuY + offY ); }
   
   const SubPic&          getSubPicFromPos(const Position& pos)  const;
   const SubPic&          getSubPicFromCU (const CodingUnit& cu) const;

--- a/source/Lib/CommonLib/UnitTools.h
+++ b/source/Lib/CommonLib/UnitTools.h
@@ -60,8 +60,9 @@ namespace CS
 {
   UnitArea  getArea                    (const CodingStructure &cs, const UnitArea& area, const ChannelType chType, const TreeType treeType);
   bool      isDualITree                (const CodingStructure &cs);
-  void      setRefinedMotionFieldCTU   ( CodingStructure& cs, const int ctuX, const int ctuY );
+  void      setRefinedMotionFieldCTU   (      CodingStructure &cs, const int ctuX, const int ctuY );
   void      setRefinedMotionField      (      CodingStructure &cs);
+  int       signalModeCons             (const CodingStructure &cs, const UnitArea &currArea, const PartSplit split, const ModeType modeTypeParent);
 }
 
 
@@ -180,7 +181,9 @@ namespace CU
   void     getIBCMergeCandidates        (const CodingUnit& cu, MergeCtx& mrgCtx, const int& mrgCandIdx = -1);
   void     fillIBCMvpCand               (CodingUnit& cu, AMVPInfo& amvpInfo);
   void     getIbcMVPsEncOnly            (CodingUnit& cu, Mv* mvPred, int& nbPred);
-  bool     isMvInRangeFPP               (const CodingUnit &cu, const Mv& mv, const int fppLinesSynchro, const ComponentID compID = COMP_Y, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL );
+  //bool     isMvInRangeFPP               (const CodingUnit &cu, const Mv& mv, const int fppLinesSynchro, const ComponentID compID = COMP_Y, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL );
+  bool     isMvInRangeFPP               (const int yB, const int nH, const int yMv, const int fppLinesSynchro, const PreCalcValues& pcv, const int yCompScale = 0, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
+  bool     isMotionBufInRangeFPP        (const CodingUnit& cu, const int fppLinesSynchro);
 }
 
 // TU tools

--- a/source/Lib/CommonLib/dtrace_next.h
+++ b/source/Lib/CommonLib/dtrace_next.h
@@ -158,6 +158,7 @@ enum DTRACE_CHANNEL
   D_MOT_COMP,             // Motion compensation
   D_ALF,
   D_ALF_EST,
+  D_CCALF_EST,
   D_CRC
 };
 #define _CNL_DEF(_s) {_s,(std::string(#_s))}
@@ -258,6 +259,7 @@ inline CDTrace* tracing_init( const std::string& sTracingFile, const std::string
     _CNL_DEF( D_MOT_COMP ),
     _CNL_DEF( D_ALF ),
     _CNL_DEF( D_ALF_EST ),
+    _CNL_DEF( D_CCALF_EST ),
     _CNL_DEF( D_CRC )
   };
   dtrace_channels_t channels( next_channels, &next_channels[sizeof( next_channels ) / sizeof( next_channels[0] )] );

--- a/source/Lib/CommonLib/x86/MCTFX86.h
+++ b/source/Lib/CommonLib/x86/MCTFX86.h
@@ -55,6 +55,9 @@ POSSIBILITY OF SUCH DAMAGE.
 //! \ingroup CommonLib
 //! \{
 
+#define cond_mm_prefetch(a,b) _mm_prefetch(a,b)
+//#define cond_mm_prefetch(a,b)
+
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_MCTF
 
 namespace vvenc {
@@ -65,6 +68,11 @@ int motionErrorLumaInt_SIMD( const Pel* org, const ptrdiff_t origStride, const P
   int error = 0;
   __m128i xerror = _mm_setzero_si128();
 
+  cond_mm_prefetch( ( const char* ) ( org ),              _MM_HINT_T0 );
+  cond_mm_prefetch( ( const char* ) ( org + origStride ), _MM_HINT_T0 );
+  cond_mm_prefetch( ( const char* ) ( buf ),              _MM_HINT_T0 );
+  cond_mm_prefetch( ( const char* ) ( buf + buffStride ), _MM_HINT_T0 );
+
   CHECK( w & 7, "SIMD blockSize needs to be a multiple of 8" );
 
 #if USE_AVX2
@@ -74,6 +82,11 @@ int motionErrorLumaInt_SIMD( const Pel* org, const ptrdiff_t origStride, const P
     {
       const Pel* origRowStart   = org + y1 * origStride;
       const Pel* bufferRowStart = buf + y1 * buffStride;
+
+      cond_mm_prefetch( ( const char* ) ( origRowStart   + 2 * origStride ), _MM_HINT_T0 );
+      cond_mm_prefetch( ( const char* ) ( origRowStart   + 3 * origStride ), _MM_HINT_T0 );
+      cond_mm_prefetch( ( const char* ) ( bufferRowStart + 2 * buffStride ), _MM_HINT_T0 );
+      cond_mm_prefetch( ( const char* ) ( bufferRowStart + 3 * buffStride ), _MM_HINT_T0 );
 
       __m256i vsum = _mm256_setzero_si256();
 
@@ -427,6 +440,9 @@ int motionErrorLumaFrac_loRes_SIMD( const Pel* org, const ptrdiff_t origStride, 
   
   CHECK( w & 7, "SIMD blockSize needs to be a multiple of 8" );
 
+  cond_mm_prefetch( ( const char* )   org,                            _MM_HINT_T0 );
+  cond_mm_prefetch( ( const char* ) ( buf + base + -1 * buffStride ), _MM_HINT_T0 );
+
 #if USE_AVX2
   if( vext >= AVX2 && ( w & 15 ) == 0 )
   {
@@ -461,6 +477,9 @@ int motionErrorLumaFrac_loRes_SIMD( const Pel* org, const ptrdiff_t origStride, 
 
       for( int y1 = 0; y1 < h + 3; y1++, rowStart += buffStride )
       {
+        cond_mm_prefetch( ( const char* ) ( origRow  + origStride ), _MM_HINT_T0 );
+        cond_mm_prefetch( ( const char* ) ( rowStart + buffStride ), _MM_HINT_T0 );
+
         __m256i xsrc1 = _mm256_loadu_si256( ( const __m256i * ) &rowStart[0] );
         __m256i xsrc2 = _mm256_loadu_si256( ( const __m256i * ) &rowStart[1] );
         __m256i xsrc3 = _mm256_loadu_si256( ( const __m256i * ) &rowStart[2] );
@@ -565,6 +584,9 @@ int motionErrorLumaFrac_loRes_SIMD( const Pel* org, const ptrdiff_t origStride, 
 
     for( int y1 = 0; y1 < h + 3; y1++, rowStart += buffStride )
     {
+      cond_mm_prefetch( ( const char* ) ( origRow + origStride  ), _MM_HINT_T0 );
+      cond_mm_prefetch( ( const char* ) ( rowStart + buffStride ), _MM_HINT_T0 );
+
       __m128i xsrc1 = _mm_loadu_si128( ( const __m128i * ) &rowStart[0] );
       __m128i xsrc2 = _mm_loadu_si128( ( const __m128i * ) &rowStart[1] );
       __m128i xsrc3 = _mm_loadu_si128( ( const __m128i * ) &rowStart[2] );

--- a/source/Lib/EncoderLib/BitAllocation.h
+++ b/source/Lib/EncoderLib/BitAllocation.h
@@ -64,7 +64,7 @@ namespace vvenc {
                                              uint32_t frameRate,
                                              const uint32_t bitDepth,
                                              const bool isUHD,
-                                             unsigned* minVA,
+                                             unsigned* minVisAct,
                                              unsigned* spVisAct);
 
   // BitAllocation functions

--- a/source/Lib/EncoderLib/CABACWriter.cpp
+++ b/source/Lib/EncoderLib/CABACWriter.cpp
@@ -540,7 +540,7 @@ void CABACWriter::coding_tree(const CodingStructure& cs, Partitioner& partitione
 void CABACWriter::mode_constraint( const PartSplit split, const CodingStructure& cs, Partitioner& partitioner, const ModeType modeType )
 {
   CHECK( split == CU_DONT_SPLIT, "splitMode shall not be no split" );
-  int val = cs.signalModeCons( split, partitioner, partitioner.modeType );
+  int val = CS::signalModeCons( cs, partitioner.currArea(), split, partitioner.modeType);
   if( val == LDT_MODE_TYPE_SIGNAL )
   {
     CHECK( modeType == MODE_TYPE_ALL, "shall not be no constraint case" );
@@ -2870,28 +2870,26 @@ void CABACWriter::exp_golomb_eqprob( unsigned symbol, unsigned count )
 }
 
 
-void CABACWriter::codeAlfCtuEnabled( CodingStructure& cs, ChannelType channel, AlfParam* alfParam)
+void CABACWriter::codeAlfCtuEnabled( CodingStructure& cs, ChannelType channel, AlfParam* alfParam, const int numCtus )
 {
   if( isLuma( channel ) )
   {
     if (alfParam->alfEnabled[COMP_Y])
-      codeAlfCtuEnabled( cs, COMP_Y, alfParam );
+      codeAlfCtuEnabled( cs, COMP_Y, alfParam, numCtus );
   }
   else
   {
     if (alfParam->alfEnabled[COMP_Cb])
-      codeAlfCtuEnabled( cs, COMP_Cb, alfParam );
+      codeAlfCtuEnabled( cs, COMP_Cb, alfParam, numCtus );
     if (alfParam->alfEnabled[COMP_Cr])
-      codeAlfCtuEnabled( cs, COMP_Cr, alfParam );
+      codeAlfCtuEnabled( cs, COMP_Cr, alfParam, numCtus );
   }
 }
 
 
-void CABACWriter::codeAlfCtuEnabled( CodingStructure& cs, ComponentID compID, AlfParam* alfParam)
+void CABACWriter::codeAlfCtuEnabled( CodingStructure& cs, ComponentID compID, AlfParam* alfParam, const int numCtus )
 {
-  uint32_t numCTUs = cs.pcv->sizeInCtus;
-
-  for( int ctuIdx = 0; ctuIdx < numCTUs; ctuIdx++ )
+  for( int ctuIdx = 0; ctuIdx < numCtus; ctuIdx++ )
   {
     codeAlfCtuEnabledFlag( cs, ctuIdx, compID );
   }
@@ -3043,26 +3041,25 @@ void CABACWriter::codeAlfCtuFilterIndex(CodingStructure& cs, uint32_t ctuRsAddr)
 }
 
 
-void CABACWriter::codeAlfCtuAlternatives( CodingStructure& cs, ChannelType channel, AlfParam* alfParam)
+void CABACWriter::codeAlfCtuAlternatives( CodingStructure& cs, ChannelType channel, AlfParam* alfParam, const int numCtus )
 {
   if( isChroma( channel ) )
   {
     if (alfParam->alfEnabled[COMP_Cb])
-      codeAlfCtuAlternatives( cs, COMP_Cb, alfParam );
+      codeAlfCtuAlternatives( cs, COMP_Cb, alfParam, numCtus );
     if (alfParam->alfEnabled[COMP_Cr])
-      codeAlfCtuAlternatives( cs, COMP_Cr, alfParam );
+      codeAlfCtuAlternatives( cs, COMP_Cr, alfParam, numCtus );
   }
 }
 
 
-void CABACWriter::codeAlfCtuAlternatives( CodingStructure& cs, ComponentID compID, AlfParam* alfParam)
+void CABACWriter::codeAlfCtuAlternatives( CodingStructure& cs, ComponentID compID, AlfParam* alfParam, const int numCtus)
 {
   if( compID == COMP_Y )
     return;
-  uint32_t numCTUs = cs.pcv->sizeInCtus;
   const uint8_t* ctbAlfFlag = cs.slice->pic->m_alfCtuEnabled[ compID ].data();
 
-  for( int ctuIdx = 0; ctuIdx < numCTUs; ctuIdx++ )
+  for( int ctuIdx = 0; ctuIdx < numCtus; ctuIdx++ )
   {
     if( ctbAlfFlag[ctuIdx] )
     {

--- a/source/Lib/EncoderLib/CABACWriter.h
+++ b/source/Lib/EncoderLib/CABACWriter.h
@@ -157,13 +157,13 @@ public:
   void        joint_cb_cr               ( const TransformUnit&          tu,       const int cbfMask );
 
 
-  void        codeAlfCtuEnabled          ( CodingStructure& cs, ChannelType channel, AlfParam* alfParam );
-  void        codeAlfCtuEnabled          ( CodingStructure& cs, ComponentID compID, AlfParam* alfParam );
+  void        codeAlfCtuEnabled          ( CodingStructure& cs, ChannelType channel, AlfParam* alfParam, const int numCtus );
+  void        codeAlfCtuEnabled          ( CodingStructure& cs, ComponentID compID, AlfParam* alfParam, const int numCtus );
   void        codeAlfCtuEnabledFlag      ( CodingStructure& cs, uint32_t ctuRsAddr, const int compIdx );
   void        codeAlfCtuFilterIndex      ( CodingStructure& cs, uint32_t ctuRsAddr );
 
-  void        codeAlfCtuAlternatives     ( CodingStructure& cs, ChannelType channel, AlfParam* alfParam );
-  void        codeAlfCtuAlternatives     ( CodingStructure& cs, ComponentID compID, AlfParam* alfParam );
+  void        codeAlfCtuAlternatives     ( CodingStructure& cs, ChannelType channel, AlfParam* alfParam, const int numCtus );
+  void        codeAlfCtuAlternatives     ( CodingStructure& cs, ComponentID compID, AlfParam* alfParam, const int numCtus );
   void        codeAlfCtuAlternative      ( CodingStructure& cs, uint32_t ctuRsAddr, const int compIdx, const AlfParam* alfParam = NULL );
   void        codeCcAlfFilterControlIdc  ( uint8_t idcVal, CodingStructure &cs, const ComponentID compID, const int curIdx,
                                            const uint8_t *filterControlIdc, Position lumaPos, const int filterCount);

--- a/source/Lib/EncoderLib/EncGOP.cpp
+++ b/source/Lib/EncoderLib/EncGOP.cpp
@@ -187,7 +187,7 @@ void EncGOP::init( const VVEncCfg& encCfg, const GOPCfg* gopCfg, RateCtrl& rateC
   xInitRPL( sps0 );
   xInitHrdParameters( sps0 );
 
-  if( m_pcEncCfg->m_DecodingRefreshType == VVENC_DRT_IDR2 )
+  if( !m_pcEncCfg->m_poc0idr )
   {
     m_associatedIRAPType = VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL;
   }
@@ -1246,7 +1246,7 @@ vvencNalUnitType EncGOP::xGetNalUnitType( const Slice* slice ) const
 {
   const GOPEntry& gopEntry = *slice->pic->gopEntry;
 
-  if( gopEntry.m_POC == 0 && m_pcEncCfg->m_DecodingRefreshType != VVENC_DRT_IDR2 )
+  if( gopEntry.m_POC == 0 && m_pcEncCfg->m_poc0idr )
   {
     return VVENC_NAL_UNIT_CODED_SLICE_IDR_N_LP;
   }
@@ -1255,9 +1255,16 @@ vvencNalUnitType EncGOP::xGetNalUnitType( const Slice* slice ) const
   {
     if( m_pcEncCfg->m_DecodingRefreshType == VVENC_DRT_CRA || m_pcEncCfg->m_DecodingRefreshType == VVENC_DRT_CRA_CRE )
     {
-      return VVENC_NAL_UNIT_CODED_SLICE_CRA;
+      if( m_lastIDR == 0 && !m_pcEncCfg->m_poc0idr )
+      {
+        return VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL;
+      }
+      else
+      {
+        return VVENC_NAL_UNIT_CODED_SLICE_CRA;
+      }
     }
-    if( m_pcEncCfg->m_DecodingRefreshType == VVENC_DRT_IDR || m_pcEncCfg->m_DecodingRefreshType == VVENC_DRT_IDR2  )
+    else
     {
       return VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL;
     }

--- a/source/Lib/EncoderLib/EncModeCtrl.cpp
+++ b/source/Lib/EncoderLib/EncModeCtrl.cpp
@@ -948,7 +948,7 @@ bool EncModeCtrl::tryMode( const EncTestMode& encTestmode, const CodingStructure
     // also isXXAvailable in IntraPrediction.cpp need to be fixed to check availability within the same CU without isDecomp
     if (m_pcEncCfg->m_FastInferMerge && !slice.isIntra() && !slice.isIRAP() && !(cs.area.lwidth() == 4 && cs.area.lheight() == 4) && !partitioner.isConsIntra())
     {
-      if ((bestCS->slice->TLayer > (m_pcEncCfg->m_maxTLayer - (m_pcEncCfg->m_FastInferMerge & 7)))
+      if (bestCS && (bestCS->slice->TLayer > (m_pcEncCfg->m_maxTLayer - (m_pcEncCfg->m_FastInferMerge & 7)))
         && (bestCS->bestParent != nullptr) && bestCS->bestParent->cus.size() && (bestCS->bestParent->cus[0]->skip))
       {
         return false;

--- a/source/Lib/EncoderLib/EncStage.h
+++ b/source/Lib/EncoderLib/EncStage.h
@@ -66,7 +66,7 @@ public:
   bool             m_isSccStrong;
   uint16_t         m_picVisActTL0;
   uint16_t         m_picVisActY;
-  uint16_t         m_picSpVisAct;
+  uint16_t         m_picSpVisAct[MAX_NUM_CH];
   int              m_picMemorySTA;
   uint16_t         m_picMotEstError;
   uint8_t          m_minNoiseLevels[QPA_MAX_NOISE_LEVELS];
@@ -90,7 +90,6 @@ public:
   , m_isSccStrong   ( false )
   , m_picVisActTL0  ( 0 )
   , m_picVisActY    ( 0 )
-  , m_picSpVisAct   ( 0 )
   , m_picMemorySTA  ( 0 )
   , m_picMotEstError( 0 )
   , m_picAuxQpOffset( 0 )
@@ -104,6 +103,7 @@ public:
   {
     std::fill_n( m_prevShared, NUM_QPA_PREV_FRAMES, nullptr );
     std::fill_n( m_minNoiseLevels, QPA_MAX_NOISE_LEVELS, 255u );
+    m_picSpVisAct[CH_L] = m_picSpVisAct[CH_C] = 0;
     m_gopEntry.setDefaultGOPEntry();
   };
 
@@ -139,7 +139,6 @@ public:
     m_isSccStrong  = false;
     m_picVisActTL0 = 0;
     m_picVisActY   = 0;
-    m_picSpVisAct  = 0;
     m_picMemorySTA = 0;
     m_cts          = yuvInBuf->cts;
     m_poc          = poc;
@@ -152,6 +151,7 @@ public:
     m_picAuxQpOffset = 0;
     std::fill_n( m_prevShared, NUM_QPA_PREV_FRAMES, nullptr );
     std::fill_n( m_minNoiseLevels, QPA_MAX_NOISE_LEVELS, 255u );
+    m_picSpVisAct[CH_L] = m_picSpVisAct[CH_C] = 0;
     m_gopEntry.setDefaultGOPEntry();
   }
 
@@ -164,7 +164,7 @@ public:
     pic->isSccStrong    = m_isSccStrong;
     pic->picVisActTL0   = m_picVisActTL0;
     pic->picVisActY     = m_picVisActY;
-    pic->picSpVisAct    = m_picSpVisAct;
+    pic->picSpVisAct    = m_picSpVisAct[CH_L];
     pic->picMemorySTA   = m_picMemorySTA;
     pic->poc            = m_poc;
     pic->cts            = m_cts;

--- a/source/Lib/EncoderLib/GOPCfg.h
+++ b/source/Lib/EncoderLib/GOPCfg.h
@@ -80,6 +80,7 @@ class GOPCfg
     bool m_picReordering;
     int  m_refreshType;
     int  m_fixIntraPeriod;
+    bool m_poc0idr;
     int  m_maxGopSize;
     int  m_defGopSize;
     int  m_nextListIdx;
@@ -101,6 +102,7 @@ class GOPCfg
       , m_picReordering   ( false )
       , m_refreshType     ( 0 )
       , m_fixIntraPeriod  ( 0 )
+      , m_poc0idr         ( false )
       , m_maxGopSize      ( 0 )
       , m_defGopSize      ( 0 )
       , m_nextListIdx     ( 0 )
@@ -120,7 +122,7 @@ class GOPCfg
     {
     };
 
-    void initGopList( int refreshType, int intraPeriod, int gopSize, int leadFrames, bool bPicReordering, const vvencGOPEntry cfgGopList[ VVENC_MAX_GOP ], const vvencMCTF& mctfCfg, int firstPassMode );
+    void initGopList( int refreshType, bool poc0idr, int intraPeriod, int gopSize, int leadFrames, bool bPicReordering, const vvencGOPEntry cfgGopList[ VVENC_MAX_GOP ], const vvencMCTF& mctfCfg, int firstPassMode );
     void getNextGopEntry( GOPEntry& gopEntry );
     void startIntraPeriod( GOPEntry& gopEntry );
     void fixStartOfLastGop( GOPEntry& gopEntry ) const;

--- a/source/Lib/EncoderLib/InterSearch.h
+++ b/source/Lib/EncoderLib/InterSearch.h
@@ -515,7 +515,9 @@ private:
 
   void xClipMvSearch              ( Mv& rcMv, const Position& pos, const struct Size& size, const PreCalcValues& pcv, const int fppLinesSynchro );
 
-  void xSetSearchRange            ( const CodingUnit&     cu,
+  void xClipMvToFppLine           ( Mv& mv, const int yB, const int nH, const int fppLinesSynchro, const PreCalcValues& pcv );
+  void xCheckAndClipMvToFppLine   ( Mv& mv, const int yB, const int nH, const int fppLinesSynchro, const PreCalcValues& pcv );
+  void xSetSearchRange            ( const CodingUnit& cu,
                                     const Mv&             cMvPred,
                                     const int             iSrchRng,
                                     SearchRange&          sr                                  
@@ -581,7 +583,7 @@ private:
                                    bool                  bBi = false
                                  );
 
-  void        xEstimateAffineAMVP     ( CodingUnit& cu, AffineAMVPInfo& affineAMVPInfo, CPelUnitBuf& origBuf, RefPicList refPicList, int iRefIdx, Mv acMvPred[3], Distortion& distBiP);
+  bool        xEstimateAffineAMVP     ( CodingUnit& cu, AffineAMVPInfo& affineAMVPInfo, CPelUnitBuf& origBuf, RefPicList refPicList, int iRefIdx, Mv acMvPred[3], Distortion& distBiP);
 
   Distortion  xGetAffineTemplateCost  ( CodingUnit& cu, CPelUnitBuf& origBuf, PelUnitBuf& predBuf, Mv acMvCand[3], int iMVPIdx, int iMVPNum, RefPicList refPicList, int iRefIdx);
   void        xCopyAffineAMVPInfo     ( AffineAMVPInfo& src, AffineAMVPInfo& dst );

--- a/source/Lib/EncoderLib/PreProcess.h
+++ b/source/Lib/EncoderLib/PreProcess.h
@@ -90,7 +90,7 @@ class PreProcess : public EncStage
     Picture* xGetStartOfLastGop   ( const PicList& picList ) const;
     void     xLinkPrevQpaBufs     ( Picture* pic, const PicList& picList ) const;
     void     xGetVisualActivity   ( Picture* pic, const PicList& picList ) const;
-    uint16_t xGetPicVisualActivity( Picture* curPic, const Picture* refPic1, const Picture* refPic2 ) const;
+    uint16_t xGetPicVisualActivity( Picture* curPic, const Picture* refPic1, const Picture* refPic2, const bool doChroma ) const;
     void     xDetectSTA           ( Picture* pic, const PicList& picList );
     void     xDetectScc           ( Picture* pic ) const;
     void     xDisableTempDown     ( Picture* pic, const PicList& picList );

--- a/source/Lib/apputils/VVEncAppCfg.h
+++ b/source/Lib/apputils/VVEncAppCfg.h
@@ -223,13 +223,13 @@ const std::vector<SVPair<vvencDecodingRefreshType>> DecodingRefreshTypeToEnumMap
   { "cra",                   VVENC_DRT_CRA },
   { "idr",                   VVENC_DRT_IDR },
   { "rpsei",                 VVENC_DRT_RECOVERY_POINT_SEI },
-  { "idr2",                  VVENC_DRT_IDR2 },
+  { "idr2",                  VVENC_DRT_IDR2 }, //deprecated
   { "cra_cre",               VVENC_DRT_CRA_CRE },
   { "0",                     VVENC_DRT_NONE },
   { "1",                     VVENC_DRT_CRA },
   { "2",                     VVENC_DRT_IDR },
   { "3",                     VVENC_DRT_RECOVERY_POINT_SEI },
-  { "4",                     VVENC_DRT_IDR2 },
+  { "4",                     VVENC_DRT_IDR2 },  //deprecated
   { "5",                     VVENC_DRT_CRA_CRE },
 };
 
@@ -625,7 +625,7 @@ int parse( int argc, char* argv[], vvenc_config* c, std::ostream& rcOstr )
     ("qp,q",                                            c->m_QP,                                             "quantization parameter, QP (0, 1, .. 63)")
     ("qpa",                                             toQPA,                                               "enable perceptually motivated QP adaptation based on XPSNR model (0: off, 1: on)", true)
     ("threads,t",                                       c->m_numThreads,                                     "number of threads (multithreading; -1: resolution < 720p: 4, >= 720p: 8 threads)")
-    ("refreshtype,-rt",                                 toDecRefreshType,                                    "intra refresh type (idr, cra, idr2, cra_cre: CRA, constrained RASL picture encoding)")
+    ("refreshtype,-rt",                                 toDecRefreshType,                                    "intra refresh type (idr, cra, cra_cre: CRA, constrained RASL picture encoding)")
     ("refreshsec,-rs",                                  c->m_IntraPeriodSec,                                 "intra period/refresh in seconds")
     ("intraperiod,-ip",                                 c->m_IntraPeriod,                                    "intra period in frames (0: specify intra period in seconds instead, see -refreshsec)")
     ("tiles",                                           toNumTiles,                                          "number of tile columns and rows")
@@ -644,9 +644,10 @@ int parse( int argc, char* argv[], vvenc_config* c, std::ostream& rcOstr )
     opts.addOptions()
     ("IntraPeriod,-ip",                                c->m_IntraPeriod,                                     "Intra period in frames (0: use intra period in seconds (refreshsec), else: n*gopsize)")
     ("RefreshSec,-rs",                                 c->m_IntraPeriodSec,                                  "Intra period/refresh in seconds")
-    ("DecodingRefreshType,-dr",                        toDecRefreshType,                                     "Intra refresh type (0:none, 1:CRA, 2:IDR, 3:RecPointSEI, 4:IDR2, 5:CRA_CRE - CRA with constrained encoding for RASL pictures)")
+    ("DecodingRefreshType,-dr",                        toDecRefreshType,                                     "intra refresh type (idr, cra, cra_cre: CRA, constrained RASL picture encoding, none, rpsei: Recovery Point SEI)")
     ("GOPSize,g",                                      c->m_GOPSize,                                         "GOP size of temporal structure (16,32)")
     ("PicReordering",                                  c->m_picReordering,                                   "Allow reordering of pictures (0:off, 1:on), should be disabled for low delay requirements")
+    ("POC0IDR",                                        c->m_poc0idr,                                         "start encoding with POC 0 IDR" )
     ;
 
     opts.setSubSection("Rate control, Perceptual Quantization");

--- a/source/Lib/apputils/YuvFileIO.h
+++ b/source/Lib/apputils/YuvFileIO.h
@@ -147,7 +147,7 @@ public:
       if( !cLogoFilename.empty() )
       {
         std::stringstream strstr;
-        if ( 0 != m_cLogoRenderer.init( cLogoFilename, m_bufferChrFmt, fileBitDepth, strstr ) )
+        if ( 0 != m_cLogoRenderer.init( cLogoFilename, m_bufferChrFmt, strstr ) )
         {
           if( !strstr.str().empty() )
             m_lastError = strstr.str();

--- a/test/vvenclibtest/vvenclibtest.cpp
+++ b/test/vvenclibtest/vvenclibtest.cpp
@@ -241,6 +241,10 @@ int testLibParameterRanges()
 
   testParamList( "DecodingRefreshType",                    vvencParams.m_DecodingRefreshType,        vvencParams, { 1, 2, 4, 5 } );
   testParamList( "DecodingRefreshType",                    vvencParams.m_DecodingRefreshType,        vvencParams, { -1,0,3,6 }, true );
+  vvencParams.m_poc0idr = true;
+  testParamList( "DecodingRefreshType",                    vvencParams.m_DecodingRefreshType,        vvencParams, { 1, 2, 5 } );
+  testParamList( "DecodingRefreshType",                    vvencParams.m_DecodingRefreshType,        vvencParams, { -1,0,3,4,6 }, true );
+  vvencParams.m_poc0idr = false;
 
   testParamList( "Level",                                  vvencParams.m_level,                      vvencParams, { 32,35,48,51,64,67,80,83,86,96,99,102 } );
   testParamList( "Level",                                  vvencParams.m_level,                      vvencParams, { 16,15,31,255,256 }, true ); // level 1 is not enough for 176x144p60 just because of the sample rate
@@ -259,8 +263,10 @@ int testLibParameterRanges()
 
   testParamList( "GOPSize",                                vvencParams.m_GOPSize,                    vvencParams, { 16,32 } );
   vvencParams.m_IntraPeriod = 1;
+  vvencParams.m_poc0idr = true;
   testParamList( "GOPSize",                                vvencParams.m_GOPSize,                    vvencParams, { 1 } );
   vvencParams.m_IntraPeriod = 32;
+  vvencParams.m_poc0idr = false;
   testParamList( "GOPSize",                                vvencParams.m_GOPSize,                    vvencParams, { -1,0,33,64,128 }, true ); //th is this intended
 
   testParamList( "Width",                                  vvencParams.m_SourceWidth,                vvencParams, { 320,1920,3840 } );
@@ -271,6 +277,10 @@ int testLibParameterRanges()
 
   testParamList( "IDRPeriod",                              vvencParams.m_IntraPeriod,                vvencParams, { -1,1,16,17,24,25,32,48,50,60, 0 } );
   testParamList( "IDRPeriod",                              vvencParams.m_IntraPeriod,                vvencParams, { -2 }, true );
+  vvencParams.m_poc0idr = true;
+  testParamList( "IDRPeriod",                              vvencParams.m_IntraPeriod,                vvencParams, { -1,1,16,17,24,25,32,48,50,60, 0 } );
+  testParamList( "IDRPeriod",                              vvencParams.m_IntraPeriod,                vvencParams, { -2 }, true );
+  vvencParams.m_poc0idr = false;
 
   testParamList( "Qp",                                     vvencParams.m_QP,                         vvencParams, { VVENC_AUTO_QP,0,1,2,3,4,51 } );
   testParamList( "Qp",                                     vvencParams.m_QP,                         vvencParams, { -2,64 }, true );


### PR DESCRIPTION
* align the layout of the first GOP with other GOPs
  * the first IDR now also has RASL images
  * use `POC0IDR` to align with old behavior
* increase the number of MCTF frames for monotonic scenes
* extended dependent frame parallelism to presets other than faster
* allowing for ALF parameter derivation using first line data only to recover some losses of `FppLinesSynchro`
* minor improvements to DMVR
* other small cleanups and improvements