### PR TITLE
Preparing v1.10.0-rc1: first IDR at POC31, adaptive MCTF, ~0.5% BDR gains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ if( NOT CMAKE_VERSION VERSION_LESS 3.13.0 )
 endif()
 
 # project name
-project( vvenc VERSION 1.9.1 )
+project( vvenc VERSION 1.10.0 )
 
 # set alternative version numbering for release candidates
-#set( PROJECT_VERSION_RC rc1 )
+set( PROJECT_VERSION_RC rc1 )
 if( PROJECT_VERSION_RC )
     set( PROJECT_VERSION "${PROJECT_VERSION}-${PROJECT_VERSION_RC}" )
 endif()

--- a/cfg/experimental/lowdelay_faster.cfg
+++ b/cfg/experimental/lowdelay_faster.cfg
@@ -144,4 +144,4 @@ ReduceIntraChromaModesFullRD  : 1      # Reduce modes for chroma full RD intra s
 FastTTSplit                   : 0      # Fast method for TT split
 ReduceFilterME                : 2      # Use reduced filter taps for subpel motion estimation (2: 4-tap, 1: 6-tap)
 SelectiveRDOQ                 : 2      # Only use RDOQ when there are non-zero unquantized coefficients (0: never, 1: always, 2: for natural content)
-FirstPassMode                 : 2      # FirstPassMode (0: default, 1: faster, 2: faster with temporal downsampling)
+FirstPassMode                 : 4      # FirstPassMode (0: default, 1: faster, 2: faster with temporal downsampling)

--- a/cfg/randomaccess_faster.cfg
+++ b/cfg/randomaccess_faster.cfg
@@ -132,4 +132,4 @@ ReduceIntraChromaModesFullRD  : 1      # Reduce modes for chroma full RD intra s
 FastTTSplit                   : 0      # Fast method for TT split
 ReduceFilterME                : 2      # Use reduced filter taps for subpel motion estimation (2: 4-tap, 1: 6-tap)
 SelectiveRDOQ                 : 2      # Only use RDOQ when there are non-zero unquantized coefficients (0: never, 1: always, 2: for natural content)
-FirstPassMode                 : 2      # FirstPassMode (0: default, 1: faster, 2: faster with temporal downsampling)
+FirstPassMode                 : 4      # FirstPassMode (0: default, 1: faster, 2: faster with temporal downsampling)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,24 @@
 /////////////////////////////////////////
+tag 1.10.0-rc1
+* libvvenc:
+  - added library parameters:
+    - vvenc_config::m_poc0idr to force POC0 to be an IDR (otherwise per default it will now be a RASL picture)
+  - changed default GOP structure of the first GOP to align with other GOPs, ensuring all intra-periods
+    and DASH segments have equal length
+  - enable spatial subsampling for 1st pass in 2-pass RC per default for faster preset
+  - adaptively extend the number of neighboring frames in MCTF pre-filtering
+  - allow ALF derivation from partial data for FPPLinesSynchro
+  - improved rate matching accuracy at high target rates on easy-to-encode content, especially for HDR
+  - disable compilation for SSE42 and AVX as no specific code is used,
+    only keep explicit support for SSE41 and AVX2
+  - around 0.5% BDR gain for all presets
+  - minor changes and cleanups to rate control, DMVR, MCTF, QPA and others
+
+* vvencFFapp:
+  - added parameter: POC0IDR to control if POC0 is an IDR (=1, default if PicReordering is 1)
+					 or RASL (=0, default if PicReordering is 0)
+
+/////////////////////////////////////////
 tag 1.9.1
 * libvvenc:
   - added library parameters:

--- a/source/Lib/CommonLib/x86/AdaptiveLoopFilterX86.h
+++ b/source/Lib/CommonLib/x86/AdaptiveLoopFilterX86.h
@@ -1151,9 +1151,9 @@ void simdFilterBlkCcAlf( const PelBuf &dstBuf, const CPelUnitBuf &recSrc, const 
   if( getChannelTypeScaleX( CH_C, nChromaFormat ) == 1 )
   {
     __m128i xfilterCoeff[4];
-    xfilterCoeff[0] = _mm_set1_epi32( ( filterCoeff[1] & 0xffff ) | ( filterCoeff[2] << 16 ) );
-    xfilterCoeff[1] = _mm_set1_epi32( ( filterCoeff[0] & 0xffff ) | ( filterCoeff[3] << 16 ) );
-    xfilterCoeff[2] = _mm_set1_epi32( ( filterCoeff[4] & 0xffff ) | ( filterCoeff[5] << 16 ) );
+    xfilterCoeff[0] = _mm_set1_epi32( ( filterCoeff[1] & 0xffff ) | ( filterCoeff[2] * (1<< 16 )));
+    xfilterCoeff[1] = _mm_set1_epi32( ( filterCoeff[0] & 0xffff ) | ( filterCoeff[3] * (1<< 16 )));
+    xfilterCoeff[2] = _mm_set1_epi32( ( filterCoeff[4] & 0xffff ) | ( filterCoeff[5] * (1<< 16 )));
     xfilterCoeff[3] = _mm_set1_epi32( ( filterCoeff[6] & 0xffff ) );
 
     for( int i = 0; i < endHeight - startHeight; i += clsSizeY )

--- a/source/Lib/CommonLib/x86/BufferX86.h
+++ b/source/Lib/CommonLib/x86/BufferX86.h
@@ -2374,8 +2374,8 @@ uint64_t AvgHighPassWithDownsamplingDiff1st_SIMD (const int width, const int hei
   pSrc -= iSrcStride;
   pSrcM1-=iSrcM1Stride;
   pSrcM1-=iSrcM1Stride;
-  uint32_t x;
-  uint32_t y;
+  int32_t x;
+  int32_t y;
   const __m128i scale1 = _mm_set_epi16 (1,1,1,1,1,1,1,1);
   for (y = 2; y < height-2; y += 2)
   {
@@ -2456,8 +2456,8 @@ uint64_t AvgHighPassWithDownsamplingDiff2nd_SIMD (const int width,const int heig
 {
   uint64_t taAct = 0;
   uint16_t act = 0;
-  uint32_t y;
-  uint32_t x;
+  int32_t y;
+  int32_t x;
   pSrc -= iSrcStride;
   pSrc -= iSrcStride;
   pSrcM1-=iSM1Stride;

--- a/source/Lib/CommonLib/x86/InitX86.cpp
+++ b/source/Lib/CommonLib/x86/InitX86.cpp
@@ -79,8 +79,8 @@ void InterpolationFilter::initInterpolationFilterX86( /*int iBitDepthY, int iBit
     _initInterpolationFilterX86<AVX2>(/*iBitDepthY, iBitDepthC*/);
     break;
   case AVX:
-    _initInterpolationFilterX86<AVX>(/*iBitDepthY, iBitDepthC*/);
-    break;
+    //_initInterpolationFilterX86<AVX>(/*iBitDepthY, iBitDepthC*/);
+    //break;
   case SSE42:
   case SSE41:
     _initInterpolationFilterX86<SSE41>(/*iBitDepthY, iBitDepthC*/);
@@ -106,8 +106,8 @@ void PelBufferOps::initPelBufOpsX86()
       _initPelBufOpsX86<AVX2>();
       break;
     case AVX:
-      _initPelBufOpsX86<AVX>();
-      break;
+      //_initPelBufOpsX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initPelBufOpsX86<SSE41>();
@@ -130,8 +130,8 @@ void LoopFilter::initLoopFilterX86()
     _initLoopFilterX86<AVX2>();
     break;
   case AVX:
-    _initLoopFilterX86<AVX>();
-    break;
+    //_initLoopFilterX86<AVX>();
+    //break;
   case SSE42:
   case SSE41:
     _initLoopFilterX86<SSE41>();
@@ -156,8 +156,8 @@ void RdCost::initRdCostX86()
       break;
 #endif
     case AVX:
-      _initRdCostX86<AVX>();
-      break;
+      //_initRdCostX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initRdCostX86<SSE41>();
@@ -179,8 +179,8 @@ void AdaptiveLoopFilter::initAdaptiveLoopFilterX86()
     _initAdaptiveLoopFilterX86<AVX2>();
     break;
   case AVX:
-    _initAdaptiveLoopFilterX86<AVX>();
-    break;
+    //_initAdaptiveLoopFilterX86<AVX>();
+    //break;
   case SSE42:
   case SSE41:
     _initAdaptiveLoopFilterX86<SSE41>();
@@ -201,8 +201,8 @@ void SampleAdaptiveOffset::initSampleAdaptiveOffsetX86()
       _initSampleAdaptiveOffsetX86<AVX2>();
       break;
     case AVX:
-      _initSampleAdaptiveOffsetX86<AVX>();
-      break;
+      //_initSampleAdaptiveOffsetX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initSampleAdaptiveOffsetX86<SSE41>();
@@ -224,8 +224,8 @@ void InterPredInterpolation::initInterPredictionX86()
       _initInterPredictionX86<AVX2>();
       break;
     case AVX:
-      _initInterPredictionX86<AVX>();
-      break;
+      //_initInterPredictionX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initInterPredictionX86<SSE41>();
@@ -246,8 +246,8 @@ void AffineGradientSearch::initAffineGradientSearchX86()
     _initAffineGradientSearchX86<AVX2>();
     break;
   case AVX:
-    _initAffineGradientSearchX86<AVX>();
-    break;
+    //_initAffineGradientSearchX86<AVX>();
+    //break;
   case SSE42:
   case SSE41:
     _initAffineGradientSearchX86<SSE41>();
@@ -268,8 +268,8 @@ void IntraPrediction::initIntraPredictionX86()
       _initIntraPredictionX86<AVX2>();
       break;
     case AVX:
-      _initIntraPredictionX86<AVX>();
-      break;
+      //_initIntraPredictionX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initIntraPredictionX86<SSE41>();
@@ -290,11 +290,11 @@ void MCTF::initMCTF_X86()
       _initMCTF_X86<AVX2 >();
       break;
     case AVX:
-      _initMCTF_X86<AVX  >();
-      break;
+      //_initMCTF_X86<AVX  >();
+      //break;
     case SSE42:
-      _initMCTF_X86<SSE42>();
-      break;
+      //_initMCTF_X86<SSE42>();
+      //break;
     case SSE41:
       _initMCTF_X86<SSE41>();
       break;
@@ -314,11 +314,11 @@ void TCoeffOps::initTCoeffOpsX86()
       _initTCoeffOpsX86<AVX2 >();
       break;
     case AVX:
-      _initTCoeffOpsX86<AVX  >();
-      break;
+      //_initTCoeffOpsX86<AVX  >();
+      //break;
     case SSE42:
-      _initTCoeffOpsX86<SSE42>();
-      break;
+      //_initTCoeffOpsX86<SSE42>();
+      //break;
     case SSE41:
       _initTCoeffOpsX86<SSE41>();
       break;
@@ -334,17 +334,17 @@ void TrQuant::initTrQuantX86()
   {
   case AVX512:
   case AVX2:
-  _initTrQuantX86<AVX2 >();
-  break;
+    _initTrQuantX86<AVX2 >();
+    break;
   case AVX:
-  _initTrQuantX86<AVX  >();
-  break;
+    //_initTrQuantX86<AVX  >();
+    //break;
   case SSE42:
-  _initTrQuantX86<SSE42>();
-  break;
+    //_initTrQuantX86<SSE42>();
+    //break;
   case SSE41:
-  _initTrQuantX86<SSE41>();
-  break;
+    _initTrQuantX86<SSE41>();
+    break;
   default:
   break;
   }
@@ -363,8 +363,8 @@ void Quant::initQuantX86()
       _initQuantX86<AVX2>();
       break;
     case AVX:
-      _initQuantX86<AVX>();
-      break;
+      //_initQuantX86<AVX>();
+      //break;
     case SSE42:
     case SSE41:
       _initQuantX86<SSE41>();

--- a/source/Lib/EncoderLib/BitAllocation.cpp
+++ b/source/Lib/EncoderLib/BitAllocation.cpp
@@ -299,7 +299,7 @@ static void clipQPValToEstimatedMinimStats (const uint8_t* minNoiseLevels, const
     return;
   }
 
-  i = std::max (0, apprI3Log2 (std::min (16.0, resFac) * i * i, false) + dQPOffset + extraQPOffset); // =6*log2
+  i = std::max (0, apprI3Log2 (std::min (1.0, resFac) * i * i, false) + dQPOffset + extraQPOffset); // = 6*log2
   if (QP < i)
   {
     QP = i;
@@ -806,7 +806,8 @@ int BitAllocation::applyQPAdaptationSubCtu (const Slice* slice, const VVEncCfg* 
 }
 
 int BitAllocation::getCtuPumpingReducingQP (const Slice* slice, const CPelBuf& origY, const Distortion uiSadBestForQPA,
-                                            std::vector<int>& ctuPumpRedQP, const uint32_t ctuRsAddr, const int baseQP)
+                                            std::vector<int>& ctuPumpRedQP, const uint32_t ctuRsAddr, const int baseQP,
+                                            const bool isBIM)
 {
   if (slice == nullptr || !slice->pps->useDQP || ctuPumpRedQP.size() <= ctuRsAddr) return 0;
 
@@ -824,7 +825,7 @@ int BitAllocation::getCtuPumpingReducingQP (const Slice* slice, const CPelBuf& o
   }
 
   const double sumAbsRatio = double (uiSadBestForQPA * 3 /*TODO: or 4? fine-tune!*/) / double (sumAbsZmOrig == 0 ? 1 : sumAbsZmOrig);
-  const int pumpingReducQP = (int (log (Clip3 (0.25, 4.0, sumAbsRatio)) / log (2.0) + (sumAbsRatio < 1.0 ? -0.5 : 0.5))) >> (baseQP >= 38/*MAX_QP_PERCEPT_QPA*/ ? 1 : 0);
+  const int pumpingReducQP = ((isBIM ? -1 : 0) + int (log (Clip3 (0.25, 4.0, sumAbsRatio)) / log (2.0) + (sumAbsRatio < 1.0 ? -0.5 : 0.5))) >> (baseQP >= 38/*MAX_QP_PERCEPT_QPA*/ ? 1 : 0);
 
   ctuPumpRedQP[ctuRsAddr] += pumpingReducQP;
 

--- a/source/Lib/EncoderLib/BitAllocation.h
+++ b/source/Lib/EncoderLib/BitAllocation.h
@@ -90,7 +90,8 @@ namespace vvenc {
                                  const Distortion uiSadBestForQPA,
                                  std::vector<int>& ctuPumpRedQP,
                                  const uint32_t ctuRsAddr,
-                                 const int baseQP );
+                                 const int baseQP,
+                                 const bool isBIM );
   }
 
 } // namespace vvenc

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
@@ -5726,15 +5726,6 @@ void EncAdaptiveLoopFilter::deriveCcAlfFilter( Picture& pic, CodingStructure& cs
     aps->ccAlfParam.newCcAlfFilter[1] = false;
   }
 
-  // Accumulate ALF statistic
-  const int filterIdx = 0;
-  const int numberOfComponents = getNumberValidComponents( m_chromaFormat );
-  for( int compIdx = 1; compIdx < numberOfComponents; compIdx++ )
-  {
-    const ComponentID compID = ComponentID( compIdx );
-    xGetFrameStatsCcalf( compID, filterIdx + 1, numCtus );
-  }
-
   const TempCtx ctxStartCcAlf( m_CtxCache, SubCtx( Ctx::CcAlfFilterControlFlag, m_CABACEstimator->getCtx() ) );
   const PelUnitBuf orgYuv = cs.picture->getOrigBuf();
   const PelUnitBuf recYuv = cs.getRecoBuf();

--- a/source/Lib/EncoderLib/EncCu.cpp
+++ b/source/Lib/EncoderLib/EncCu.cpp
@@ -2007,7 +2007,8 @@ void EncCu::xCheckRDCostMerge( CodingStructure *&tempCS, CodingStructure *&bestC
     {
       const Picture*    pic = slice.pic;
       const uint32_t rsAddr = getCtuAddr (partitioner.currQgPos, *pic->cs->pcv);
-      const int pumpReducQP = BitAllocation::getCtuPumpingReducingQP (&slice, tempCS->getOrgBuf (COMP_Y), uiSadBestForQPA, *m_globalCtuQpVector, rsAddr, m_pcEncCfg->m_QP);
+      const int pumpReducQP = BitAllocation::getCtuPumpingReducingQP (&slice, tempCS->getOrgBuf (COMP_Y), uiSadBestForQPA, *m_globalCtuQpVector, rsAddr,
+                              m_pcEncCfg->m_QP, m_pcEncCfg->m_RCNumPasses != 2 && m_pcEncCfg->m_blockImportanceMapping && !pic->m_picShared->m_ctuBimQpOffset.empty());
 
       if (pumpReducQP != 0) // subtract QP offset, reduces Intra-period pumping or overcoding
       {

--- a/source/Lib/apputils/IStreamIO.h
+++ b/source/Lib/apputils/IStreamIO.h
@@ -462,6 +462,14 @@ class IStreamToArr
     IStreamToArr( T* v, size_t maxSize )
     : _valVec        ( v )
     , _maxSize       ( maxSize )
+    , _curSize       ( nullptr )
+    {
+    }
+
+    IStreamToArr( T* v, size_t maxSize, int* curSize )
+    : _valVec        ( v )
+    , _maxSize       ( maxSize )
+    , _curSize       ( curSize )
     {
     }
 
@@ -478,6 +486,7 @@ class IStreamToArr
   private:
     T*     _valVec;
     size_t _maxSize;
+    int*   _curSize;
 };
 
 template<typename T>
@@ -487,6 +496,7 @@ inline std::istream& operator >> ( std::istream& in, IStreamToArr<T>& toArr )
 
   bool fail = false;
   size_t pos = 0;
+  if ( toArr._curSize ) *toArr._curSize = 0;
   // split into multiple lines if any
   while ( ! in.eof() )
   {
@@ -527,6 +537,8 @@ inline std::istream& operator >> ( std::istream& in, IStreamToArr<T>& toArr )
   {
     in.setstate( std::ios::failbit );
   }
+
+  if ( toArr._curSize ) *toArr._curSize = static_cast<int>( std::min<size_t>( pos, toArr._maxSize ) );
 
   return in;
 }

--- a/source/Lib/apputils/VVEncAppCfg.h
+++ b/source/Lib/apputils/VVEncAppCfg.h
@@ -518,8 +518,8 @@ int parse( int argc, char* argv[], vvenc_config* c, std::ostream& rcOstr )
   IStreamToArr<unsigned int>        toTileColumnWidth            ( &c->m_tileColumnWidth[0], 10 );
   IStreamToArr<unsigned int>        toTileRowHeight              ( &c->m_tileRowHeight[0], 10 );
 
-  IStreamToArr<int>                 toMCTFFrames                 ( &c->m_vvencMCTF.MCTFFrames[0], VVENC_MAX_MCTF_FRAMES   );
-  IStreamToArr<double>              toMCTFStrengths              ( &c->m_vvencMCTF.MCTFStrengths[0], VVENC_MAX_MCTF_FRAMES);
+  IStreamToArr<int>                 toMCTFFrames                 ( &c->m_vvencMCTF.MCTFFrames[0], VVENC_MAX_MCTF_FRAMES, &c->m_vvencMCTF.numFrames );
+  IStreamToArr<double>              toMCTFStrengths              ( &c->m_vvencMCTF.MCTFStrengths[0], VVENC_MAX_MCTF_FRAMES, &c->m_vvencMCTF.numStrength );
   IStreamToEnum<int>                toColorPrimaries             ( &c->m_colourPrimaries,        &ColorPrimariesToIntMap );
   IStreamToEnum<int>                toTransferCharacteristics    ( &c->m_transferCharacteristics,&TransferCharacteristicsToIntMap );
   IStreamToEnum<int>                toColorMatrix                ( &c->m_matrixCoefficients,     &ColorMatrixToIntMap );

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -29,8 +29,8 @@ if( VVENC_ENABLE_X86_SIMD )
   # get x86 include files
   file( GLOB X86_INC_FILES "../CommonLib/x86/*.h" )
 
-  # get avx source files
-  file( GLOB AVX_SRC_FILES "../CommonLib/x86/avx/*.cpp" )
+  ## get avx source files
+  #file( GLOB AVX_SRC_FILES "../CommonLib/x86/avx/*.cpp" )
 
   # get avx2 source files
   file( GLOB AVX2_SRC_FILES "../CommonLib/x86/avx2/*.cpp" )
@@ -38,8 +38,8 @@ if( VVENC_ENABLE_X86_SIMD )
   # get sse4.1 source files
   file( GLOB SSE41_SRC_FILES "../CommonLib/x86/sse41/*.cpp" )
 
-  # get sse4.2 source files
-  file( GLOB SSE42_SRC_FILES "../CommonLib/x86/sse42/*.cpp" )
+  ## get sse4.2 source files
+  #file( GLOB SSE42_SRC_FILES "../CommonLib/x86/sse42/*.cpp" )
 endif()
 
 # get public/extern include files
@@ -87,30 +87,31 @@ set( CMAKE_VISIBILITY_INLINES_HIDDEN TRUE )
 if( VVENC_ENABLE_X86_SIMD )
   # set needed compile definitions
   set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE41 )
-  set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE42 )
-  set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX )
+  #set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE42 )
+  #set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX )
   set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX2 )
   # set needed compile flags
   if( MSVC )
-    set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "/arch:AVX" )
+    #set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "/arch:AVX" )
     set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
   elseif( UNIX OR MINGW )
     include( vvencCompilerSupport )
 
     set_if_compiler_supports_flag( FLAG_mxsave -mxsave  )
     set_if_compiler_supports_flag( FLAG_msse41 -msse4.1 )
-    set_if_compiler_supports_flag( FLAG_msse42 -msse4.2 )
-    set_if_compiler_supports_flag( FLAG_mavx   -mavx    )
+    #set_if_compiler_supports_flag( FLAG_msse42 -msse4.2 )
+    #set_if_compiler_supports_flag( FLAG_mavx   -mavx    )
     set_if_compiler_supports_flag( FLAG_mavx2  -mavx2   )
 
     set_property( SOURCE ${X86_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS ${FLAG_mxsave} )
     set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse41}" )
-    set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse42}" )
-    set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "${FLAG_mavx}"   )
+    #set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse42}" )
+    #set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "${FLAG_mavx}"   )
     set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "${FLAG_mavx2}"  )
   endif()
 
-  add_library( ${LIB_NAME}_x86_simd OBJECT ${SSE41_SRC_FILES} ${SSE42_SRC_FILES} ${AVX_SRC_FILES} ${AVX2_SRC_FILES} )
+  #add_library( ${LIB_NAME}_x86_simd OBJECT ${SSE41_SRC_FILES} ${SSE42_SRC_FILES} ${AVX_SRC_FILES} ${AVX2_SRC_FILES} )
+  add_library( ${LIB_NAME}_x86_simd OBJECT ${SSE41_SRC_FILES} ${AVX2_SRC_FILES} )
   # disble LTO for the files compiled with special architecture flags
   set_target_properties( ${LIB_NAME}_x86_simd PROPERTIES
                                               INTERPROCEDURAL_OPTIMIZATION                OFF


### PR DESCRIPTION
* first IDR per default at POC31 instead of POC0 to align with other GOPs
* improved RC, especially for high rates and low activity scenes, especially for HDR
* enabled spatial sub-sampling for 2pRC in preset faster
* number of MCTF references adaptively increased
* reducing the efficiency gap for dependent frame parallelism (still experimental, as not harmonized with RC)
* many other minor cleanups and changes