### PR TITLE
IFP and RC harmonization, fixes for ARM, early GCC 11

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -73,6 +73,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..  -DCMAKE_BUILD_TYPE=Release -A "${{ matrix.config.msvc_arch }}"
+        cmake ..  -DCMAKE_BUILD_TYPE=Release -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build . --config Release
       shell: cmd

--- a/.gitlab-ci-internal.yml
+++ b/.gitlab-ci-internal.yml
@@ -214,6 +214,7 @@ test_vc193x_Win32:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: Win32
+     CONFIG_OPTIONS: "-DVVENC_OVERRIDE_COMPILER_CHECK=1"
   tags:
     - vc193x
 
@@ -221,6 +222,7 @@ test_vc193x:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: x64
+     CONFIG_OPTIONS: "-DVVENC_OVERRIDE_COMPILER_CHECK=1"
   tags:
     - vc193x
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,31 @@ if( ( "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64\|arm"
 endif()
 
 # we enable x86 intrinsics for all target architectures, because they are implemented through simd-everywhere on non-x86
-set( VVENC_ENABLE_X86_SIMD TRUE CACHE BOOL "enable x86 intrinsics" )
+set( VVENC_ENABLE_X86_SIMD TRUE                      CACHE BOOL "enable x86 intrinsics" )
 set( VVENC_ENABLE_ARM_SIMD ${VVENC_ARM_SIMD_DEFAULT} CACHE BOOL "enable ARM intrinsics" )
 
 include( vvencCompilerSupport )
+check_problematic_compiler( VVENC_PROBLEMATIC_COMPILER "MSVC" 19.38 "" )
+
+if( VVENC_PROBLEMATIC_COMPILER )
+  set( VVENC_OVERRIDE_COMPILER_CHECK      OFF        CACHE BOOL "Build with known problematic compiler version" )
+
+  if( VVENC_OVERRIDE_COMPILER_CHECK )
+    set( VVENC_PROBLEMATIC_COMPILER_MSG_TYPE     WARNING )
+    set( VVENC_PROBLEMATIC_COMPILER_MSG_OVERRIDE
+         "The performance will not be optimal due to workarounds." )
+  else()
+    set( VVENC_PROBLEMATIC_COMPILER_MSG_TYPE FATAL_ERROR )
+    set( VVENC_PROBLEMATIC_COMPILER_MSG_OVERRIDE
+         "Set -DVVENC_OVERRIDE_COMPILER_CHECK=ON to build with this compiler anyways, which enables workarounds impacting performance.")
+  endif()
+
+  message( ${VVENC_PROBLEMATIC_COMPILER_MSG_TYPE}
+          "Binaries compiled with ${CMAKE_CXX_COMPILER} version ${CMAKE_CXX_COMPILER_VERSION} are known not to behave as intended. "
+          "The problematic version range is ${VVENC_PROBLEMATIC_COMPILER_VERSION_RANGE}. Please consider using a different compiler.\n"
+          ${VVENC_PROBLEMATIC_COMPILER_MSG_OVERRIDE} )
+
+endif()
 
 # enable sse4.1 build for all source files for gcc and clang
 if( VVENC_ENABLE_X86_SIMD )
@@ -81,14 +102,14 @@ endif()
 # enable install target
 set( VVENC_ENABLE_INSTALL                   ON  CACHE BOOL   "Enable or disable install target" )
 
-# enable postfix                                             
+# enable postfix
 set( VVENC_ENABLE_BUILD_TYPE_POSTFIX        OFF CACHE BOOL   "Enable or disable build type postfix for apps and libs" )
 
 set( VVENC_ENABLE_LINK_TIME_OPT             ON  CACHE BOOL   "Enable link time optimization for release and profile builds" )
 
 set( VVENC_ENABLE_THIRDPARTY_JSON           ON  CACHE BOOL   "Enable use of thirdparty json library" )
 
-set( VVENC_INSTALL_FULLFEATURE_APP		    OFF CACHE BOOL   "Install the full-feature app: vvencFFapp" )
+set( VVENC_INSTALL_FULLFEATURE_APP          OFF CACHE BOOL   "Install the full-feature app: vvencFFapp" )
 
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
@@ -300,7 +321,7 @@ if( VVENC_ENABLE_INSTALL )
     
     set( CMAKE_INSTALL_RPATH ${RPATH_BASE} ${RPATH_BASE}/${RPATH_REL_DIR} )
     message( STATUS "CMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH}" )
-  endif()  
+  endif()
 endif()
 
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ ifneq ($(install-ffapp),)
 CONFIG_OPTIONS += -DVVENC_INSTALL_FULLFEATURE_APP=$(install-ffapp)
 endif
 
+ifneq ($(override-compiler-check),)
+CONFIG_OPTIONS += -DVVENC_OVERRIDE_COMPILER_CHECK=$(override-compiler-check)
+endif
+
 ifeq ($(j),)
 # Query cmake for the number of cores
 NUM_JOBS := $(shell cmake -P cmake/modules/vvencNumCores.cmake)

--- a/cmake/modules/vvencCompilerSupport.cmake
+++ b/cmake/modules/vvencCompilerSupport.cmake
@@ -83,3 +83,21 @@ function( _emscripten_enable_wasm_simd128 )
     set( CMAKE_REQUIRED_FLAGS -msimd128 PARENT_SCOPE )
   endif()
 endfunction()
+
+function( check_problematic_compiler output_var compiler_id first_bad_version first_fixed_version )
+  if( CMAKE_CXX_COMPILER_ID STREQUAL "${compiler_id}"
+      AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "${first_bad_version}"
+      AND (
+        NOT "${first_fixed_version}"
+        OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "${first_fixed_version}" ) )
+
+    set( ${output_var} TRUE PARENT_SCOPE )
+
+    if( "${first_fixed_version}" )
+      set( ${output_var}_VERSION_RANGE "(${first_bad_version}...${first_fixed_version}]" PARENT_SCOPE )
+    else()
+      set( ${output_var}_VERSION_RANGE "(${first_bad_version}...)"                       PARENT_SCOPE )
+    endif()
+
+  endif()
+endfunction()

--- a/include/vvenc/vvencCfg.h
+++ b/include/vvenc/vvencCfg.h
@@ -430,7 +430,7 @@ typedef struct vvenc_config
   int                 m_framesToBeEncoded;                                               // number of encoded frames (default: 0, all)
   int                 m_inputBitDepth[ 2 ];                                              // bit-depth of input pictures (2d array for luma,chroma)
 
-  int                 m_numThreads;                                                      // number of worker threads ( if <0: <720p 4threads, else 8threads (limited to available cores))
+  int                 m_numThreads;                                                      // number of worker threads ( if <0: <720p 4threads, <5K 2880p 8threads, else 12threads (limited to available cores))
 
   int                 m_QP;                                                              // QP value of key-picture (0-63, default: 32)
   int                 m_RCTargetBitrate;                                                 // target bitrate in bps (default: 0 (RC disabled))
@@ -761,7 +761,7 @@ typedef struct vvenc_config
   bool                m_picReordering;
   bool                m_reservedFlag;
   bool                m_poc0idr;
-  int8_t              m_fppLinesSynchro;
+  int8_t              m_ifpLines;
   bool                m_blockImportanceMapping;
   bool                m_saoScc;
   bool                m_addGOP32refPics;
@@ -774,8 +774,14 @@ typedef struct vvenc_config
                                                                                          // if negative, the absolute value is interpreted as a 4-bit fixed point multiplier of the target bitrate).
                                                                                          // -24, i.e. -1.1000 binary, means the maxrate would be set to be the 1.5x of the target bitrate.
                                                                                          // for convenience use VVENC_SET_MAXRATE_FACTOR, e.g. VVENC_SET_MAXRATE_FACTOR(1.5), to set the multiplier
-  int                 m_forceScc;
-  double              m_reservedDouble[9];
+  int8_t              m_forceScc;
+  bool                m_ifp;
+
+  int8_t              m_reservedInt8[2];
+
+  int                 m_minIntraDist;
+  int                 m_reservedInt;
+  double              m_reservedDouble[8];
 
   // internal state variables
   bool                m_configDone;                                                      // state variable, Private context used for internal data ( do not change )

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -501,8 +501,6 @@ static constexpr uint8_t MAX_TMP_BUFS = 6;
 
 static constexpr int QPA_MAX_NOISE_LEVELS = 8;
 
-static constexpr int FPPLS_ALF_DERIVE_LINES   = 1; ///< number of CTU lines for ALF filter derivation
-static constexpr int FPPLS_CCALF_DERIVE_LINES = 1; ///< number of CTU lines for CCALF filter derivation
 
 
 // ====================================================================================================================

--- a/source/Lib/CommonLib/DepQuant.cpp
+++ b/source/Lib/CommonLib/DepQuant.cpp
@@ -1436,7 +1436,7 @@ void DepQuant::quant( TransformUnit& tu, const ComponentID compID, const CCoeffB
     const uint32_t    log2TrHeight    = Log2(height);
     const bool isLfnstApplied         = tu.cu->lfnstIdx > 0 && (CU::isSepTree(*tu.cu) ? true : isLuma(compID));
     const bool enableScalingLists     = getUseScalingList(width, height, (tu.mtsIdx[compID] == MTS_SKIP), isLfnstApplied);
-    static_cast<DQIntern::DepQuant*>(p)->quant( tu, pSrc, compID, cQP, Quant::m_dLambda, ctx, uiAbsSum, enableScalingLists, Quant::getQuantCoeff(scalingListType, qpRem, log2TrWidth, log2TrHeight) );
+    p->quant( tu, pSrc, compID, cQP, Quant::m_dLambda, ctx, uiAbsSum, enableScalingLists, Quant::getQuantCoeff(scalingListType, qpRem, log2TrWidth, log2TrHeight) );
   }
   else
   {
@@ -1460,7 +1460,7 @@ void DepQuant::dequant( const TransformUnit& tu, CoeffBuf& dstCoeff, const Compo
     const uint32_t    log2TrHeight   = Log2(height);
     const bool isLfnstApplied        = tu.cu->lfnstIdx > 0 && (CU::isSepTree(*tu.cu) ? true : isLuma(compID));
     const bool enableScalingLists    = getUseScalingList(width, height, (tu.mtsIdx[compID] == MTS_SKIP), isLfnstApplied);
-    static_cast<DQIntern::DepQuant*>(p)->dequant( tu, dstCoeff, compID, cQP, enableScalingLists, Quant::getDequantCoeff(scalingListType, qpRem, log2TrWidth, log2TrHeight) );
+    p->dequant( tu, dstCoeff, compID, cQP, enableScalingLists, Quant::getDequantCoeff(scalingListType, qpRem, log2TrWidth, log2TrHeight) );
   }
   else
   {
@@ -1472,7 +1472,7 @@ void DepQuant::init( int rdoq, bool useRDOQTS, int thrVal )
 {
   QuantRDOQ2::init( rdoq, useRDOQTS, thrVal );
 
-  static_cast<DQIntern::DepQuant*>(p)->init( thrVal );
+  p->init( thrVal );
 }
 
 } // namespace vvenc

--- a/source/Lib/CommonLib/DepQuant.h
+++ b/source/Lib/CommonLib/DepQuant.h
@@ -241,8 +241,8 @@ class DepQuantImpl
 public:
   virtual ~DepQuantImpl() {}
   virtual void quant   ( TransformUnit& tu, const CCoeffBuf& srcCoeff, const ComponentID compID, const QpParam& cQP, const double lambda, const Ctx& ctx, TCoeff& absSum, bool enableScalingLists, int* quantCoeff ) = 0;
-  virtual void dequant ( const TransformUnit& tu,  CoeffBuf& recCoeff, const ComponentID compID, const QpParam& cQP,                                                      bool enableScalingLists, int* quantCoeff );
-  virtual void init    ( int dqTrVal );
+  void         dequant ( const TransformUnit& tu,  CoeffBuf& recCoeff, const ComponentID compID, const QpParam& cQP,                                                      bool enableScalingLists, int* quantCoeff );
+  void         init    ( int dqTrVal );
 
 protected:
   DQIntern::Quantizer  m_quant;

--- a/source/Lib/CommonLib/InterPrediction.h
+++ b/source/Lib/CommonLib/InterPrediction.h
@@ -82,7 +82,7 @@ protected:
   InterpolationFilter  m_if;
   Pel*                 m_filteredBlock        [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS_SIGNAL][LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS_SIGNAL][MAX_NUM_COMP];
   Pel*                 m_filteredBlockTmp     [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS_SIGNAL][MAX_NUM_COMP];
-  int                  m_fppLinesSynchro;
+  int                  m_ifpLines;
 
   int  xRightShiftMSB         ( int numer, int denom );
   void xApplyBDOF             ( PelBuf& yuvDst, const ClpRng& clpRng );
@@ -122,7 +122,7 @@ public:
                             PelUnitBuf &predDst, PelUnitBuf &predSrc0, PelUnitBuf &predSrc1);
 
   static bool isSubblockVectorSpreadOverLimit(int a, int b, int c, int d, int predType);
-  bool xIsAffineMvInRangeFPP (const CodingUnit& cu, const Mv* _mv, const int fppLinesSynchro, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
+  bool xIsAffineMvInRangeFPP (const CodingUnit& cu, const Mv* _mv, const int ifpLines, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
 };
 
 class DMVR : public InterPredInterpolation
@@ -171,7 +171,7 @@ public:
   InterPrediction();
   virtual ~InterPrediction();
 
-  void    init                  ( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize, const int fppLinesSynchro = 0 );
+  void    init                  ( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize, const int ifpLines = 0 );
   void    destroy               ();
 
   // inter

--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -161,6 +161,7 @@ Picture::Picture()
     , isFinished        ( false )
     , isLongTerm        ( false )
     , isFlush           ( false )
+    , isInProcessList   ( false )
     , precedingDRAP     ( false )
     , gopEntry          ( nullptr )
     , refCounter        ( 0 )
@@ -226,6 +227,7 @@ void Picture::reset()
   isFinished          = false;
   isLongTerm          = false;
   isFlush             = false;
+  isInProcessList     = false;
   isMeanQPLimited     = false;
   precedingDRAP       = false;
 
@@ -236,6 +238,9 @@ void Picture::reset()
   gopAdaptedQP        = 0;
   actualHeadBits      = 0;
   actualTotalBits     = 0;
+  encRCPic            = nullptr;
+  picApsGlobal        = nullptr;
+  refApsGlobal        = nullptr;
 
   std::fill_n( m_sharedBufs, (int)NUM_PIC_TYPES, nullptr );
   std::fill_n( m_bufsOrigPrev, NUM_QPA_PREV_FRAMES, nullptr );

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -114,6 +114,7 @@ struct PicApsGlobal{
   int      poc;
   unsigned tid;
   bool     initalized = false;
+  int      refCnt = 0;
   ParameterSetMap<APS> apsMap;
   PicApsGlobal( int _p ) : poc(_p), tid(MAX_UINT), apsMap( MAX_NUM_APS * MAX_NUM_APS_TYPE ) {}
   PicApsGlobal( int _p, unsigned _t ) : poc(_p), tid(_t), apsMap( MAX_NUM_APS * MAX_NUM_APS_TYPE ) {}
@@ -216,6 +217,7 @@ public:
   bool                          isFinished;
   bool                          isLongTerm;
   bool                          isFlush;
+  bool                          isInProcessList;
   bool                          precedingDRAP; // preceding a DRAP picture in decoding order
 
   const GOPEntry*               gopEntry;

--- a/source/Lib/CommonLib/Slice.cpp
+++ b/source/Lib/CommonLib/Slice.cpp
@@ -443,7 +443,7 @@ void Slice::updateRefPicCounter( int step )
   }
 }
 
-bool Slice::checkRefPicsReconstructed() const
+bool Slice::checkAllRefPicsReconstructed() const
 {
   for ( int refList = 0; refList < NUM_REF_PIC_LIST_01; refList++ )
   {
@@ -451,6 +451,23 @@ bool Slice::checkRefPicsReconstructed() const
     for ( int i = 0; i < numOfActiveRef; i++ )
     {
       if ( ! refPicList[ refList ][ i ]->isReconstructed )
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool Slice::checkAllRefPicsAccessible() const
+{
+  for ( int refList = 0; refList < NUM_REF_PIC_LIST_01; refList++ )
+  {
+    int numOfActiveRef = numRefIdx[ refList ];
+    for ( int i = 0; i < numOfActiveRef; i++ )
+    {
+      if ( ! refPicList[ refList ][ i ]->isInProcessList )
       {
         return false;
       }

--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -1265,7 +1265,8 @@ public:
   void                        resetSlicePart();
   void                        constructRefPicList(const PicList& rcListPic, bool extBorder, const bool usingLongTerm = true);
   void                        updateRefPicCounter( int step );
-  bool                        checkRefPicsReconstructed() const;
+  bool                        checkAllRefPicsAccessible() const;
+  bool                        checkAllRefPicsReconstructed() const;
   void                        setRefPOCList();
   void                        setSMVDParam();
   void                        checkColRefIdx(uint32_t curSliceSegmentIdx, const Picture* pic) const;

--- a/source/Lib/CommonLib/TimeProfiler.h
+++ b/source/Lib/CommonLib/TimeProfiler.h
@@ -91,6 +91,7 @@ namespace vvenc {
   E_( P_INTRA_CHROMA            ) \
   E_( P_INTRA                   ) \
   E_( P_QUANT                   ) \
+  E_( P_DEQUANT                 ) \
   E_( P_TRAFO                   ) \
   E_( P_RESHAPER                ) \
   E_( P_DEBLOCK_FILTER          ) \

--- a/source/Lib/CommonLib/TrQuant.cpp
+++ b/source/Lib/CommonLib/TrQuant.cpp
@@ -292,7 +292,7 @@ void TrQuant::xDeQuant(const TransformUnit& tu,
                        const ComponentID   &compID,
                        const QpParam       &cQP)
 {
-  PROFILER_SCOPE_AND_STAGE( 1, _TPROF, P_QUANT );
+  PROFILER_SCOPE_AND_STAGE( 1, _TPROF, P_DEQUANT );
   m_quant->dequant( tu, dstCoeff, compID, cQP );
 }
 

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -71,6 +71,8 @@ namespace vvenc {
 
 #define FIX_FOR_TEMPORARY_COMPILER_ISSUES_ENABLED         1 // Some compilers fail on particular code fragments, remove this when the compiler is fixed (or new version is used)
 
+#define IFP_RC_DETERMINISTIC                              0 // Enables Rate Control deterministic behavior (same results) when using IFP
+
 // ====================================================================================================================
 // General settings
 // ====================================================================================================================

--- a/source/Lib/CommonLib/UnitTools.cpp
+++ b/source/Lib/CommonLib/UnitTools.cpp
@@ -3548,18 +3548,18 @@ bool CU::isMTSAllowed(const CodingUnit &cu, const ComponentID compID)
   return mtsAllowed;
 }
 
-bool CU::isMvInRangeFPP( const int yB, const int nH, const int yMv, const int fppLinesSynchro, const PreCalcValues& pcv, const int chromaShift, const int mvPrecShift )
+bool CU::isMvInRangeFPP( const int yB, const int nH, const int yMv, const int ifpLines, const PreCalcValues& pcv, const int chromaShift, const int mvPrecShift )
 {
   //const int dctifMarginVerBot = 4 >> yCompScale;
   const int ctuLogScale = pcv.maxCUSizeLog2 - chromaShift;
-  const int yBMax       = ( pcv.heightInCtus - 1 - fppLinesSynchro ) << ctuLogScale;
-  const int yRefMax     = ( ( ( yB >> ctuLogScale ) + fppLinesSynchro + 1 ) << ctuLogScale ) - 1;
+  const int yBMax       = ( pcv.heightInCtus - 1 - ifpLines ) << ctuLogScale;
+  const int yRefMax     = ( ( ( yB >> ctuLogScale ) + ifpLines + 1 ) << ctuLogScale ) - 1;
   if( yB < yBMax && ( yB + nH + ( 4 >> chromaShift ) + (yMv >> (mvPrecShift + chromaShift) ) - 1 > yRefMax ) )
     return false;
   return true;
 }
 
-bool CU::isMotionBufInRangeFPP( const CodingUnit &cu, const int fppLinesSynchro )
+bool CU::isMotionBufInRangeFPP( const CodingUnit &cu, const int ifpLines )
 {
   const CMotionBuf mb = cu.getMotionBuf();
   const ComponentID compID = COMP_Y;
@@ -3584,7 +3584,7 @@ bool CU::isMotionBufInRangeFPP( const CodingUnit &cu, const int fppLinesSynchro 
           const Mv& mv = mi.mv[i];
           const int refMaxPosY = cuBottom + dctifMarginVerBot + (mv.ver >> mvPrecShift);
           const int refCtuRow = std::min( (int)((refMaxPosY > 0) ? refMaxPosY >> maxCUSizeShift: -1), (int)(cu.cs->pcv->heightInCtus - 1));
-          if( refCtuRow > ( curCtuRow + fppLinesSynchro ) )
+          if( refCtuRow > ( curCtuRow + ifpLines ) )
             return false;
         }
       }

--- a/source/Lib/CommonLib/UnitTools.h
+++ b/source/Lib/CommonLib/UnitTools.h
@@ -181,9 +181,8 @@ namespace CU
   void     getIBCMergeCandidates        (const CodingUnit& cu, MergeCtx& mrgCtx, const int& mrgCandIdx = -1);
   void     fillIBCMvpCand               (CodingUnit& cu, AMVPInfo& amvpInfo);
   void     getIbcMVPsEncOnly            (CodingUnit& cu, Mv* mvPred, int& nbPred);
-  //bool     isMvInRangeFPP               (const CodingUnit &cu, const Mv& mv, const int fppLinesSynchro, const ComponentID compID = COMP_Y, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL );
-  bool     isMvInRangeFPP               (const int yB, const int nH, const int yMv, const int fppLinesSynchro, const PreCalcValues& pcv, const int yCompScale = 0, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
-  bool     isMotionBufInRangeFPP        (const CodingUnit& cu, const int fppLinesSynchro);
+  bool     isMvInRangeFPP               (const int yB, const int nH, const int yMv, const int ifpLines, const PreCalcValues& pcv, const int yCompScale = 0, const int mvPrecShift = MV_FRACTIONAL_BITS_INTERNAL);
+  bool     isMotionBufInRangeFPP        (const CodingUnit& cu, const int ifpLines);
 }
 
 // TU tools

--- a/source/Lib/CommonLib/arm/BufferARM.h
+++ b/source/Lib/CommonLib/arm/BufferARM.h
@@ -65,7 +65,8 @@ namespace vvenc
 template<ARM_VEXT vext>
 void applyLut_SIMD( const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, const Pel* lut )
 {
-  if( ( width & 31 ) == 0 )
+
+  if( ( width & 31 ) == 0 && ( height & 3 ) == 0 )
   {
     int16x8x4_t xtmp1;
     int16x8x4_t xtmp2;
@@ -219,7 +220,7 @@ void applyLut_SIMD( const Pel* src, const ptrdiff_t srcStride, Pel* dst, const p
       dst += ( dstStride << 2 );
     }
   }
-  else if( ( width & 15 ) == 0 )
+  else if( ( width & 15 ) == 0 && ( height & 3 ) == 0 )
   {
     int16x8x2_t xtmp1;
     int16x8x2_t xtmp2;
@@ -309,7 +310,7 @@ void applyLut_SIMD( const Pel* src, const ptrdiff_t srcStride, Pel* dst, const p
       dst += ( dstStride << 2 );
     }
   }
-  else if( ( width & 7 ) == 0 )
+  else if( ( width & 7 ) == 0 && ( height & 3 ) == 0 )
   {
     int16x8_t xtmp1;
     int16x8_t xtmp2;
@@ -366,7 +367,16 @@ void applyLut_SIMD( const Pel* src, const ptrdiff_t srcStride, Pel* dst, const p
       dst += ( dstStride << 2 );
     }
   }
-
+  else
+  {
+#define RSP_SGNL_OP( ADDR ) dst[ADDR] = lut[src[ADDR]]
+#define RSP_SGNL_INC        src += srcStride; dst += dstStride;
+    
+    SIZE_AWARE_PER_EL_OP( RSP_SGNL_OP, RSP_SGNL_INC )
+    
+#undef RSP_SGNL_OP
+#undef RSP_SGNL_INC
+  }
   return;
 }
 

--- a/source/Lib/CommonLib/x86/CommonDefX86.cpp
+++ b/source/Lib/CommonLib/x86/CommonDefX86.cpp
@@ -266,7 +266,7 @@ X86_VEXT read_x86_extension_flags( X86_VEXT request )
   static const X86_VEXT max_supported = _get_x86_extensions();
   static X86_VEXT       ext_flags     = max_supported;
 #else
-  static const X86_VEXT max_supported = AVX;                               // disable AVX2 for non-x86 because the SIMD-Everywhere implementation is buggy
+  static const X86_VEXT max_supported = AVX2;                               // disable AVX2 for non-x86 because the SIMD-Everywhere implementation is buggy
   static X86_VEXT       ext_flags     = SIMD_EVERYWHERE_EXTENSION_LEVEL;   // default to SSE42 for WASM and SIMD-everywhere
 #endif
 
@@ -276,8 +276,6 @@ X86_VEXT read_x86_extension_flags( X86_VEXT request )
     {
 #ifdef REAL_TARGET_X86
       THROW( "requested SIMD level (" << request << ") not supported by current CPU (max " << max_supported << ")." );
-#else
-      THROW( "requested SIMD level (" << request << ") not supported because the SIMD-Everywhere implementation for AVX2 is buggy." );
 #endif
     }
 

--- a/source/Lib/CommonLib/x86/DepQuantX86.h
+++ b/source/Lib/CommonLib/x86/DepQuantX86.h
@@ -115,8 +115,6 @@ namespace DQIntern
 
     int      cffBitsCtxOffset;
     bool     anyRemRegBinsLt4;
-    unsigned effWidth;
-    unsigned effHeight;
     int      initRemRegBins;
   };
 
@@ -1157,11 +1155,6 @@ namespace DQIntern
     {
     }
 
-    void init( int dqTrVal )
-    {
-      m_quant.init( dqTrVal );
-    }
-
     void quant( TransformUnit &tu, const CCoeffBuf &srcCoeff, const ComponentID compID, const QpParam &cQP, const double lambda, const Ctx &ctx, TCoeff &absSum, bool enableScalingLists, int *quantCoeff )
     {
       //===== reset / pre-init =====
@@ -1308,8 +1301,6 @@ namespace DQIntern
 
       int effectWidth  = std::min( 32, effWidth );
       int effectHeight = std::min( 32, effHeight );
-      m_state_curr.effWidth         = effectWidth;
-      m_state_curr.effHeight        = effectHeight;
       m_state_curr.initRemRegBins   = ( effectWidth * effectHeight * MAX_TU_LEVEL_CTX_CODED_BIN_CONSTRAINT ) / 16;
       m_state_curr.anyRemRegBinsLt4 = true; // for the first coeff use scalar impl., because it check against the init state, which
                                             // prohibits some paths
@@ -1504,7 +1495,6 @@ namespace DQIntern
 
   private:
     CommonCtx<vext> m_commonCtx;
-    Quantizer       m_quant;
     Decisions       m_trellis[MAX_TB_SIZEY * MAX_TB_SIZEY][2];
     Rom             m_scansRom;
 

--- a/source/Lib/CommonLib/x86/FixMissingIntrin.h
+++ b/source/Lib/CommonLib/x86/FixMissingIntrin.h
@@ -83,6 +83,8 @@ static inline __m128i _mm_loadu_si32( const void* p )
 {
   return _mm_cvtsi32_si128( *(int32_t*)p );
 }
+#elif defined( REAL_TARGET_X86 ) && defined( __GNUC__ ) && !defined( __llvm__ ) && !defined( __INTEL_COMPILER ) && __GNUC__ <= 11 && __GNUC_MINOR__ <= 2
+#define _mm_loadu_si32( p ) _mm_cvtsi32_si128( *(int32_t*)( p ) )
 #endif
 
 #ifdef MISSING_INTRIN_mm_loadu_si64

--- a/source/Lib/EncoderLib/EncCu.cpp
+++ b/source/Lib/EncoderLib/EncCu.cpp
@@ -1715,9 +1715,9 @@ void EncCu::xCheckRDCostMerge( CodingStructure *&tempCS, CodingStructure *&bestC
           continue;
         }
         mergeCtx.setMergeInfo( cu, uiMergeCand );
-        if( m_pcEncCfg->m_fppLinesSynchro && 
-         (  ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) ) ||
-            ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) )
+        if( m_pcEncCfg->m_ifpLines && 
+         (  ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) ) ||
+            ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) )
           ) )
         {
           // skip candidate
@@ -1907,9 +1907,9 @@ void EncCu::xCheckRDCostMerge( CodingStructure *&tempCS, CodingStructure *&bestC
             continue;
           }
           mergeCtx.setMmvdMergeCandiInfo(cu, mmvdMergeCand);
-          if( m_pcEncCfg->m_fppLinesSynchro &&
-            ( ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) ) ||
-              ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) )
+          if( m_pcEncCfg->m_ifpLines &&
+            ( ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) ) ||
+              ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) )
             ) )
           {
             // skip candidate
@@ -2124,9 +2124,9 @@ void EncCu::xCheckRDCostMerge( CodingStructure *&tempCS, CodingStructure *&bestC
         tempCS->initStructData(encTestMode.qp);
         continue;
       }
-      if( m_pcEncCfg->m_fppLinesSynchro && !m_pcEncCfg->m_useFastMrg &&
-        ( ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) ) ||
-          ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv ) )
+      if( m_pcEncCfg->m_ifpLines && !m_pcEncCfg->m_useFastMrg &&
+        ( ( cu.refIdx[L0] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L0][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) ) ||
+          ( cu.refIdx[L1] >= 0 && !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), cu.mv[L1][0].ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv ) )
         ) )
       {
         // skip candidate
@@ -2392,10 +2392,10 @@ void EncCu::xCheckRDCostMergeGeo(CodingStructure *&tempCS, CodingStructure *&bes
         continue;
       }
 
-      if( m_pcEncCfg->m_fppLinesSynchro ) 
+      if( m_pcEncCfg->m_ifpLines ) 
       {
-        skipCandFpp[L0][mergeCand] = !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), mergeCtx.mvFieldNeighbours[(mergeCand << 1) + 0].mv.ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv );
-        skipCandFpp[L1][mergeCand] = !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), mergeCtx.mvFieldNeighbours[(mergeCand << 1) + 1].mv.ver, m_pcEncCfg->m_fppLinesSynchro, *cu.cs->pcv );
+        skipCandFpp[L0][mergeCand] = !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), mergeCtx.mvFieldNeighbours[(mergeCand << 1) + 0].mv.ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv );
+        skipCandFpp[L1][mergeCand] = !CU::isMvInRangeFPP( cu.ly(), cu.lheight(), mergeCtx.mvFieldNeighbours[(mergeCand << 1) + 1].mv.ver, m_pcEncCfg->m_ifpLines, *cu.cs->pcv );
         if( skipCandFpp[L0][mergeCand] || skipCandFpp[L1][mergeCand] )
           continue;
       }
@@ -2638,7 +2638,7 @@ void EncCu::xCheckRDCostMergeGeo(CodingStructure *&tempCS, CodingStructure *&bes
       cu.mmvdMergeIdx     = MAX_UINT;
 
       CU::spanGeoMotionInfo(cu, mergeCtx, cu.geoSplitDir, cu.geoMergeIdx0, cu.geoMergeIdx1);
-      if( m_pcEncCfg->m_fppLinesSynchro && 
+      if( m_pcEncCfg->m_ifpLines && 
         ( skipCandFpp[L0][cu.geoMergeIdx0] || skipCandFpp[L1][cu.geoMergeIdx0] || skipCandFpp[L0][cu.geoMergeIdx1] || skipCandFpp[L1][cu.geoMergeIdx1] ) ) 
       {
         tempCS->initStructData(encTestMode.qp);
@@ -4050,7 +4050,7 @@ bool EncCu::xCheckSATDCostAffineMerge(CodingStructure*& tempCS, CodingUnit& cu, 
       CU::spanMotionInfo( cu );
     }
 
-    if( m_pcEncCfg->m_fppLinesSynchro && ( !( CU::isMotionBufInRangeFPP( cu, m_pcEncCfg->m_fppLinesSynchro ) ) ) )
+    if( m_pcEncCfg->m_ifpLines && ( !( CU::isMotionBufInRangeFPP( cu, m_pcEncCfg->m_ifpLines ) ) ) )
     {
       // Do not use this mode
       continue;

--- a/source/Lib/EncoderLib/EncGOP.h
+++ b/source/Lib/EncoderLib/EncGOP.h
@@ -147,6 +147,7 @@ private:
   std::list<Picture*>       m_gopEncListOutput;
   std::list<Picture*>       m_procList;
   std::list<Picture*>       m_rcUpdateList;
+  std::list<Picture*>       m_rcInputReorderList;  // used in RC in IFP lines synchro mode
   std::deque<PicApsGlobal*> m_globalApsList;
 
   std::vector<int>          m_globalCtuQpVector;
@@ -200,6 +201,7 @@ private:
   void xSelectReferencePictureList    ( Slice* slice ) const;
   void xSyncAlfAps                    ( Picture& pic );
 
+  void xUpdateRcIfp                   ();
   void xWritePicture                  ( Picture& pic, AccessUnitList& au, bool isEncodeLtRef );
   int  xWriteParameterSets            ( Picture& pic, AccessUnitList& accessUnit, HLSWriter& hlsWriter );
   int  xWritePictureSlices            ( Picture& pic, AccessUnitList& accessUnit, HLSWriter& hlsWriter );

--- a/source/Lib/EncoderLib/EncLib.cpp
+++ b/source/Lib/EncoderLib/EncLib.cpp
@@ -56,6 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "EncStage.h"
 #include "PreProcess.h"
 #include "EncGOP.h"
+#include "CommonLib/x86/CommonDefX86.h"
 
 //! \ingroup EncoderLib
 //! \{
@@ -111,6 +112,13 @@ void EncLib::initEncoderLib( const vvenc_config& encCfg )
   // copy config parameter
   const_cast<VVEncCfg&>(m_encCfg) = encCfg;
 
+#if defined( REAL_TARGET_X86 ) && defined( _MSC_VER ) && _MSC_VER >= 1938 
+  if( read_x86_extension_flags() >= x86_simd::AVX2 )
+  {
+    msg.log( VVENC_WARNING, "WARNING: MSVC version >= 17.8 produces invalid AVX2 code, partially disabling AVX2!\n" );
+  }
+
+#endif
   // setup modified configs for rate control
   if( m_encCfg.m_RCNumPasses > 1 || m_encCfg.m_LookAhead )
   {

--- a/source/Lib/EncoderLib/GOPCfg.h
+++ b/source/Lib/EncoderLib/GOPCfg.h
@@ -93,6 +93,8 @@ class GOPCfg
     int  m_maxTid;
     int  m_firstPassMode;
     int  m_defaultNumActive[ 2 ];
+    int  m_minIntraDist;
+    int  m_lastIntraPOC;
 
   public:
     GOPCfg( MsgLog& _m )
@@ -115,6 +117,8 @@ class GOPCfg
       , m_maxTid          ( 0 )
       , m_firstPassMode   ( 0 )
       , m_defaultNumActive{ 0, 0 }
+      , m_minIntraDist    ( -1 )
+      , m_lastIntraPOC    ( -1 )
     {
     };
 
@@ -122,17 +126,19 @@ class GOPCfg
     {
     };
 
-    void initGopList( int refreshType, bool poc0idr, int intraPeriod, int gopSize, int leadFrames, bool bPicReordering, const vvencGOPEntry cfgGopList[ VVENC_MAX_GOP ], const vvencMCTF& mctfCfg, int firstPassMode );
+    void initGopList( int refreshType, bool poc0idr, int intraPeriod, int gopSize, int leadFrames, bool bPicReordering, const vvencGOPEntry cfgGopList[ VVENC_MAX_GOP ], const vvencMCTF& mctfCfg, int firstPassMode, int m_minIntraDist );
     void getNextGopEntry( GOPEntry& gopEntry );
     void startIntraPeriod( GOPEntry& gopEntry );
-    void fixStartOfLastGop( GOPEntry& gopEntry ) const;
+    void fixStartOfLastGop( GOPEntry& gopEntry );
     void getDefaultRPLLists( RPLList& rpl0, RPLList& rpl1 ) const;
+    void setLastIntraSTA( int poc ) { m_lastIntraPOC = poc; }
 
     int  getMaxTLayer() const                             { return m_maxTid; }
     const std::vector<int>& getMaxDecPicBuffering() const { return m_maxDecPicBuffering; }
     const std::vector<int>& getNumReorderPics() const     { return m_numReorderPics; }
     int  getDefaultNumActive( int l ) const               { return m_defaultNumActive[ l ]; }
 
+    bool isSTAallowed( int poc ) const;
     bool hasNonZeroTemporalId() const;
     bool hasLeadingPictures() const;
     bool isChromaDeltaQPEnabled() const;

--- a/source/Lib/EncoderLib/InterSearch.h
+++ b/source/Lib/EncoderLib/InterSearch.h
@@ -513,10 +513,10 @@ private:
                                     const bool            bFastSettings = false
                                   );
 
-  void xClipMvSearch              ( Mv& rcMv, const Position& pos, const struct Size& size, const PreCalcValues& pcv, const int fppLinesSynchro );
+  void xClipMvSearch              ( Mv& rcMv, const Position& pos, const struct Size& size, const PreCalcValues& pcv, const int ifpLines );
 
-  void xClipMvToFppLine           ( Mv& mv, const int yB, const int nH, const int fppLinesSynchro, const PreCalcValues& pcv );
-  void xCheckAndClipMvToFppLine   ( Mv& mv, const int yB, const int nH, const int fppLinesSynchro, const PreCalcValues& pcv );
+  void xClipMvToFppLine           ( Mv& mv, const int yB, const int nH, const int ifpLines, const PreCalcValues& pcv );
+  void xCheckAndClipMvToFppLine   ( Mv& mv, const int yB, const int nH, const int ifpLines, const PreCalcValues& pcv );
   void xSetSearchRange            ( const CodingUnit& cu,
                                     const Mv&             cMvPred,
                                     const int             iSrchRng,

--- a/source/Lib/vvenc/vvencimpl.cpp
+++ b/source/Lib/vvenc/vvencimpl.cpp
@@ -70,6 +70,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #  include <malloc.h>
 #endif
 
+#if defined( TARGET_SIMD_ARM )
+#  include "CommonLib/arm/CommonDefARM.h"
+#endif
 
 #if _DEBUG
 #define HANDLE_EXCEPTION 0
@@ -796,6 +799,9 @@ const char* VVEncImpl::setSIMDExtension( const char* simdId )
     try
     {
       read_x86_extension_flags( request_ext );
+#if defined( TARGET_SIMD_ARM )
+      read_arm_extension_flags( request_ext == x86_simd::UNDEFINED ? arm_simd::UNDEFINED : request_ext != x86_simd::SCALAR ? arm_simd::NEON : arm_simd::SCALAR );
+#endif
     }
     catch( Exception& )
     {


### PR DESCRIPTION
* harmonized inter frame parallelization and rate control
* fixed some buggy ARM NEON code
* fixed ARM NEON activation when selecting `--SIMD=SCALAR`
* workaround for buggy implementation of `_mm_loadu_si32` in early GCC 11 (extensively used in DepQuantX86.h)
* added minimal intra distance restriction and parameter
* increased default number of threads to 12 for 5K and higher resolutions