### PR TITLE
hotfix for ARM based systems

### DIFF
--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -149,7 +149,7 @@ namespace vvenc {
 
 
 #if defined( TARGET_SIMD_X86 ) && !defined( REAL_TARGET_X86 )
-#  define SIMD_EVERYWHERE_EXTENSION_LEVEL                 AVX2
+#  define SIMD_EVERYWHERE_EXTENSION_LEVEL                 SSE41
 #endif
 
 // End of SIMD optimizations


### PR DESCRIPTION
SIMD_EVERYWHERE_EXTENSION_LEVEL reset to "SSE41".

The define was previously set to "AVX2" which decreases the performance on ARM based systems drastically.