### PR TITLE
pthreads specific thread implementation to set stack size

### DIFF
--- a/source/Lib/Utilities/NoMallocThreadPool.cpp
+++ b/source/Lib/Utilities/NoMallocThreadPool.cpp
@@ -48,10 +48,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "NoMallocThreadPool.h"
 
 
-#if __linux
-#include <pthread.h>
-#endif
-
 //! \ingroup Utilities
 //! \{
 
@@ -68,7 +64,11 @@ NoMallocThreadPool::NoMallocThreadPool( int numThreads, const char * threadPoolN
   int tid = 0;
   for( auto& t: m_threads )
   {
+#if PTHREAD_WRAPPER
+    t = PThread( this, tid++, *encCfg );
+#else
     t = std::thread( &NoMallocThreadPool::threadProc, this, tid++, *encCfg );
+#endif
   }
 }
 

--- a/source/Lib/Utilities/NoMallocThreadPool.cpp
+++ b/source/Lib/Utilities/NoMallocThreadPool.cpp
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "NoMallocThreadPool.h"
 
+#include <thread>
 
 //! \ingroup Utilities
 //! \{
@@ -64,11 +65,7 @@ NoMallocThreadPool::NoMallocThreadPool( int numThreads, const char * threadPoolN
   int tid = 0;
   for( auto& t: m_threads )
   {
-#if PTHREAD_WRAPPER
-    t = PThread( this, tid++, *encCfg );
-#else
-    t = std::thread( &NoMallocThreadPool::threadProc, this, tid++, *encCfg );
-#endif
+    t = ThreadImpl( &NoMallocThreadPool::threadProc, this, tid++, *encCfg );
   }
 }
 

--- a/source/Lib/Utilities/NoMallocThreadPool.cpp
+++ b/source/Lib/Utilities/NoMallocThreadPool.cpp
@@ -293,12 +293,13 @@ NoMallocThreadPool::PThread::PThread( TFunc&& func, TArgs&&... args )
   };
 
   pthread_attr_t attr;
-  CHECK( pthread_attr_init( &attr ) != 0, "pthread_attr_init() failed" );
+  int ret = pthread_attr_init( &attr );
+  CHECK( ret != 0, "pthread_attr_init() failed" );
 
   try
   {
     size_t currStackSize = 0;
-    int ret = pthread_attr_getstacksize( &attr, &currStackSize );
+    ret = pthread_attr_getstacksize( &attr, &currStackSize );
     CHECK( ret != 0, "pthread_attr_getstacksize() failed" );
 
     if( currStackSize < THREAD_MIN_STACK_SIZE )

--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -535,6 +535,13 @@ private:
         pthread_attr_destroy( &attr );
         THROW( "pthread_attr_setstacksize() failed" );
       }
+#  ifdef _DEBUG
+      if( pthread_attr_setguardsize( &attr, 1024 * 1024 ) != 0 )   // set stack guard size to 1MB to more reliably deteck stack overflows
+      {
+        pthread_attr_destroy( &attr );
+        THROW( "pthread_attr_setguardsize() failed" );
+      }
+#  endif
 
       m_joinable = 0 == pthread_create( &m_id, &attr, threadFn, call.get() );
       pthread_attr_destroy( &attr );

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -170,6 +170,10 @@ else()
   target_link_libraries( ${LIB_NAME} PRIVATE Threads::Threads )
 endif()
 
+if( CMAKE_USE_PTHREADS_INIT )
+  target_compile_definitions( ${LIB_NAME} PRIVATE HAVE_PTHREADS )
+endif()
+
 # set the folder where to place the projects
 set_target_properties( ${LIB_NAME} PROPERTIES
                                    VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
Adds a thread class implemented with pthreads to set the stack size to at least 1MB. It exposes an interface similar to std::thread, so it is interchangeable with that for our use case.

fixes GitHub issue [#410](https://github.com/fraunhoferhhi/vvenc/issues/410)