### PR TITLE
NoMallocThreadPool: include pthread if using pthread

### DIFF
--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -52,6 +52,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <chrono>
 #include <array>
 
+#ifdef HAVE_PTHREADS
+#include <pthread.h>
+#endif
+
 #include "CommonLib/CommonDef.h"
 #if ENABLE_TIME_PROFILING_MT_MODE
 #include "CommonLib/TimeProfiler.h"


### PR DESCRIPTION
Using clang with libc++ does not include pthread.h implicitly through <thread> by default, so using pthread_t will cause a compilation error.

```c++
[1/41] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/MCTF.cpp.o
FAILED: source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/MCTF.cpp.o
ccache D:\clang\msys64\clang64\bin\ccache.exe  clang++ -DHAVE_PTHREADS -DTARGET_SIMD_X86 -DVVENC_SOURCE -D_WIN32_WINNT=0x0600 -ID:/clang/build/vvenc-git/source/Lib/vvenc/../../../include -ID:/clang/build/vvenc-git/build-64bit -ID:/clang/build/vvenc-git/source/Lib/vvenc/. -ID:/clang/build/vvenc-git/source/Lib/vvenc/.. -ID:/clang/build/vvenc-git/source/Lib/vvenc/../DecoderLib -ID:/clang/build/vvenc-git/source/Lib/vvenc/../EncoderLib -ID:/clang/build/vvenc-git/source/Lib/vvenc/../CommonLib -ID:/clang/build/vvenc-git/source/Lib/vvenc/../CommonLib/x86 -ID:/clang/build/vvenc-git/source/Lib/vvenc/../CommonLib/arm -ID:/clang/build/vvenc-git/source/Lib/vvenc/../apputils -ID:/clang/build/vvenc-git/source/Lib/vvenc/../../../thirdparty/nlohmann_json/single_include -isystem D:/clang/build/vvenc-git/source/Lib/vvenc/../../../thirdparty -D_FORTIFY_SOURCE=2 -fstack-protector-strong -mtune=generic -O2 -pipe -D__USE_MINGW_ANSI_STDIO=1 -DVVENC_ENABLE_THIRDPARTY_JSON -DVVENC_ENABLE_THIRDPARTY_JSON -O3 -DNDEBUG -std=gnu++14 -fvisibility=hidden -fvisibility-inlines-hidden -msse4.1 -Wall -Werror -Wno-deprecated-register -Wno-unused-const-variable -Wno-unknown-attributes -MD -MT source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/MCTF.cpp.o -MF source\Lib\vvenc\CMakeFiles\vvenc.dir\__\CommonLib\MCTF.cpp.o.d -o source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/MCTF.cpp.o -c D:/clang/build/vvenc-git/source/Lib/CommonLib/MCTF.cpp
In file included from D:/clang/build/vvenc-git/source/Lib/CommonLib/MCTF.cpp:52:
D:/clang/build/vvenc-git/source/Lib/vvenc/../Utilities/NoMallocThreadPool.h:505:5: error: unknown type name 'pthread_t'
  505 |     pthread_t m_id       = 0;
      |     ^
1 error generated.
```