### PR TITLE
Avoid checking for arm/aarch64 in toolchain path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ message( STATUS "CMAKE_MODULE_PATH: updating module path to: ${CMAKE_MODULE_PATH
 # check for arm architecture support
 set( VVENC_ARM_SIMD_DEFAULT FALSE )
 if( ( "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64\|arm"
-    OR "${CMAKE_CXX_COMPILER}" MATCHES "aarch64\|arm"
     OR "${CMAKE_OSX_ARCHITECTURES}" MATCHES "arm64\|armv" )
     AND NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "x86\|x64" )
   set( VVENC_ARM_SIMD_DEFAULT TRUE )


### PR DESCRIPTION
Since the `CMAKE_CXX_COMPILER` contains the full path including directory components, this check will enable Arm intrinsics even on non-Arm platforms if the directory the compiler resides in happens to contain the substring "arm", for example:

        /home/parma/toolchains/g++-14
               ^^^

`CMAKE_SYSTEM_PROCESSOR` already specifies the target architecture so there is no need to additionally check the compiler string, therefore we simply remove this condition.