### PR TITLE
Fix build failures on AArch64 with GCC-14

### DIFF
--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -96,6 +96,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #if defined( __GNUC__ ) && __GNUC__ >= 8 && !defined( __clang__ )
 # define GCC_WARNING_DISABLE_maybe_uninitialized _Pragma("GCC diagnostic push"); \
                                                  _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"");
+# define GCC_WARNING_DISABLE_uninitialized       _Pragma("GCC diagnostic push"); \
+                                                 _Pragma("GCC diagnostic ignored \"-Wuninitialized\"");
 # define GCC_WARNING_DISABLE_class_memaccess     _Pragma("GCC diagnostic push"); \
                                                  _Pragma("GCC diagnostic ignored \"-Wclass-memaccess\"");
 # define GCC_WARNING_DISABLE_array_bounds        _Pragma("GCC diagnostic push"); \
@@ -103,6 +105,7 @@ POSSIBILITY OF SUCH DAMAGE.
 # define GCC_WARNING_RESET                       _Pragma("GCC diagnostic pop");
 #else
 # define GCC_WARNING_DISABLE_maybe_uninitialized
+# define GCC_WARNING_DISABLE_uninitialized
 # define GCC_WARNING_DISABLE_class_memaccess
 # define GCC_WARNING_DISABLE_array_bounds
 # define GCC_WARNING_RESET

--- a/source/Lib/CommonLib/x86/InterpolationFilterX86.h
+++ b/source/Lib/CommonLib/x86/InterpolationFilterX86.h
@@ -2102,6 +2102,9 @@ void simdFilter4x4_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel*
   else
 #endif
   {
+    // Avoid -Wuninitialized warning on coeffV load when building with GCC-14.
+    GCC_WARNING_DISABLE_uninitialized
+
     ALIGN_DATA( 64, const TFilterCoeff coeffV[10] ) = { 0, 0, 0, _coeffV[3], _coeffV[2], _coeffV[1], _coeffV[0], 0 ,0,0};
 
     __m128i cH    = _mm_loadl_epi64  ( ( const __m128i* ) coeffH );
@@ -2156,6 +2159,7 @@ void simdFilter4x4_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel*
       
       src+=srcStride;
     }
+    GCC_WARNING_RESET
 
     _dst0x = _mm_srai_epi32( _dst0x, shift2nd );
     _dst1x = _mm_srai_epi32( _dst1x, shift2nd );

--- a/source/Lib/CommonLib/x86/IntraPredX86.h
+++ b/source/Lib/CommonLib/x86/IntraPredX86.h
@@ -288,7 +288,8 @@ void IntraPredAngleLumaCore_SIMD(int16_t* pDstBuf,const ptrdiff_t dstStride,int1
           int deltaFract = deltaPos & (32 - 1);
 
           const TFilterCoeff      intraSmoothingFilter[4] = {TFilterCoeff(16 - (deltaFract >> 1)), TFilterCoeff(32 - (deltaFract >> 1)), TFilterCoeff(16 + (deltaFract >> 1)), TFilterCoeff(deltaFract >> 1)};
-          const TFilterCoeff *f = useCubicFilter ? InterpolationFilter::getChromaFilterTable(deltaFract) : intraSmoothingFilter;
+          const TFilterCoeff *f = InterpolationFilter::getChromaFilterTable(deltaFract);
+          f = useCubicFilter ? f : intraSmoothingFilter;
 
           int refMainIndex   = deltaInt + 1;
           pDst=&pDstBuf[y*dstStride];
@@ -336,7 +337,8 @@ void IntraPredAngleLumaCore_SIMD(int16_t* pDstBuf,const ptrdiff_t dstStride,int1
         int deltaFract = deltaPos & (32 - 1);
 
         const TFilterCoeff      intraSmoothingFilter[4] = {TFilterCoeff(16 - (deltaFract >> 1)), TFilterCoeff(32 - (deltaFract >> 1)), TFilterCoeff(16 + (deltaFract >> 1)), TFilterCoeff(deltaFract >> 1)};
-        const TFilterCoeff *f = useCubicFilter ? InterpolationFilter::getChromaFilterTable(deltaFract) : intraSmoothingFilter;
+        const TFilterCoeff *f = InterpolationFilter::getChromaFilterTable(deltaFract);
+        f = useCubicFilter ? f : intraSmoothingFilter;
 
         int refMainIndex   = deltaInt + 1;
         pDst=&pDstBuf[y*dstStride];
@@ -391,10 +393,11 @@ void IntraPredAngleLumaCore_SIMD(int16_t* pDstBuf,const ptrdiff_t dstStride,int1
     {
       int deltaInt   = deltaPos >> 5;
       int deltaFract = deltaPos & (32 - 1);
- 
+
       const TFilterCoeff      intraSmoothingFilter[4] = {TFilterCoeff(16 - (deltaFract >> 1)), TFilterCoeff(32 - (deltaFract >> 1)), TFilterCoeff(16 + (deltaFract >> 1)), TFilterCoeff(deltaFract >> 1)};
-      const TFilterCoeff *f = useCubicFilter ? InterpolationFilter::getChromaFilterTable(deltaFract) : intraSmoothingFilter;
-   
+      const TFilterCoeff *f = InterpolationFilter::getChromaFilterTable(deltaFract);
+      f = useCubicFilter ? f : intraSmoothingFilter;
+
       int refMainIndex   = deltaInt + 1;
       pDst=&pDstBuf[y*dstStride];
       __m128i coeff = _mm_loadl_epi64( ( __m128i const * )f);   //load 4 16 bit filter coeffs


### PR DESCRIPTION
When building with GCC-14 on an AArch64 machine, the build currently fails with `-Werror` due to a couple of warnings that are turned into errors:

* GCC appears to not understand the indexing for the `coeffV` array load and incorrectly reports this as an out of bounds access. Add a new `GCC_WARNING_DISABLE_uninitialized` to handle this.

* GCC reports the ternary setting `f` in `IntraPredAngleLumaCore_SIMD` as being set from a maybe-uninitialised source. Splitting the ternary appears to be sufficient to suppress this.