### PR TITLE
Add CONFIGURE_DEPENDS to CMake GLOB lists

### DIFF
--- a/source/App/vvencFFapp/CMakeLists.txt
+++ b/source/App/vvencFFapp/CMakeLists.txt
@@ -2,10 +2,10 @@
 set( EXE_NAME vvencFFapp )
 
 # get source files
-file( GLOB SRC_FILES "*.cpp" )
+file( GLOB SRC_FILES CONFIGURE_DEPENDS "*.cpp" )
 
 # get include files
-file( GLOB INC_FILES "*.h" )
+file( GLOB INC_FILES CONFIGURE_DEPENDS "*.h" )
 
 # get address sanitizer libs for gcc
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
@@ -17,7 +17,7 @@ endif()
 # set resource file for MSVC compilers
 if( MSVC )
   set( RESOURCE_FILE ${EXE_NAME}.rc )
-  file( GLOB NATVIS_FILES "../../VisualStudio/*.natvis" )
+  file( GLOB NATVIS_FILES CONFIGURE_DEPENDS "../../VisualStudio/*.natvis" )
   # extend the stack size on windows to 2MB
   set( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /STACK:0x200000" )
 endif()

--- a/source/App/vvencapp/CMakeLists.txt
+++ b/source/App/vvencapp/CMakeLists.txt
@@ -2,10 +2,10 @@
 set( EXE_NAME vvencapp )
 
 # get source files
-file( GLOB SRC_FILES "*.cpp" )
+file( GLOB SRC_FILES CONFIGURE_DEPENDS "*.cpp" )
 
 # get include files
-file( GLOB INC_FILES "*.h" )
+file( GLOB INC_FILES CONFIGURE_DEPENDS "*.h" )
 
 # get address sanitizer libs for gcc
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -12,10 +12,10 @@ else()
 endif()
 
 # get source files
-file( GLOB BASE_SRC_FILES "*.cpp"  "../CommonLib/*.cpp"  "../Utilities/*.cpp" "../DecoderLib/*.cpp" "../EncoderLib/*.cpp" )
+file( GLOB BASE_SRC_FILES CONFIGURE_DEPENDS "*.cpp"  "../CommonLib/*.cpp"  "../Utilities/*.cpp" "../DecoderLib/*.cpp" "../EncoderLib/*.cpp" )
 
 # get include files
-file( GLOB BASE_INC_FILES "*.h" "../CommonLib/*.h"  "../Utilities/*.h" "../DecoderLib/*.h" "../EncoderLib/*.h" "../apputils/*.h" )
+file( GLOB BASE_INC_FILES CONFIGURE_DEPENDS "*.h" "../CommonLib/*.h"  "../Utilities/*.h" "../DecoderLib/*.h" "../EncoderLib/*.h" "../apputils/*.h" )
 
 
 if( NOT DEFINED VVENC_ENABLE_X86_SIMD )
@@ -24,33 +24,33 @@ endif()
 
 if( VVENC_ENABLE_X86_SIMD )
   # get x86 source files
-  file( GLOB X86_SRC_FILES "../CommonLib/x86/*.cpp" )
+  file( GLOB X86_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.cpp" )
 
   # get x86 include files
-  file( GLOB X86_INC_FILES "../CommonLib/x86/*.h" )
+  file( GLOB X86_INC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.h" )
 
   # get avx source files
-  file( GLOB AVX_SRC_FILES "../CommonLib/x86/avx/*.cpp" )
+  file( GLOB AVX_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/avx/*.cpp" )
 
   # get avx2 source files
-  file( GLOB AVX2_SRC_FILES "../CommonLib/x86/avx2/*.cpp" )
+  file( GLOB AVX2_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/avx2/*.cpp" )
 
   # get sse4.1 source files
-  file( GLOB SSE41_SRC_FILES "../CommonLib/x86/sse41/*.cpp" )
+  file( GLOB SSE41_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/sse41/*.cpp" )
 
   # get sse4.2 source files
-  file( GLOB SSE42_SRC_FILES "../CommonLib/x86/sse42/*.cpp" )
+  file( GLOB SSE42_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/sse42/*.cpp" )
 endif()
 
 if( VVENC_ENABLE_ARM_SIMD )
-  file( GLOB ARM_SRC_FILES      "../CommonLib/arm/*.cpp"      )
-  file( GLOB ARM_INC_FILES      "../CommonLib/arm/*.h"        )
+  file( GLOB ARM_SRC_FILES CONFIGURE_DEPENDS      "../CommonLib/arm/*.cpp"      )
+  file( GLOB ARM_INC_FILES CONFIGURE_DEPENDS      "../CommonLib/arm/*.h"        )
 
-  file( GLOB ARM_NEON_SRC_FILES "../CommonLib/arm/neon/*.cpp" )
+  file( GLOB ARM_NEON_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/neon/*.cpp" )
 endif()
 
 # get public/extern include files
-file( GLOB PUBLIC_INC_FILES  "../../../include/${LIB_NAME}/*.h" )
+file( GLOB PUBLIC_INC_FILES CONFIGURE_DEPENDS  "../../../include/${LIB_NAME}/*.h" )
 
 # get all private include files
 set( PRIVATE_INC_FILES ${BASE_INC_FILES} ${X86_INC_FILES} ${ARM_INC_FILES} )
@@ -61,7 +61,7 @@ set( INC_FILES ${PRIVATE_INC_FILES} ${PUBLIC_INC_FILES}  )
 
 # NATVIS files for Visual Studio
 if( MSVC )
-  file( GLOB NATVIS_FILES "../../VisualStudio/*.natvis" )
+  file( GLOB NATVIS_FILES CONFIGURE_DEPENDS "../../VisualStudio/*.natvis" )
 
   # example: place header files in different folders
   source_group( "Natvis Files" FILES ${NATVIS_FILES} )

--- a/test/vvencinterfacetest/CMakeLists.txt
+++ b/test/vvencinterfacetest/CMakeLists.txt
@@ -2,10 +2,10 @@
 set( EXE_NAME vvencinterfacetest )
 
 # get source files
-file( GLOB SRC_FILES "*.c" )
+file( GLOB SRC_FILES CONFIGURE_DEPENDS "*.c" )
 
 # get include files
-file( GLOB INC_FILES "*.h" )
+file( GLOB INC_FILES CONFIGURE_DEPENDS "*.h" )
 
 # set resource file for MSVC compilers
 if( MSVC )

--- a/test/vvenclibtest/CMakeLists.txt
+++ b/test/vvenclibtest/CMakeLists.txt
@@ -2,10 +2,10 @@
 set( EXE_NAME vvenclibtest )
 
 # get source files
-file( GLOB SRC_FILES "*.cpp" )
+file( GLOB SRC_FILES CONFIGURE_DEPENDS "*.cpp" )
 
 # get include files
-file( GLOB INC_FILES "*.h" )
+file( GLOB INC_FILES CONFIGURE_DEPENDS "*.h" )
 
 # set resource file for MSVC compilers
 if( MSVC )


### PR DESCRIPTION
The addition of new source files will not ordinarily trigger them to be added to the build due to how `GLOB`s are implemented in CMake.

CMake 3.12 added a new `CONFIGURE_DEPENDS` flag to enable CMake to re-check `GLOB` results during build time and re-generate the build scripts if necessary. The existing `CMakeLists.txt` already specifies a minimum CMake version of 3.13 so this should always be available.