### PR TITLE
Fix added this local variables by value

### DIFF
--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -157,7 +157,7 @@ struct BlockingBarrier
     BlockingBarrier* nonconst = const_cast<BlockingBarrier*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
-#if __GNUC__ && (__cplusplus > 201703L)
+#if __MINGW32__ && (__cplusplus > 201703L)
     nonconst->m_cond.wait( l, [=, this] { return !m_intBarrier.isBlocked(); } );
 #else
     nonconst->m_cond.wait( l, [=] { return !m_intBarrier.isBlocked(); } );
@@ -214,7 +214,7 @@ struct WaitCounter
     WaitCounter* nonconst = const_cast<WaitCounter*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
-#if __GNUC__ && (__cplusplus > 201703L)
+#if __MINGW32__ && (__cplusplus > 201703L)
     nonconst->m_cond.wait( l, [=, this] { return m_count == 0; } );
 #else
     nonconst->m_cond.wait( l, [=] { return m_count == 0; } );

--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -157,7 +157,11 @@ struct BlockingBarrier
     BlockingBarrier* nonconst = const_cast<BlockingBarrier*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
+#if __GNUC__ && (__cplusplus > 201703L)
+    nonconst->m_cond.wait( l, [=, this] { return !m_intBarrier.isBlocked(); } );
+#else
     nonconst->m_cond.wait( l, [=] { return !m_intBarrier.isBlocked(); } );
+#endif
   }
 
   BlockingBarrier()  = default;
@@ -210,7 +214,11 @@ struct WaitCounter
     WaitCounter* nonconst = const_cast<WaitCounter*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
+#if __GNUC__ && (__cplusplus > 201703L)
+    nonconst->m_cond.wait( l, [=, this] { return m_count == 0; } );
+#else
     nonconst->m_cond.wait( l, [=] { return m_count == 0; } );
+#endif
   }
 
   WaitCounter() = default;


### PR DESCRIPTION
```
NoMallocThreadPool.h: In lambda function:
NoMallocThreadPool.h:220:31: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
  220 |     nonconst->m_cond.wait( l, [=] { return m_count == 0; } );
      |                               ^
NoMallocThreadPool.h:220:31: note: add explicit 'this' or '*this' capture
```