### PR TITLE
Added typedef va_list

### DIFF
--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -564,6 +564,9 @@ template <typename T> inline void Check3( T minVal, T maxVal, T a)
   CHECK( ( a > maxVal ) || ( a < minVal ), "ERROR: Range check " << minVal << " >= " << a << " <= " << maxVal << " failed" );
 }  ///< general min/max clip
 
+#if __GNUC__ && __cplusplus
+typedef char *  va_list;
+#endif
 // global logger message callback function - DEPRECATED - will be removed in next major version
 extern std::function<void( void*, int, const char*, va_list )> g_msgFnc;
 extern void * g_msgFncCtx;

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -564,7 +564,7 @@ template <typename T> inline void Check3( T minVal, T maxVal, T a)
   CHECK( ( a > maxVal ) || ( a < minVal ), "ERROR: Range check " << minVal << " >= " << a << " <= " << maxVal << " failed" );
 }  ///< general min/max clip
 
-#if __GNUC__ && __cplusplus
+#if __MINGW32__ && __cplusplus
 typedef char *  va_list;
 #endif
 // global logger message callback function - DEPRECATED - will be removed in next major version


### PR DESCRIPTION
```
CommonDef.h:569:62: warning: ignoring attributes on template argument 'void(void*, int, const char*, va_list)' {aka 'void(void*, int, const char*, char*)'} [-Wignored-attributes]
  569 | extern std::function<void( void*, int, const char*, va_list )> g_msgFnc;
      |                                                              ^
```