### PR TITLE
Fix added integer int

### DIFF
--- a/include/vvenc/vvencCfg.h
+++ b/include/vvenc/vvencCfg.h
@@ -695,7 +695,7 @@ typedef struct vvenc_config
   unsigned int        m_masteringDisplay[10];                                            // mastering display colour volume, vector of size 10, format: G(x,y)B(x,y)R(x,y)WP(x,y)L(max,min), 0 <= GBR,WP <= 50000, 0 <= L <= uint (SEI)
                                                                                          // GBR xy coordinates in increments of 1/50000 (in the ranges 0 to 50000) (e.g. 0.333 = 16667)
                                                                                          // min/max luminance value in units of 1/10000 candela per square metre
-  unsigned int        m_contentLightLevel[2];                                            // upper bound on the max light level and max avg light level among all individual samples in a 4:4:4 representation. in units of candelas per square metre (SEI)
+  int        m_contentLightLevel[2];                                                     // upper bound on the max light level and max avg light level among all individual samples in a 4:4:4 representation. in units of candelas per square metre (SEI)
   int                 m_preferredTransferCharacteristics;                                // Alternative transfer characteristics SEI which will override the corresponding entry in the VUI, if < 0 SEI is not written")
 
   bool                m_alf;                                                             // Adaptive Loop Filter

--- a/source/Lib/apputils/VVEncAppCfg.h
+++ b/source/Lib/apputils/VVEncAppCfg.h
@@ -563,7 +563,7 @@ int parse( int argc, char* argv[], vvenc_config* c, std::ostream& rcOstr )
   IStreamToEnum<int>                toPrefTransferCharacteristics( &c->m_preferredTransferCharacteristics, &TransferCharacteristicsToIntMap );
 
   IStreamToArr<unsigned int>        toMasteringDisplay            ( &c->m_masteringDisplay[0], 10  );
-  IStreamToArr<unsigned int>        toContentLightLevel           ( &c->m_contentLightLevel[0], 2 );
+  IStreamToArr<int>                 toContentLightLevel           ( &c->m_contentLightLevel[0], 2 );
 
   IStreamToArr<char>                toTraceRule                   ( &c->m_traceRule[0], VVENC_MAX_STRING_LEN  );
   IStreamToArr<char>                toTraceFile                   ( &c->m_traceFile[0], VVENC_MAX_STRING_LEN  );

--- a/source/Lib/vvenc/vvencCfg.cpp
+++ b/source/Lib/vvenc/vvencCfg.cpp
@@ -236,7 +236,7 @@ static inline std::string vvenc_getMasteringDisplayStr( unsigned int md[10]  )
   return css.str();
 }
 
-static inline std::string vvenc_getContentLightLevelStr( unsigned int cll[2] )
+static inline std::string vvenc_getContentLightLevelStr( int cll[2] )
 {
   std::stringstream css;
 


### PR DESCRIPTION
```
vvencCfg.cpp:1923:57: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
 1923 |   vvenc_confirmParameter( c, (c->m_contentLightLevel[0] < 0 || c->m_contentLightLevel[0] > 10000),  "max content light level must 0 <= cll <= 10000 ");
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
vvencCfg.cpp:1924:57: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
 1924 |   vvenc_confirmParameter( c, (c->m_contentLightLevel[1] < 0 || c->m_contentLightLevel[1] > 10000),  "max average content light level must 0 <= cll <= 10000 ");
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```