### PR TITLE
Fix SIMD unit tests for transforms

### DIFF
--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -50,6 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h>
 #include <stdio.h>
 #include <vector>
+#include <time.h>
 
 #include "CommonLib/TrQuant_EMT.h"
 #include "CommonLib/TypeDef.h"
@@ -282,14 +283,14 @@ static bool test_TCoeffOps()
 
 int main()
 {
-  unsigned seed = rand();
+  unsigned seed = time( NULL );
   srand( seed );
 
   bool passed = test_TCoeffOps();
 
   if( !passed )
   {
-    printf( "\nerror: some tests failed for seed=%d!\n\n", seed );
+    printf( "\nerror: some tests failed for seed=%u!\n\n", seed );
     exit( EXIT_FAILURE );
   }
   printf( "\nsuccess: all tests passed!\n\n" );

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -217,7 +217,7 @@ static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_case
     // Clamp lines down to the next multiple of four when generating
     // reducedLines to avoid existing x86 implementations over-writing.
     unsigned lines        = 1 << rng.get( 1, 6 );
-    unsigned reducedLines = lines == 2 ? lines : std::min( 32u, rng.get( 0, lines, 4 ) );
+    unsigned reducedLines = lines == 2 ? lines : std::min( 32u, rng.get( 4, lines, 4 ) );
     unsigned cutoff       = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     if( !check_one_fastInvCore( ref, opt, idx, trSize, lines, reducedLines, cutoff, g, t ) )
     {
@@ -240,7 +240,7 @@ static bool check_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned num_c
     // Clamp line down to the next multiple of four when generating reducedLine
     // to avoid existing x86 implementations over-writing.
     unsigned line        = 1 << rng.get( 1, 6 );
-    unsigned reducedLine = line == 2 ? 2 : std::min( 32u, rng.get( 0, line, 4 ) );
+    unsigned reducedLine = line == 2 ? 2 : std::min( 32u, rng.get( 4, line, 4 ) );
     unsigned cutoff      = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     unsigned shift       = rng.get( 1, 16 );          // Shift must be at least one to avoid UB.
     if( !check_one_fastFwdCore_2D( ref, opt, idx, trSize, line, reducedLine, cutoff, shift, g, t ) )

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -282,11 +282,14 @@ static bool test_TCoeffOps()
 
 int main()
 {
+  unsigned seed = rand();
+  srand( seed );
+
   bool passed = test_TCoeffOps();
 
   if( !passed )
   {
-    printf( "\nerror: some tests failed!\n\n" );
+    printf( "\nerror: some tests failed for seed=%d!\n\n", seed );
     exit( EXIT_FAILURE );
   }
   printf( "\nsuccess: all tests passed!\n\n" );

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -90,7 +90,7 @@ public:
 
   T operator()() const
   {
-    return rand() & ( ( 1 << m_bits ) - 1 );
+    return ( rand() & ( ( 1 << m_bits ) - 1 ) ) - ( 1 << m_bits >> 1 );
   }
 
 private:
@@ -208,7 +208,7 @@ static bool check_one_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned i
 static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_cases, unsigned idx, unsigned trSize )
 {
   printf( "Testing TCoeffOps::fastInvCore trSize=%d\n", trSize );
-  InputGenerator<TCoeff> g{ 10 };
+  InputGenerator<TCoeff> g{ 16 };
   TrafoGenerator<TMatrixCoeff> t{ 8 };
   DimensionGenerator rng;
 
@@ -231,7 +231,7 @@ static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_case
 static bool check_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned num_cases, unsigned idx, unsigned trSize )
 {
   printf( "Testing TCoeffOps::fastFwdCore_2D trSize=%d\n", trSize );
-  InputGenerator<TCoeff> g{ 10 };
+  InputGenerator<TCoeff> g{ 16 };
   TrafoGenerator<TMatrixCoeff> t{ 8 };
   DimensionGenerator rng;
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -231,7 +231,7 @@ static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_case
 static bool check_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned num_cases, unsigned idx, unsigned trSize )
 {
   printf( "Testing TCoeffOps::fastFwdCore_2D trSize=%d\n", trSize );
-  InputGenerator<TCoeff> g{ 16 };
+  InputGenerator<TCoeff> g{ 11 }; // signed 10 bit in both positive/negative, i.e. 11 bit shifted to signed
   TrafoGenerator<TMatrixCoeff> t{ 8 };
   DimensionGenerator rng;
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -49,7 +49,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <stddef.h>
 #include <stdio.h>
-#include <vector>
 #include <time.h>
 
 #include "CommonLib/TrQuant_EMT.h"
@@ -218,7 +217,7 @@ static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_case
     // Clamp lines down to the next multiple of four when generating
     // reducedLines to avoid existing x86 implementations over-writing.
     unsigned lines        = 1 << rng.get( 1, 6 );
-    unsigned reducedLines = lines == 2 ? lines : std::min( 32u, rng.get( 4u, lines, 4 ) );
+    unsigned reducedLines = lines == 2 ? lines : std::min( 32u, rng.get( 0, lines, 4 ) );
     unsigned cutoff       = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     if( !check_one_fastInvCore( ref, opt, idx, trSize, lines, reducedLines, cutoff, g, t ) )
     {
@@ -241,7 +240,7 @@ static bool check_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned num_c
     // Clamp line down to the next multiple of four when generating reducedLine
     // to avoid existing x86 implementations over-writing.
     unsigned line        = 1 << rng.get( 1, 6 );
-    unsigned reducedLine = line == 2 ? 2 : std::min( 32u, rng.get( 4u, line, 4 ) );
+    unsigned reducedLine = line == 2 ? 2 : std::min( 32u, rng.get( 0, line, 4 ) );
     unsigned cutoff      = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     unsigned shift       = rng.get( 1, 16 );          // Shift must be at least one to avoid UB.
     if( !check_one_fastFwdCore_2D( ref, opt, idx, trSize, line, reducedLine, cutoff, shift, g, t ) )

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -216,8 +216,8 @@ static bool check_fastInvCore( TCoeffOps* ref, TCoeffOps* opt, unsigned num_case
   {
     // Clamp lines down to the next multiple of four when generating
     // reducedLines to avoid existing x86 implementations over-writing.
-    unsigned lines        = 1 << rng.get( 2, 6 );
-    unsigned reducedLines = std::min( 32u, rng.get( 4u, lines, 4 ) );
+    unsigned lines        = 1 << rng.get( 1, 6 );
+    unsigned reducedLines = lines == 2 ? lines : std::min( 32u, rng.get( 4u, lines, 4 ) );
     unsigned cutoff       = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     if( !check_one_fastInvCore( ref, opt, idx, trSize, lines, reducedLines, cutoff, g, t ) )
     {
@@ -239,8 +239,8 @@ static bool check_fastFwdCore_2D( TCoeffOps* ref, TCoeffOps* opt, unsigned num_c
   {
     // Clamp line down to the next multiple of four when generating reducedLine
     // to avoid existing x86 implementations over-writing.
-    unsigned line        = 1 << rng.get( 2, 6 );
-    unsigned reducedLine = std::min( 32u, rng.get( 4u, line, 4 ) );
+    unsigned line        = 1 << rng.get( 1, 6 );
+    unsigned reducedLine = line == 2 ? 2 : std::min( 32u, rng.get( 4u, line, 4 ) );
     unsigned cutoff      = rng.get( 4, trSize, 4 );  // Cutoff must be a non-zero multiple of four.
     unsigned shift       = rng.get( 1, 16 );          // Shift must be at least one to avoid UB.
     if( !check_one_fastFwdCore_2D( ref, opt, idx, trSize, line, reducedLine, cutoff, shift, g, t ) )


### PR DESCRIPTION
* ensure only actually occuring cases are tested
* ensure only bitdepths are used that actually occur in the codec
  * signed 8 bit for transformation
  * signed 16 bit for coefficients
  * signed 11 bit for residual