### PR TITLE
Add unit test for checking jumps backwards in DTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,7 @@ add_subdirectory( "source/App/vvencapp" )
 add_subdirectory( "source/App/vvencFFapp" )
 add_subdirectory( "test/vvenclibtest" )
 add_subdirectory( "test/vvencinterfacetest" )
+add_subdirectory( "test/vvencdtstest" )
 
 if( NOT BUILD_SHARED_LIBS )
   add_subdirectory( "test/vvenc_unit_test" )

--- a/test/vvencdtstest/CMakeLists.txt
+++ b/test/vvencdtstest/CMakeLists.txt
@@ -1,0 +1,37 @@
+# executable
+set( EXE_NAME vvencdtstest )
+
+# get source files
+file( GLOB SRC_FILES CONFIGURE_DEPENDS "*.c" )
+
+# get include files
+file( GLOB INC_FILES CONFIGURE_DEPENDS "*.h" )
+
+# set resource file for MSVC compilers
+if( MSVC )
+  set( RESOURCE_FILE ${EXE_NAME}.rc )
+endif()
+
+# add executable
+add_executable( ${EXE_NAME} ${SRC_FILES} ${INC_FILES} ${RESOURCE_FILE} )
+set_target_properties( ${EXE_NAME} PROPERTIES RELEASE_POSTFIX        "${CMAKE_RELEASE_POSTFIX}" )
+set_target_properties( ${EXE_NAME} PROPERTIES DEBUG_POSTFIX          "${CMAKE_DEBUG_POSTFIX}" )
+set_target_properties( ${EXE_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX "${CMAKE_RELWITHDEBINFO_POSTFIX}" )
+set_target_properties( ${EXE_NAME} PROPERTIES MINSIZEREL_POSTFIX     "${CMAKE_MINSIZEREL_POSTFIX}" )
+if( VVENC_LIBRARY_ONLY )
+  set_target_properties( ${EXE_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE )
+endif()
+
+target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
+                                            $<$<CXX_COMPILER_ID:GNU>:-Wall -fdiagnostics-show-option>
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4100 /wd4244 /wd4251 /wd4996>)
+
+target_link_libraries( ${EXE_NAME} vvenc )
+
+# example: place header files in different folders
+source_group( "Header Files"   FILES ${INC_FILES} )
+source_group( "Resource Files" FILES ${RESOURCE_FILE} )
+
+
+# set the folder where to place the projects
+set_target_properties( ${EXE_NAME}  PROPERTIES FOLDER test )

--- a/test/vvencdtstest/vvencdtstest.c
+++ b/test/vvencdtstest/vvencdtstest.c
@@ -1,0 +1,160 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2024, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------------------- */
+
+/**
+  \file    vvencdtstest.c
+  \brief   This vvencdtstest.c file checks the DTS that the encoder outputs are
+           monotonic increasing.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "vvenc/vvenc.h"
+#include "vvenc/vvencCfg.h"
+
+#define WIDTH 64
+#define HEIGHT 64
+#define FRAMES 20
+
+#ifdef NDEBUG
+#error "Please build this test with NDEBUG undefined"
+#endif
+
+static void init_in_buf( vvencYUVBuffer *in_buf, uint64_t seq );
+static void init_out_buf( vvencAccessUnit *out_buf );
+static bool check_dts( const vvencAccessUnit *out_buf, int64_t last_dts );
+
+int main( int argc, char* argv[] )
+{
+  vvencAccessUnit out_buf;
+  vvencYUVBuffer in_buf;
+  bool success = true;
+  vvencEncoder *enc;
+  uint64_t last_dts;
+  vvenc_config cfg;
+  bool enc_done;
+  int ret;
+
+  // Config
+  vvenc_init_default( &cfg, WIDTH, HEIGHT, 30, 0, VVENC_DEFAULT_QP, VVENC_FAST );
+  cfg.m_TicksPerSecond = -1;
+  enc = vvenc_encoder_create();
+  assert( enc );
+  ret = vvenc_encoder_open( enc, &cfg );
+  assert( ret == 0 );
+
+  // Encode
+  init_out_buf( &out_buf );
+  last_dts = -10;
+  for ( uint64_t i = 0, seq = 0; i < FRAMES; i++, seq++ ) {
+    init_in_buf( &in_buf, seq );
+    ret = vvenc_encode( enc, &in_buf, &out_buf, &enc_done );
+    assert( ret == 0 );
+
+    if ( out_buf.payloadUsedSize > 0 ) {
+      success = check_dts( &out_buf, last_dts ) && success;
+      last_dts = out_buf.dts;
+    }
+
+    if ( i == FRAMES / 2 )
+      seq += 10; // Jump cts forward
+  }
+
+  // Drain
+  do {
+    ret = vvenc_encode( enc, NULL, &out_buf, &enc_done );
+    assert( ret == 0 );
+
+    success = check_dts( &out_buf, last_dts ) && success;
+    last_dts = out_buf.dts;
+  } while ( !enc_done && (out_buf.payloadUsedSize > 0) );
+
+  vvenc_encoder_close( enc );
+  return success? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+
+static void init_in_buf( vvencYUVBuffer *in_buf, uint64_t seq )
+{
+  static int16_t plane[WIDTH * HEIGHT];
+
+  in_buf->planes[0].ptr = plane;
+  in_buf->planes[0].width = WIDTH;
+  in_buf->planes[0].height = HEIGHT;
+  in_buf->planes[0].stride = WIDTH;
+
+  in_buf->planes[1].ptr = plane;
+  in_buf->planes[1].width = WIDTH / 2;
+  in_buf->planes[1].height = HEIGHT / 2;
+  in_buf->planes[1].stride = WIDTH / 2;
+
+  in_buf->planes[2].ptr = plane;
+  in_buf->planes[2].width = WIDTH / 2;
+  in_buf->planes[2].height = HEIGHT / 2;
+  in_buf->planes[2].stride = WIDTH / 2;
+
+  in_buf->sequenceNumber = seq;
+  in_buf->cts = seq;
+  in_buf->ctsValid = true;
+}
+
+static void init_out_buf( vvencAccessUnit *out_buf )
+{
+  static unsigned char payload[WIDTH * HEIGHT];
+
+  out_buf->payload = payload;
+  out_buf->payloadSize = WIDTH * HEIGHT;
+}
+
+static bool check_dts( const vvencAccessUnit *out_buf, int64_t last_dts )
+{
+  printf( "% 3ld", out_buf->dts );
+
+  if ( (int64_t) out_buf->dts < last_dts ) {
+    printf( "\t[jump backwards]\n" );
+    return false;
+  }
+
+  printf( "\n" );
+  return true;
+}

--- a/test/vvencdtstest/vvencdtstest.rc
+++ b/test/vvencdtstest/vvencdtstest.rc
@@ -1,0 +1,153 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2024, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "resource.h"
+#include "resource_version.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral (Default) (unknown sub-lang: 0x8) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ZZZ)
+LANGUAGE LANG_NEUTRAL, 0x8
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION VS_FILE_VERSION
+ PRODUCTVERSION VS_FILE_VERSION
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "200004b0"
+        BEGIN
+            VALUE "CompanyName", "Fraunhofer Heinrich Hertz Institute"
+            VALUE "FileDescription", "vvencdtstest Test"
+            VALUE "FileVersion", VS_FILE_VERSION_STR
+            VALUE "InternalName", "vvencdtstest.exe"
+            VALUE "LegalCopyright", "(c) Copyright (2019-2023) Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V"
+            VALUE "OriginalFilename", "vvencdtstest.exe"
+            VALUE "ProductName", "vvencdtstest"
+            VALUE "ProductVersion", VS_FILE_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x2000, 1200
+    END
+END
+
+#endif    // Neutral (Default) (unknown sub-lang: 0x8) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+


### PR DESCRIPTION
This simple test checks for any jump backward in the DTS that the encoder outputs.

Right now the test is failing:
```sh
$ make debug && bin/debug-static/vvencdtstest
...
  5
 -4	[jump backwards]
 -3
 -2
 -1
  0
  1
  2
  3
 14
  5	[jump backwards]
  6
  7
 18
 19
 20
 21
 22
 23
 24
 $ echo $?
 1
 ```