### PR TITLE
Fix issue #479 (fix dts calculation when frames are missing on input)

### DIFF
--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -172,6 +172,8 @@ Picture::Picture()
     , sliceDataNumBins    ( 0 )
     , cts                 ( 0 )
     , ctsValid            ( false )
+    , picsInMissing       ( 0 )
+    , picOutOffset        ( 0 )
     , isPreAnalysis       ( false )
     , m_picShared         ( nullptr )
     , gopAdaptedQP        ( 0 )
@@ -245,6 +247,11 @@ void Picture::reset()
   encRCPic             = nullptr;
   picApsGlobal         = nullptr;
   refApsGlobal         = nullptr;
+
+  cts                  = 0;
+  ctsValid             = false;
+  picsInMissing        = 0;
+  picOutOffset         = 0;
 
   picVA.reset();
 

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -242,6 +242,8 @@ public:
   int                           sliceDataNumBins;
   uint64_t                      cts;
   bool                          ctsValid;
+  int64_t                       picsInMissing;      // summed up missing frames on input
+  int64_t                       picOutOffset;       // signalization of pic offset to re-calc dts
   bool                          isPreAnalysis;
 
   PicShared*                    m_picShared;

--- a/source/Lib/EncoderLib/EncGOP.h
+++ b/source/Lib/EncoderLib/EncGOP.h
@@ -149,6 +149,9 @@ private:
   bool                      m_disableLMCSIP;
   int                       m_lastCodingNum;
   int                       m_numPicsCoded;
+  int                       m_numPicsInMissing;
+  int                       m_numPicsOutOffset;
+  uint64_t                  m_lastCts;
   int                       m_pocRecOut;
   int                       m_ticksPerFrameMul4;
   int                       m_lastIDR;


### PR DESCRIPTION
- fixes issue #479 
- detect if frames are missing on input depending on timestamps (cts)
- dts is now calculated depending on missing frames
- adding test case 'checkDtsDefault'