### PR TITLE
Fix unit test execution when building in shared linking mode

### DIFF
--- a/cmake/modules/vvencTests.cmake
+++ b/cmake/modules/vvencTests.cmake
@@ -19,7 +19,9 @@ add_test( NAME Test_vvenclibtest-sdk_default             COMMAND vvenclibtest 4 
 add_test( NAME Test_vvenclibtest-sdk_stringapi_interface COMMAND vvenclibtest 5 )
 add_test( NAME Test_vvenclibtest-timestamps              COMMAND vvenclibtest 6 )
 
-add_test( NAME Test_vvenc_unit_test COMMAND vvenc_unit_test )
+if( NOT BUILD_SHARED_LIBS )
+  add_test( NAME Test_vvenc_unit_test COMMAND vvenc_unit_test )
+endif()
 
 set( CLEANUP_TEST_FILES "" )
 


### PR DESCRIPTION
The unit test is built only when static linking, but the test itself was still being invoked when running `ctest` in shared linking mode. This leads to the following test failure in  `ctest`:

```
Could not find executable vvenc_unit_test.
```

This adds a fix so the unit test is not run in shared builds.
