### PR TITLE
Add missing header for stdarg

### DIFF
--- a/include/vvenc/vvencCfg.h
+++ b/include/vvenc/vvencCfg.h
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 #define VVENC_NAMESPACE_BEGIN
 #define VVENC_NAMESPACE_END


### PR DESCRIPTION
```
[ 61%] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc.dir/__/EncoderLib/EncAdaptiveLoopFilter.cpp.o
In file included from /home/brad/tmp/vvenc/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp:48:
In file included from /home/brad/tmp/vvenc/source/Lib/vvenc/../EncoderLib/EncAdaptiveLoopFilter.h:48:
/home/brad/tmp/vvenc/source/Lib/vvenc/../../../include/vvenc/vvencCfg.h:72:63: error: unknown type name 'va_list'; did you mean '__va_list'?
typedef void (*vvencLoggingCallback)(void*, int, const char*, va_list);
                                                              ^~~~~~~
                                                              __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
typedef __builtin_va_list       __va_list;
                                ^
1 error generated.
```