### PR TITLE
Fix SSE4.1 crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,6 @@ endif()
 
 # enable sse4.1 build for all source files for gcc and clang
 if( VVENC_ENABLE_X86_SIMD )
-  if( UNIX OR MINGW )
-    # when building for non-x86, but emulating simd using simd-everywhere (e.g. on ARM),
-    # the x86-compiler flags are not understood by the compiler
-    set_if_compiler_supports_flag( FLAG_msse41 -msse4.1 )
-    add_compile_options( ${FLAG_msse41} )
-  endif()
-
   if( NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" )
     check_missing_intrinsics()
   endif()

--- a/source/Lib/CommonLib/x86/CommonDefX86.cpp
+++ b/source/Lib/CommonLib/x86/CommonDefX86.cpp
@@ -277,12 +277,19 @@ X86_VEXT read_x86_extension_flags( X86_VEXT request )
     if( request > max_supported )
     {
 #ifdef REAL_TARGET_X86
-      THROW( "requested SIMD level (" << request << ") not supported by current CPU (max " << max_supported << ")." );
+      THROW( "requested SIMD level (" << x86_vext_to_string( request ) << ") not supported by current CPU (max " << x86_vext_to_string( max_supported ) << ")." );
 #endif
     }
 
     ext_flags = request;
   }
+
+#ifdef REAL_TARGET_X86
+  if( max_supported < X86_SIMD_SSE41 )
+  {
+    THROW( "maximum SIMD level of current CPU is " << x86_vext_to_string( max_supported ) << " but at least SSE4.1 is required." );
+  }
+#endif
 
   return ext_flags;
 }

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -118,6 +118,10 @@ if( VVENC_ENABLE_X86_SIMD )
     set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse42}" )
     set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "${FLAG_mavx}"   )
     set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "${FLAG_mavx2}"  )
+    
+    set_source_files_properties( ../EncoderLib/EncAdaptiveLoopFilter.cpp APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse41}" )
+    set_source_files_properties( ../CommonLib/LoopFilter.cpp APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse41}" )
+    set_source_files_properties( ../CommonLib/QuantRDOQ2.cpp APPEND PROPERTY COMPILE_FLAGS "${FLAG_msse41}" )
   endif()
 
   add_library( ${LIB_NAME}_x86_simd OBJECT ${SSE41_SRC_FILES} ${SSE42_SRC_FILES} ${AVX_SRC_FILES} ${AVX2_SRC_FILES} )


### PR DESCRIPTION
- msse4.1 flag is added only for designated files
- throw error if cpu does not support SSE4.1
- fixes issue #493 