### PR TITLE
SEI: implement sdi and aci writers

### DIFF
--- a/source/Lib/CommonLib/SEI.cpp
+++ b/source/Lib/CommonLib/SEI.cpp
@@ -139,6 +139,7 @@ const char *SEI::getSEIMessageString(SEI::PayloadType payloadType)
     case SEI::GENERALIZED_CUBEMAP_PROJECTION:       return "Generalized cubemap projection";
     case SEI::SAMPLE_ASPECT_RATIO_INFO:             return "Sample aspect ratio information";
     case SEI::SUBPICTURE_LEVEL_INFO:                return "Subpicture level information";
+    case SEI::ALPHA_CHANNEL:                        return "Alpha channel information";
     default:                                        return "Unknown";
   }
 }

--- a/source/Lib/CommonLib/SEI.cpp
+++ b/source/Lib/CommonLib/SEI.cpp
@@ -140,6 +140,7 @@ const char *SEI::getSEIMessageString(SEI::PayloadType payloadType)
     case SEI::SAMPLE_ASPECT_RATIO_INFO:             return "Sample aspect ratio information";
     case SEI::SUBPICTURE_LEVEL_INFO:                return "Subpicture level information";
     case SEI::ALPHA_CHANNEL:                        return "Alpha channel information";
+    case SEI::SCALABILITY_DIMENSION_INFO:           return "Scalability dimension information";
     default:                                        return "Unknown";
   }
 }

--- a/source/Lib/CommonLib/SEI.h
+++ b/source/Lib/CommonLib/SEI.h
@@ -86,6 +86,7 @@ public:
     AMBIENT_VIEWING_ENVIRONMENT          = 148,
     CONTENT_COLOUR_VOLUME                = 149,
     ALPHA_CHANNEL                        = 165,
+    SCALABILITY_DIMENSION_INFO           = 208,
   };
 
   SEI() {}
@@ -255,6 +256,30 @@ public:
   bool     alphaChannelIncrFlag;
   bool     alphaChannelClipFlag;
   bool     alphaChannelClipTypeFlag;
+};
+
+class SEIScalabilityDimensionInfo : public SEI
+{
+public:
+  PayloadType payloadType() const { return SCALABILITY_DIMENSION_INFO; }
+
+  SEIScalabilityDimensionInfo()
+    : sdiMaxLayersMinus1(0)
+    , sdiMultiviewInfoFlag(false)
+    , sdiAuxiliaryInfoFlag(false)
+    , sdiViewIdLenMinus1(0)
+    {}
+  virtual ~SEIScalabilityDimensionInfo() {}
+
+  uint32_t sdiMaxLayersMinus1;
+  bool sdiMultiviewInfoFlag;
+  bool sdiAuxiliaryInfoFlag;
+  u_int32_t sdiViewIdLenMinus1;
+  std::vector<u_int32_t> sdiLayerId;
+  std::vector<u_int32_t> sdiViewIdVal;
+  std::vector<u_int32_t> sdiAuxId;
+  std::vector<u_int32_t> sdiNumAssociatedPrimaryLayersMinus1;
+  std::vector<std::vector<u_int32_t>>  sdiAssociatedPrimaryLayerIdx;
 };
 
 static const uint32_t ISO_IEC_11578_LEN=16;

--- a/source/Lib/CommonLib/SEI.h
+++ b/source/Lib/CommonLib/SEI.h
@@ -85,6 +85,7 @@ public:
     ALTERNATIVE_TRANSFER_CHARACTERISTICS = 147,
     AMBIENT_VIEWING_ENVIRONMENT          = 148,
     CONTENT_COLOUR_VOLUME                = 149,
+    ALPHA_CHANNEL                        = 165,
   };
 
   SEI() {}
@@ -227,6 +228,33 @@ public:
   int                   sariAspectRatioIdc;
   int                   sariSarWidth;
   int                   sariSarHeight;
+};
+
+class SEIAlphaChannelInfo : public SEI
+{
+public:
+  PayloadType payloadType() const { return ALPHA_CHANNEL; }
+
+  SEIAlphaChannelInfo()
+    : alphaChannelCancelFlag(false)
+    , alphaChannelUseIdc(0)
+    , alphaChannelBitDepthMinus8(0)
+    , alphaTransparentValue(0)
+    , alphaOpaqueValue(0)
+    , alphaChannelIncrFlag(false)
+    , alphaChannelClipFlag(false)
+    , alphaChannelClipTypeFlag(false)
+    {}
+  virtual ~SEIAlphaChannelInfo() {}
+
+  bool     alphaChannelCancelFlag;
+  uint32_t alphaChannelUseIdc;
+  uint32_t alphaChannelBitDepthMinus8;
+  uint32_t alphaTransparentValue;
+  uint32_t alphaOpaqueValue;
+  bool     alphaChannelIncrFlag;
+  bool     alphaChannelClipFlag;
+  bool     alphaChannelClipTypeFlag;
 };
 
 static const uint32_t ISO_IEC_11578_LEN=16;

--- a/source/Lib/EncoderLib/SEIwrite.cpp
+++ b/source/Lib/EncoderLib/SEIwrite.cpp
@@ -137,6 +137,9 @@ void SEIWriter::xWriteSEIpayloadData(OutputBitstream &bs, const SEI& sei, HRD &h
   case SEI::SAMPLE_ASPECT_RATIO_INFO:
     xWriteSEISampleAspectRatioInfo(*static_cast<const SEISampleAspectRatioInfo*>(&sei));
     break;
+  case SEI::ALPHA_CHANNEL:
+    xWriteSEIAlphaChannelInfo(*static_cast<const SEIAlphaChannelInfo*>(&sei));
+    break;
   default:
     THROW("Trying to write unhandled SEI message");
     break;
@@ -802,6 +805,24 @@ void SEIWriter::xWriteSEISampleAspectRatioInfo(const SEISampleAspectRatioInfo &s
     {
       WRITE_CODE( (uint32_t)sei.sariSarWidth, 16,                           "sari_sar_width");
       WRITE_CODE( (uint32_t)sei.sariSarHeight, 16,                           "sari_sar_height");
+    }
+  }
+}
+
+void SEIWriter::xWriteSEIAlphaChannelInfo(const SEIAlphaChannelInfo &sei)
+{
+  WRITE_FLAG( sei.alphaChannelCancelFlag,                                       "alpha_channel_cancel_flag" );
+  if(!sei.alphaChannelCancelFlag)
+  {
+    WRITE_CODE( sei.alphaChannelUseIdc, 3,                                      "alpha_channel_use_idc" );
+    WRITE_CODE( sei.alphaChannelBitDepthMinus8, 3,                              "alpha_channel_bit_depth_minus8" );
+    WRITE_CODE( sei.alphaTransparentValue, sei.alphaChannelBitDepthMinus8 + 9,  "alpha_channel_transparent_value" );
+    WRITE_CODE( sei.alphaOpaqueValue,sei.alphaChannelBitDepthMinus8 + 9,        "alpha_channel_opaque_value" );
+    WRITE_FLAG( sei.alphaChannelIncrFlag,                                       "alpha_channel_incr_flag" );
+    WRITE_FLAG( sei.alphaChannelClipFlag,                                       "alpha_channel_clip_flag" );
+    if ( sei.alphaChannelIncrFlag)
+    {
+      WRITE_FLAG( sei.alphaChannelClipTypeFlag,                                 "alpha_channel_clip_type_flag" );
     }
   }
 }

--- a/source/Lib/EncoderLib/SEIwrite.cpp
+++ b/source/Lib/EncoderLib/SEIwrite.cpp
@@ -140,6 +140,9 @@ void SEIWriter::xWriteSEIpayloadData(OutputBitstream &bs, const SEI& sei, HRD &h
   case SEI::ALPHA_CHANNEL:
     xWriteSEIAlphaChannelInfo(*static_cast<const SEIAlphaChannelInfo*>(&sei));
     break;
+  case SEI::SCALABILITY_DIMENSION_INFO:
+    xWriteSEIScalabilityDimensionInfo(*static_cast<const SEIScalabilityDimensionInfo*>(&sei));
+    break;
   default:
     THROW("Trying to write unhandled SEI message");
     break;
@@ -823,6 +826,40 @@ void SEIWriter::xWriteSEIAlphaChannelInfo(const SEIAlphaChannelInfo &sei)
     if ( sei.alphaChannelIncrFlag)
     {
       WRITE_FLAG( sei.alphaChannelClipTypeFlag,                                 "alpha_channel_clip_type_flag" );
+    }
+  }
+}
+
+void SEIWriter::xWriteSEIScalabilityDimensionInfo(const SEIScalabilityDimensionInfo &sei)
+{
+  WRITE_CODE( sei.sdiMaxLayersMinus1, 6,                                "sdi_max_layers_minus1");
+  WRITE_FLAG( sei.sdiMultiviewInfoFlag,                                 "sdi_multiview_info_flag");
+  WRITE_FLAG( sei.sdiAuxiliaryInfoFlag,                                 "sdi_auxiliary_info_flag");
+  if (sei.sdiMultiviewInfoFlag || sei.sdiAuxiliaryInfoFlag)
+  {
+    if (sei.sdiMultiviewInfoFlag)
+    {
+      WRITE_CODE( sei.sdiViewIdLenMinus1, 4,                            "sdi_view_id_len_minus1");
+    }
+    for (unsigned int i=0; i<=sei.sdiMaxLayersMinus1; i++)
+    {
+      WRITE_CODE( sei.sdiLayerId[i], 6,                                 "sdi_layer_id");
+      if (sei.sdiMultiviewInfoFlag)
+      {
+        WRITE_CODE( sei.sdiViewIdVal[i], sei.sdiViewIdLenMinus1+1,      "sdi_view_id_val");
+      }
+      if (sei.sdiAuxiliaryInfoFlag)
+      {
+        WRITE_CODE( sei.sdiAuxId[i], 8,                                 "sdi_aux_id");
+        if (sei.sdiAuxId[i]>0)
+        {
+          WRITE_CODE( sei.sdiNumAssociatedPrimaryLayersMinus1[i], 6,    "sdi_num_associated_primary_layers_minus1");
+          for (unsigned int j=0; j<=sei.sdiNumAssociatedPrimaryLayersMinus1[i]; j++)
+          {
+            WRITE_CODE( sei.sdiAssociatedPrimaryLayerIdx[i][j], 6,      "sdi_associated_primary_layer_idx");
+          }
+        }
+      }
     }
   }
 }

--- a/source/Lib/EncoderLib/SEIwrite.h
+++ b/source/Lib/EncoderLib/SEIwrite.h
@@ -82,6 +82,7 @@ protected:
   void xWriteSEIGeneralizedCubemapProjection      (const SEIGeneralizedCubemapProjection &sei);
   void xWriteSEISubpictureLevelInfo               (const SEISubpicureLevelInfo &sei);
   void xWriteSEISampleAspectRatioInfo             (const SEISampleAspectRatioInfo &sei);
+  void xWriteSEIAlphaChannelInfo                  (const SEIAlphaChannelInfo &sei);
 
   void xWriteSEIUserDataRegistered(const SEIUserDataRegistered& sei);
   void xWriteSeiFgc(const SeiFgc& sei);

--- a/source/Lib/EncoderLib/SEIwrite.h
+++ b/source/Lib/EncoderLib/SEIwrite.h
@@ -83,6 +83,7 @@ protected:
   void xWriteSEISubpictureLevelInfo               (const SEISubpicureLevelInfo &sei);
   void xWriteSEISampleAspectRatioInfo             (const SEISampleAspectRatioInfo &sei);
   void xWriteSEIAlphaChannelInfo                  (const SEIAlphaChannelInfo &sei);
+  void xWriteSEIScalabilityDimensionInfo          (const SEIScalabilityDimensionInfo &sei);
 
   void xWriteSEIUserDataRegistered(const SEIUserDataRegistered& sei);
   void xWriteSeiFgc(const SeiFgc& sei);


### PR DESCRIPTION
In order to enable alpha channel signalling, this PR implements the SEI writers, which is a part of needs for that aim:
* ITU 274 8.19: Scalability Dimension Info
* ITU 274 8.23: Alpha Channel 