### PR TITLE
Fix 32-bit Arm build when VVENC_ENABLE_ARM_SIMD is disabled

### DIFF
--- a/source/Lib/CommonLib/x86/BufferX86.h
+++ b/source/Lib/CommonLib/x86/BufferX86.h
@@ -1888,9 +1888,9 @@ uint64_t AvgHighPass_SIMD( const int width, const int height, const Pel* pSrc, c
       for (x = 1; x < width-1-6; x += 6)
       {
         sum=0;
-        lineM1 = _mm_lddqu_si128 ((__m128i*) &pSrc[ (y -1)  *iSrcStride + x-1]);
-        line0  = _mm_lddqu_si128 ((__m128i*) &pSrc [(y)*iSrcStride + x-1]);
-        lineP1 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-1]);
+        lineM1 = _mm_loadu_si128 ((__m128i*) &pSrc[ (y -1)  *iSrcStride + x-1]);
+        line0  = _mm_loadu_si128 ((__m128i*) &pSrc [(y)*iSrcStride + x-1]);
+        lineP1 = _mm_loadu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-1]);
 
         tmp1 = _mm_madd_epi16 (line0, scale0);
         tmp2 = _mm_madd_epi16 (lineP1, scale1);
@@ -1917,9 +1917,9 @@ uint64_t AvgHighPass_SIMD( const int width, const int height, const Pel* pSrc, c
 
         sum+=_mm_extract_epi32 (tmp1, 0);
 
-        lineM1 = _mm_lddqu_si128 ((__m128i*) &pSrc[ (y -1)  *iSrcStride + x-1+2]);
-        line0  = _mm_lddqu_si128((__m128i*) &pSrc [(y)*iSrcStride + x-1+2]);
-        lineP1 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-1+2]);
+        lineM1 = _mm_loadu_si128 ((__m128i*) &pSrc[ (y -1)  *iSrcStride + x-1+2]);
+        line0  = _mm_loadu_si128 ((__m128i*) &pSrc [(y)*iSrcStride + x-1+2]);
+        lineP1 = _mm_loadu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-1+2]);
         tmp1 = _mm_madd_epi16 (line0, scale00);
         tmp2 = _mm_madd_epi16 (lineP1, scale11);
         tmp3 = _mm_madd_epi16 (lineM1, scale11);
@@ -1947,6 +1947,7 @@ uint64_t AvgHighPass_SIMD( const int width, const int height, const Pel* pSrc, c
         sum+=_mm_extract_epi32 (tmp1, 0);
         saAct += (uint64_t) sum;
       }
+
       // last collum
       for (; x < width - 1; x++) //
       {
@@ -1974,8 +1975,8 @@ uint64_t HDHighPass_SIMD  (const int width, const int height,const Pel*  pSrc,co
     {
       for (x = 1; x < width - 1-8 ; x+=8)  // cnt cols
       {
-        __m128i M0 = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-        __m128i M1 = _mm_lddqu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
+        __m128i M0 = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+        __m128i M1 = _mm_loadu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
         M1 = _mm_sub_epi16 (M0, M1);
         M1 = _mm_abs_epi16 (M1);
         M1 = _mm_hadd_epi16 (M1, M1);
@@ -1992,8 +1993,8 @@ uint64_t HDHighPass_SIMD  (const int width, const int height,const Pel*  pSrc,co
         taAct += (uint64_t)act;
       }
       // last collum
-      __m128i M0 = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i M1 = _mm_lddqu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
+      __m128i M0 = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i M1 = _mm_loadu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
 
       M1 = _mm_sub_epi16 (M0, M1);
       M1 = _mm_abs_epi16 (M1);
@@ -2091,9 +2092,9 @@ uint64_t  HDHighPass2_SIMD  (const int width, const int height,const Pel*  pSrc,
     {
       for (x = 1; x < width - 1-8 ; x+=8)  // cnt cols
       {
-        __m128i M0 = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-        __m128i M1 = _mm_lddqu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
-        __m128i M2 = _mm_lddqu_si128 ((__m128i*) &pSM2  [y *iSM2Stride + x]);
+        __m128i M0 = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+        __m128i M1 = _mm_loadu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
+        __m128i M2 = _mm_loadu_si128 ((__m128i*) &pSM2  [y *iSM2Stride + x]);
         M1 = _mm_slli_epi16 (M1, 1);
         M1 = _mm_sub_epi16 (M0, M1);
         M1 = _mm_add_epi16 (M1,M2);
@@ -2106,9 +2107,9 @@ uint64_t  HDHighPass2_SIMD  (const int width, const int height,const Pel*  pSrc,
         taAct += (uint64_t)act;
       }
       // last collum
-      __m128i M0 = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i M1 = _mm_lddqu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
-      __m128i M2 = _mm_lddqu_si128 ((__m128i*) &pSM2  [y *iSM2Stride + x]);
+      __m128i M0 = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i M1 = _mm_loadu_si128 ((__m128i*) &pSM1  [y *iSM1Stride + x]);
+      __m128i M2 = _mm_loadu_si128 ((__m128i*) &pSM2  [y *iSM2Stride + x]);
       M1 = _mm_slli_epi16 (M1, 1);
       M1 = _mm_sub_epi16 (M0, M1);
       M1 = _mm_add_epi16 (M1,M2);
@@ -2302,12 +2303,12 @@ uint64_t AvgHighPassWithDownsampling_SIMD ( const int width, const int height, c
         for (int x = 2; x < width-2; x += 4)
         {
           {
-            lM2 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y-2)*iSrcStride + x-2]);
-            lM1 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y-1)*iSrcStride + x-2]);
-            l0  = _mm_lddqu_si128 ((__m128i*) &pSrc[ y   *iSrcStride + x-2]);
-            lP1 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-2]);
-            lP2 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y+2)*iSrcStride + x-2]);
-            lP3 = _mm_lddqu_si128 ((__m128i*) &pSrc[(y+3)*iSrcStride + x-2]);
+            lM2 = _mm_loadu_si128 ((__m128i*) &pSrc[(y-2)*iSrcStride + x-2]);
+            lM1 = _mm_loadu_si128 ((__m128i*) &pSrc[(y-1)*iSrcStride + x-2]);
+            l0  = _mm_loadu_si128 ((__m128i*) &pSrc[ y   *iSrcStride + x-2]);
+            lP1 = _mm_loadu_si128 ((__m128i*) &pSrc[(y+1)*iSrcStride + x-2]);
+            lP2 = _mm_loadu_si128 ((__m128i*) &pSrc[(y+2)*iSrcStride + x-2]);
+            lP3 = _mm_loadu_si128 ((__m128i*) &pSrc[(y+3)*iSrcStride + x-2]);
 
             if ( x < width-2)
             {
@@ -2381,10 +2382,10 @@ uint64_t AvgHighPassWithDownsamplingDiff1st_SIMD (const int width, const int hei
   {
     for (x = 2; x < width-2-10; x += 8)
     {
-      __m128i lineM0u = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i lineM0d = _mm_lddqu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
-      __m128i lineM1u = _mm_lddqu_si128 ((__m128i*) &pSrcM1[ y   *iSrcM1Stride + x]);
-      __m128i lineM1d = _mm_lddqu_si128 ((__m128i*) &pSrcM1[(y+1)*iSrcM1Stride + x]);
+      __m128i lineM0u = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i lineM0d = _mm_loadu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
+      __m128i lineM1u = _mm_loadu_si128 ((__m128i*) &pSrcM1[ y   *iSrcM1Stride + x]);
+      __m128i lineM1d = _mm_loadu_si128 ((__m128i*) &pSrcM1[(y+1)*iSrcM1Stride + x]);
       __m128i M0 = _mm_add_epi16 (lineM0u, lineM0d);
       __m128i M1 = _mm_add_epi16 (lineM1u, lineM1d);
 
@@ -2405,10 +2406,10 @@ uint64_t AvgHighPassWithDownsamplingDiff1st_SIMD (const int width, const int hei
     }
     // last collum
     {
-      __m128i lineM0u = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i lineM0d = _mm_lddqu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
-      __m128i lineM1u = _mm_lddqu_si128 ((__m128i*) &pSrcM1[ y   *iSrcM1Stride + x]);
-      __m128i lineM1d = _mm_lddqu_si128 ((__m128i*) &pSrcM1[(y+1)*iSrcM1Stride + x]);
+      __m128i lineM0u = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i lineM0d = _mm_loadu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
+      __m128i lineM1u = _mm_loadu_si128 ((__m128i*) &pSrcM1[ y   *iSrcM1Stride + x]);
+      __m128i lineM1d = _mm_loadu_si128 ((__m128i*) &pSrcM1[(y+1)*iSrcM1Stride + x]);
       __m128i M0 = _mm_add_epi16 (lineM0u, lineM0d);
       __m128i M1 = _mm_add_epi16 (lineM1u, lineM1d);
       M1 = _mm_sub_epi16 (M0, M1); /* abs (sum (o[u0, u1, d0, d1]) - sum (oM1[u0, u1, d0, d1])) */
@@ -2469,12 +2470,12 @@ uint64_t AvgHighPassWithDownsamplingDiff2nd_SIMD (const int width,const int heig
   {
     for (x = 2; x < width-2-10; x += 8)
     {
-      __m128i lineM0u = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i lineM0d = _mm_lddqu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
-      __m128i lineM1u = _mm_lddqu_si128 ((__m128i*) &pSrcM1[ y   *iSM1Stride + x]);
-      __m128i lineM1d = _mm_lddqu_si128 ((__m128i*) &pSrcM1[(y+1)*iSM1Stride + x]);
-      __m128i lineM2u = _mm_lddqu_si128 ((__m128i*) &pSrcM2[ y   *iSM2Stride + x]);
-      __m128i lineM2d = _mm_lddqu_si128 ((__m128i*) &pSrcM2[(y+1)*iSM2Stride + x]);
+      __m128i lineM0u = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i lineM0d = _mm_loadu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
+      __m128i lineM1u = _mm_loadu_si128 ((__m128i*) &pSrcM1[ y   *iSM1Stride + x]);
+      __m128i lineM1d = _mm_loadu_si128 ((__m128i*) &pSrcM1[(y+1)*iSM1Stride + x]);
+      __m128i lineM2u = _mm_loadu_si128 ((__m128i*) &pSrcM2[ y   *iSM2Stride + x]);
+      __m128i lineM2d = _mm_loadu_si128 ((__m128i*) &pSrcM2[(y+1)*iSM2Stride + x]);
 
       __m128i M0 = _mm_add_epi16 (lineM0u, lineM0d);
       __m128i M1 = _mm_add_epi16 (lineM1u, lineM1d);
@@ -2494,12 +2495,12 @@ uint64_t AvgHighPassWithDownsamplingDiff2nd_SIMD (const int width,const int heig
     }
     // last collum
     {
-      __m128i lineM0u = _mm_lddqu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
-      __m128i lineM0d = _mm_lddqu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
-      __m128i lineM1u = _mm_lddqu_si128 ((__m128i*) &pSrcM1[ y   *iSM1Stride + x]);
-      __m128i lineM1d = _mm_lddqu_si128 ((__m128i*) &pSrcM1[(y+1)*iSM1Stride + x]);
-      __m128i lineM2u = _mm_lddqu_si128 ((__m128i*) &pSrcM2[ y   *iSM2Stride + x]);
-      __m128i lineM2d = _mm_lddqu_si128 ((__m128i*) &pSrcM2[(y+1)*iSM2Stride + x]);
+      __m128i lineM0u = _mm_loadu_si128 ((__m128i*) &pSrc  [ y   *iSrcStride + x]); /* load 8 16-bit values */
+      __m128i lineM0d = _mm_loadu_si128 ((__m128i*) &pSrc  [(y+1)*iSrcStride + x]);
+      __m128i lineM1u = _mm_loadu_si128 ((__m128i*) &pSrcM1[ y   *iSM1Stride + x]);
+      __m128i lineM1d = _mm_loadu_si128 ((__m128i*) &pSrcM1[(y+1)*iSM1Stride + x]);
+      __m128i lineM2u = _mm_loadu_si128 ((__m128i*) &pSrcM2[ y   *iSM2Stride + x]);
+      __m128i lineM2d = _mm_loadu_si128 ((__m128i*) &pSrcM2[(y+1)*iSM2Stride + x]);
 
       __m128i M0 = _mm_add_epi16 (lineM0u, lineM0d);
       __m128i M1 = _mm_add_epi16 (lineM1u, lineM1d);

--- a/source/Lib/CommonLib/x86/CommonDefX86.h
+++ b/source/Lib/CommonLib/x86/CommonDefX86.h
@@ -92,7 +92,7 @@ X86_VEXT           string_to_x86_vext( const std::string& ext_name );
 X86_VEXT           read_x86_extension_flags( X86_VEXT request = x86_simd::UNDEFINED );
 const std::string& read_x86_extension_name();
 
-#if (defined TARGET_SIMD_ARM && !defined REAL_TARGET_AARCH64)
+#if (defined REAL_TARGET_ARM && !defined REAL_TARGET_AARCH64)
 // _mm_loadl_epi64 / _mm_storel_epi64 could cause memory crash in 32 Bit ARM Architecture 
 #define _vv_loadl_epi64 _mm_loadu_si64
 #define _vv_storel_epi64 _mm_storeu_si64

--- a/source/Lib/CommonLib/x86/InterpolationFilterX86.h
+++ b/source/Lib/CommonLib/x86/InterpolationFilterX86.h
@@ -97,11 +97,11 @@ static void fullPelCopySSE( const ClpRng& clpRng, const void*_src, int srcStride
       {
         if( sizeof( Tsrc )==1 )
         {
-          vsrc = _mm_cvtepu8_epi16( _mm_lddqu_si128( ( __m128i const * )&src[col+i] ) );
+          vsrc = _mm_cvtepu8_epi16( _mm_loadu_si128( ( __m128i const * )&src[col+i] ) );
         }
         else
         {
-          vsrc = _mm_lddqu_si128( ( __m128i const * )&src[col+i] );
+          vsrc = _mm_loadu_si128( ( __m128i const * )&src[col+i] );
         }
 
         if( isFirst == isLast )
@@ -498,7 +498,7 @@ static void simdInterpolateHorM4( const int16_t* src, int srcStride, int16_t *ds
   __m128i voffset = _mm_set1_epi32( offset );
   __m128i vibdimin = _mm_set1_epi16( clpRng.min() );
   __m128i vibdimax = _mm_set1_epi16( clpRng.max() );
-  __m128i vcoeffh = _mm_lddqu_si128( ( __m128i const * )coeff );
+  __m128i vcoeffh = _mm_loadu_si128( ( __m128i const * )coeff );
 
   __m128i vzero, vshufc0, vshufc1;
   __m128i vsum;
@@ -522,8 +522,8 @@ static void simdInterpolateHorM4( const int16_t* src, int srcStride, int16_t *ds
         __m128i vtmp[2];
         for( int i = 0; i < 4; i += 2 )
         {
-          __m128i vsrc0 = _mm_lddqu_si128( ( __m128i const * )&src[col + i] );
-          __m128i vsrc1 = _mm_lddqu_si128( ( __m128i const * )&src[col + i + 1] );
+          __m128i vsrc0 = _mm_loadu_si128( ( __m128i const * )&src[col + i] );
+          __m128i vsrc1 = _mm_loadu_si128( ( __m128i const * )&src[col + i + 1] );
           vsrc0 = _mm_madd_epi16( vsrc0, vcoeffh );
           vsrc1 = _mm_madd_epi16( vsrc1, vcoeffh );
           vtmp[i / 2] = _mm_hadd_epi32( vsrc0, vsrc1 );
@@ -533,7 +533,7 @@ static void simdInterpolateHorM4( const int16_t* src, int srcStride, int16_t *ds
       else
       {
         __m128i vtmp0, vtmp1;
-        __m128i vsrc = _mm_lddqu_si128( ( __m128i const * )&src[col] );
+        __m128i vsrc = _mm_loadu_si128( ( __m128i const * )&src[col] );
         vtmp0 = _mm_shuffle_epi8( vsrc, vshufc0 );
         vtmp1 = _mm_shuffle_epi8( vsrc, vshufc1 );
 
@@ -1149,7 +1149,7 @@ static void simdInterpolateVerM8( const int16_t *src, int srcStride, int16_t *ds
   {
     for( int i = 0; i < N - 1; i++ )
     {
-      vsrc[i] = _mm_lddqu_si128( ( __m128i const * )&src[col + i * srcStride] );
+      vsrc[i] = _mm_loadu_si128( ( __m128i const * )&src[col + i * srcStride] );
     }
 
     for( int row = 0; row < height; row++ )
@@ -1157,7 +1157,7 @@ static void simdInterpolateVerM8( const int16_t *src, int srcStride, int16_t *ds
       cond_mm_prefetch( (const char *) &src[col + ( N + 0 ) * srcStride], _MM_HINT_T0 );
       cond_mm_prefetch( (const char *) &src[col + ( N + 1 ) * srcStride], _MM_HINT_T0 );
 
-      vsrc[N - 1] = _mm_lddqu_si128( ( __m128i const * )&src[col + ( N - 1 ) * srcStride] );
+      vsrc[N - 1] = _mm_loadu_si128( ( __m128i const * )&src[col + ( N - 1 ) * srcStride] );
       vsuma = vsumb = vzero;
       for( int i = 0; i < N; i += 2 )
       {
@@ -3343,8 +3343,8 @@ void xWeightedGeoBlk_SSE(const ClpRngs &clpRng, const CodingUnit& cu, const uint
     {
       for (int x = 0; x < width; x += 8)
       {
-        __m128i s0 = _mm_lddqu_si128((__m128i *) (src0 + x));
-        __m128i s1 = _mm_lddqu_si128((__m128i *) (src1 + x));
+        __m128i s0 = _mm_loadu_si128((__m128i *) (src0 + x));
+        __m128i s1 = _mm_loadu_si128((__m128i *) (src1 + x));
         __m128i w0;
         if (compIdx != COMP_Y && cu.chromaFormat != CHROMA_444)
         {
@@ -3353,16 +3353,16 @@ void xWeightedGeoBlk_SSE(const ClpRngs &clpRng, const CodingUnit& cu, const uint
           if (g_angle2mirror[angle] == 1)
           {
             w0p0 =
-              _mm_lddqu_si128((__m128i *) (weight - (x << 1) - (8 - 1)));   // first sub-sample the required weights.
-            w0p1 = _mm_lddqu_si128((__m128i *) (weight - (x << 1) - 8 - (8 - 1)));
+              _mm_loadu_si128((__m128i *) (weight - (x << 1) - (8 - 1)));   // first sub-sample the required weights.
+            w0p1 = _mm_loadu_si128((__m128i *) (weight - (x << 1) - 8 - (8 - 1)));
             const __m128i shuffle_mask = _mm_set_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
             w0p0 = _mm_shuffle_epi8(w0p0, shuffle_mask);
             w0p1 = _mm_shuffle_epi8(w0p1, shuffle_mask);
           }
           else
           {
-            w0p0 = _mm_lddqu_si128((__m128i *) (weight + (x << 1)));   // first sub-sample the required weights.
-            w0p1 = _mm_lddqu_si128((__m128i *) (weight + (x << 1) + 8));
+            w0p0 = _mm_loadu_si128((__m128i *) (weight + (x << 1)));   // first sub-sample the required weights.
+            w0p1 = _mm_loadu_si128((__m128i *) (weight + (x << 1) + 8));
           }
           w0p0 = _mm_mullo_epi16(w0p0, mask);
           w0p1 = _mm_mullo_epi16(w0p1, mask);
@@ -3372,13 +3372,13 @@ void xWeightedGeoBlk_SSE(const ClpRngs &clpRng, const CodingUnit& cu, const uint
         {
           if (g_angle2mirror[angle] == 1)
           {
-            w0 = _mm_lddqu_si128((__m128i *) (weight - x - (8 - 1)));
+            w0 = _mm_loadu_si128((__m128i *) (weight - x - (8 - 1)));
             const __m128i shuffle_mask = _mm_set_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
             w0 = _mm_shuffle_epi8(w0, shuffle_mask);
           }
           else
           {
-            w0 = _mm_lddqu_si128((__m128i *) (weight + x));
+            w0 = _mm_loadu_si128((__m128i *) (weight + x));
           }
         }
         __m128i w1 = _mm_sub_epi16(mmEight, w0);

--- a/source/Lib/CommonLib/x86/IntraPredX86.h
+++ b/source/Lib/CommonLib/x86/IntraPredX86.h
@@ -112,8 +112,8 @@ void IntraPredAngleChroma_SIMD(int16_t* pDst,const ptrdiff_t dstStride,int16_t* 
           // Do linear filtering
           for (int l=0; l<width; l+=8) {
             refMainIndex        = l+ deltaInt+1;
-            __m128i vpred0 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex]);
-            __m128i vpred1 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex+1]);
+            __m128i vpred0 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex]);
+            __m128i vpred1 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex+1]);
             vpred0 = _mm_mullo_epi16(v32minfract, vpred0);
             vpred1 = _mm_mullo_epi16(vfract, vpred1);
             __m128i vpred = _mm_srli_epi16(_mm_add_epi16(_mm_add_epi16(vpred0, vpred1), voffset), 5);
@@ -138,8 +138,8 @@ void IntraPredAngleChroma_SIMD(int16_t* pDst,const ptrdiff_t dstStride,int16_t* 
         // Do linear filtering
         for (int l=0; l<width; l+=8) {
           refMainIndex        = l+ deltaInt+1;
-          __m128i vpred0 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex]);
-          __m128i vpred1 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex+1]);
+          __m128i vpred0 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex]);
+          __m128i vpred1 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex+1]);
           vpred0 = _mm_mullo_epi16(v32minfract, vpred0);
           vpred1 = _mm_mullo_epi16(vfract, vpred1);
           __m128i vpred = _mm_srli_epi16(_mm_add_epi16(_mm_add_epi16(vpred0, vpred1), voffset), 5);
@@ -160,8 +160,8 @@ void IntraPredAngleChroma_SIMD(int16_t* pDst,const ptrdiff_t dstStride,int16_t* 
       __m128i v32minfract = _mm_set1_epi16(32-deltaFract);
       // Do linear filtering
       refMainIndex        = deltaInt+1;
-      __m128i vpred0 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex]);
-      __m128i vpred1 = _mm_lddqu_si128((__m128i*)&pBorder[refMainIndex+1]);
+      __m128i vpred0 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex]);
+      __m128i vpred1 = _mm_loadu_si128((__m128i*)&pBorder[refMainIndex+1]);
       vpred0 = _mm_mullo_epi16(v32minfract, vpred0);
       vpred1 = _mm_mullo_epi16(vfract, vpred1);
       __m128i vpred = _mm_srli_epi16(_mm_add_epi16(_mm_add_epi16(vpred0, vpred1), voffset), 5);

--- a/source/Lib/CommonLib/x86/RdCostX86.h
+++ b/source/Lib/CommonLib/x86/RdCostX86.h
@@ -104,7 +104,7 @@ Distortion RdCost::xGetSSE_SIMD( const DistParam &rcDtParam )
       for( int iX = 0; iX < iCols; iX += 8 )
       {
         __m128i Src1 = ( sizeof( Torg ) > 1 ) ? ( _mm_loadu_si128 ( ( const __m128i* )( &pSrc1[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc1[iX] ) ), _mm_setzero_si128() ) );
-        __m128i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm_lddqu_si128( ( const __m128i* )( &pSrc2[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc2[iX] ) ), _mm_setzero_si128() ) );
+        __m128i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm_loadu_si128( ( const __m128i* )( &pSrc2[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc2[iX] ) ), _mm_setzero_si128() ) );
         __m128i Diff = _mm_sub_epi16( Src1, Src2 );
         __m128i Res = _mm_madd_epi16( Diff, Diff );
         Sum = _mm_add_epi32( Sum, Res );
@@ -178,8 +178,8 @@ Distortion RdCost::xGetSSE_NxN_SIMD( const DistParam &rcDtParam )
       {
         for( int iX = 0; iX < iWidth; iX+=16 )
         {
-          __m256i Src1 = ( sizeof( Torg ) > 1 ) ? ( _mm256_lddqu_si256( ( __m256i* )( &pSrc1[iX] ) ) ) : ( _mm256_unpacklo_epi8( _mm256_permute4x64_epi64( _mm256_castsi128_si256( _mm_lddqu_si128( ( __m128i* )( &pSrc1[iX] ) ) ), 0xD8 ), _mm256_setzero_si256() ) );
-          __m256i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm256_lddqu_si256( ( __m256i* )( &pSrc2[iX] ) ) ) : ( _mm256_unpacklo_epi8( _mm256_permute4x64_epi64( _mm256_castsi128_si256( _mm_lddqu_si128( ( __m128i* )( &pSrc2[iX] ) ) ), 0xD8 ), _mm256_setzero_si256() ) );
+          __m256i Src1 = ( sizeof( Torg ) > 1 ) ? ( _mm256_lddqu_si256( ( __m256i* )( &pSrc1[iX] ) ) ) : ( _mm256_unpacklo_epi8( _mm256_permute4x64_epi64( _mm256_castsi128_si256( _mm_loadu_si128( ( __m128i* )( &pSrc1[iX] ) ) ), 0xD8 ), _mm256_setzero_si256() ) );
+          __m256i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm256_lddqu_si256( ( __m256i* )( &pSrc2[iX] ) ) ) : ( _mm256_unpacklo_epi8( _mm256_permute4x64_epi64( _mm256_castsi128_si256( _mm_loadu_si128( ( __m128i* )( &pSrc2[iX] ) ) ), 0xD8 ), _mm256_setzero_si256() ) );
           __m256i Diff = _mm256_sub_epi16( Src1, Src2 );
           __m256i Res = _mm256_madd_epi16( Diff, Diff );
           Sum = _mm256_add_epi32( Sum, Res );
@@ -203,7 +203,7 @@ Distortion RdCost::xGetSSE_NxN_SIMD( const DistParam &rcDtParam )
         for( int iX = 0; iX < iWidth; iX+=8 )
         {
           __m128i Src1 = ( sizeof( Torg ) > 1 ) ? ( _mm_loadu_si128( ( const __m128i* )( &pSrc1[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc1[iX] ) ), _mm_setzero_si128() ) );
-          __m128i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm_lddqu_si128( ( const __m128i* )( &pSrc2[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc2[iX] ) ), _mm_setzero_si128() ) );
+          __m128i Src2 = ( sizeof( Tcur ) > 1 ) ? ( _mm_loadu_si128( ( const __m128i* )( &pSrc2[iX] ) ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )( &pSrc2[iX] ) ), _mm_setzero_si128() ) );
           __m128i Diff = _mm_sub_epi16( Src1, Src2 );
           __m128i Res = _mm_madd_epi16( Diff, Diff );
           Sum = _mm_add_epi32( Sum, Res );
@@ -273,7 +273,7 @@ Distortion RdCost::xGetSAD_SIMD( const DistParam &rcDtParam )
       for( int iX = 0; iX < iCols; iX+=8 )
       {
         __m128i vsrc1 = _mm_loadu_si128( ( const __m128i* )( &pSrc1[iX] ) );
-        __m128i vsrc2 = _mm_lddqu_si128( ( const __m128i* )( &pSrc2[iX] ) );
+        __m128i vsrc2 = _mm_loadu_si128( ( const __m128i* )( &pSrc2[iX] ) );
         vsum16 = _mm_add_epi16( vsum16, _mm_abs_epi16( _mm_sub_epi16( vsrc1, vsrc2 ) ) );
       }
       __m128i vsumtemp = _mm_add_epi32( _mm_unpacklo_epi16( vsum16, vzero ), _mm_unpackhi_epi16( vsum16, vzero ) );
@@ -661,10 +661,8 @@ static uint32_t xCalcHAD8x8_SSE( const Torg *piOrg, const Tcur *piCur, const int
   for( int k = 0; k < 8; k++ )
   {
     __m128i r0 = ( sizeof( Torg ) > 1 ) ? ( _mm_loadu_si128( ( __m128i* )piOrg ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )piOrg ), _mm_setzero_si128() ) );
-    __m128i r1 = ( sizeof( Tcur ) > 1 ) ? ( _mm_lddqu_si128( ( __m128i* )piCur ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )piCur ), _mm_setzero_si128() ) ); // th  _mm_loadu_si128( (__m128i*)piCur )
+    __m128i r1 = ( sizeof( Tcur ) > 1 ) ? ( _mm_loadu_si128( ( __m128i* )piCur ) ) : ( _mm_unpacklo_epi8( _vv_loadl_epi64( ( const __m128i* )piCur ), _mm_setzero_si128() ) );
     m2[0][k] = _mm_sub_epi16( r0, r1 ); // 11bit
-    //m2[1][k] = _mm_cvtepi16_epi32( _mm_srli_si128( m2[0][k], 8 ) );
-    //m2[0][k] = _mm_cvtepi16_epi32( m2[0][k] );
     piCur += iStrideCur;
     piOrg += iStrideOrg;
   }
@@ -980,7 +978,7 @@ static uint32_t xCalcHAD16x8_SSE( const Torg *piOrg, const Tcur *piCur, const in
     for( int k = 0; k < 8; k++ )
     {
       __m128i r0 = _mm_loadu_si128( (__m128i*) piOrgPtr );
-      __m128i r1 = _mm_lddqu_si128( (__m128i*) piCurPtr );
+      __m128i r1 = _mm_loadu_si128( (__m128i*) piCurPtr );
       m2[k][l][0] = _mm_sub_epi16( r0, r1 );
       m2[k][l][1] = _mm_cvtepi16_epi32( _mm_srli_si128( m2[k][l][0], 8 ) );
       m2[k][l][0] = _mm_cvtepi16_epi32( m2[k][l][0] );
@@ -1186,7 +1184,7 @@ static uint32_t xCalcHAD8x16_SSE( const Torg *piOrg, const Tcur *piCur, const in
   for( int k = 0; k < 16; k++ )
   {
     __m128i r0 =_mm_loadu_si128( (__m128i*)piOrg );
-    __m128i r1 =_mm_lddqu_si128( (__m128i*)piCur );
+    __m128i r1 =_mm_loadu_si128( (__m128i*)piCur );
     m1[0][k] = _mm_sub_epi16( r0, r1 );
     m1[1][k] = _mm_cvtepi16_epi32( _mm_srli_si128( m1[0][k], 8 ) );
     m1[0][k] = _mm_cvtepi16_epi32( m1[0][k] );
@@ -1374,7 +1372,7 @@ static uint32_t xCalcHAD8x4_SSE( const Torg *piOrg, const Tcur *piCur, const int
   for( int k = 0; k < 4; k++ )
   {
     __m128i r0 = (sizeof( Torg ) > 1) ? (_mm_loadu_si128 ( (__m128i*)piOrg )) : (_mm_unpacklo_epi8( _vv_loadl_epi64( (const __m128i*)piOrg ), _mm_setzero_si128() ));
-    __m128i r1 = (sizeof( Tcur ) > 1) ? (_mm_lddqu_si128( (__m128i*)piCur )) : (_mm_unpacklo_epi8( _vv_loadl_epi64( (const __m128i*)piCur ), _mm_setzero_si128() )); // th  _mm_loadu_si128( (__m128i*)piCur )
+    __m128i r1 = (sizeof( Tcur ) > 1) ? (_mm_loadu_si128( (__m128i*)piCur )) : (_mm_unpacklo_epi8( _vv_loadl_epi64( (const __m128i*)piCur ), _mm_setzero_si128() )); // th  _mm_loadu_si128( (__m128i*)piCur )
     m1[k] = _mm_sub_epi16( r0, r1 );
     piCur += iStrideCur;
     piOrg += iStrideOrg;
@@ -2322,8 +2320,8 @@ static uint32_t xCalcHAD8x16_AVX2( const Pel* piOrg, const Pel* piCur, const int
     {
       for( int k = 0; k < 16; k++ )
       {
-        __m256i r0 = _mm256_cvtepi16_epi32( _mm_lddqu_si128( (__m128i*)piOrg ) );
-        __m256i r1 = _mm256_cvtepi16_epi32( _mm_lddqu_si128( (__m128i*)piCur ) );
+        __m256i r0 = _mm256_cvtepi16_epi32( _mm_loadu_si128( (__m128i*)piOrg ) );
+        __m256i r1 = _mm256_cvtepi16_epi32( _mm_loadu_si128( (__m128i*)piCur ) );
         m1[k] = _mm256_sub_epi32( r0, r1 );
         piCur += iStrideCur;
         piOrg += iStrideOrg;


### PR DESCRIPTION
It is possible to enable the `VVENC_ENABLE_ARM_SIMD` and `VVENC_ENABLE_X86_SIMD` options independent of each other in the `CMakeLists.txt` configuration, however if only the Arm Neon kernels are disabled the resulting code causes bus errors when built and run under 32-bit Arm.

This is due to a pair of issues:

* The existing `_vv_` unaligned macros are guarded by `TARGET_SIMD_ARM` rather than `REAL_TARGET_ARM`. This means that if the Neon kernels are disabled but the x86 kernels remain enabled, the macros are then incorrectly disabled.

* There is a missing macro covering use of the `_mm_lddqu_si128` intrinsic, which causes tests to crash due to alignment issues. With the `_vv_` macro guard fixed we can adjust this to use `_mm_loadu_si128` on 32-bit Arm targets instead.