### PR TITLE
Arm: Enable inter-prediction optimizations with SVE/SVE2 enabled

### DIFF
--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -131,12 +131,9 @@ void TCoeffOps::initTCoeffOpsARM()
 void InterPredInterpolation::initInterPredictionARM()
 {
   auto vext = read_arm_extension_flags();
-  switch (vext){
-    case NEON:
-      _initInterPredictionARM<NEON>();
-      break;
-    default:
-      break;
+  if( vext >= NEON )
+  {
+    _initInterPredictionARM<NEON>();
   }
 }
 #endif


### PR DESCRIPTION
The existing code only enables the inter-prediction optimized kernel when the extension flags report exactly Neon. This means that if SVE or SVE2 are returned instead then this kernel will be unintentionally disabled.

Adjust this condition to check if _at least_ Neon is enabled in order to match the other `init*` functions in this file.