### PR TITLE
Add unit tests for MCTF motionErrorLumaInt8

### DIFF
--- a/source/Lib/CommonLib/MCTF.cpp
+++ b/source/Lib/CommonLib/MCTF.cpp
@@ -545,7 +545,7 @@ double calcVarCore( const Pel* org, const ptrdiff_t origStride, const int w, con
   return variance / 256.0;
 }
 
-MCTF::MCTF()
+MCTF::MCTF( bool enableOpt )
   : m_encCfg     ( nullptr )
   , m_threadPool ( nullptr )
   , m_isFinalPass( true )
@@ -566,13 +566,15 @@ MCTF::MCTF()
   m_applyBlock              = applyBlockCore;
   m_calcVar                 = calcVarCore;
 
+  if( enableOpt )
+  {
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_MCTF
-  initMCTF_X86();
+    initMCTF_X86();
 #endif
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_MCTF
-  initMCTF_ARM();
+    initMCTF_ARM();
 #endif
-
+  }
 }
 
 MCTF::~MCTF()

--- a/source/Lib/CommonLib/MCTF.h
+++ b/source/Lib/CommonLib/MCTF.h
@@ -130,7 +130,7 @@ struct Picture;
 class MCTF : public EncStage
 {
 public:
-  MCTF();
+  MCTF( bool enableOpt = true );
   virtual ~MCTF();
 
   void init( const VVEncCfg& encCfg, bool isFinalPass, NoMallocThreadPool* threadPool );
@@ -141,18 +141,19 @@ protected:
 private:
   void filter( const std::deque<Picture*>& picFifo, int filterIdx );
 
-#if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_MCTF
+#if defined(TARGET_SIMD_X86) && ENABLE_SIMD_OPT_MCTF
   void initMCTF_X86();
   template <X86_VEXT vext>
   void _initMCTF_X86();
 #endif
 
-#if defined(TARGET_SIMD_ARM)  && ENABLE_SIMD_OPT_MCTF
+#if defined(TARGET_SIMD_ARM) && ENABLE_SIMD_OPT_MCTF
   void initMCTF_ARM();
   template <ARM_VEXT vext>
   void _initMCTF_ARM();
 #endif
 
+public:
   int ( *m_motionErrorLumaIntX )( const Pel* org, const ptrdiff_t origStride, const Pel* buf, const ptrdiff_t buffStride, const int w, const int h, const int besterror );
   int ( *m_motionErrorLumaInt8 )( const Pel* org, const ptrdiff_t origStride, const Pel* buf, const ptrdiff_t buffStride, const int w, const int h, const int besterror );
 

--- a/test/vvenc_unit_test/CMakeLists.txt
+++ b/test/vvenc_unit_test/CMakeLists.txt
@@ -22,7 +22,7 @@ if( VVENC_LIBRARY_ONLY )
 endif()
 
 target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
-                                            $<$<CXX_COMPILER_ID:GNU>:-Wall -fdiagnostics-show-option -Wno-ignored-attributes>
+                                            $<$<CXX_COMPILER_ID:GNU>:-Wall -fdiagnostics-show-option -Wno-ignored-attributes -Wno-sign-compare>
 
                                             $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4251 /wd4996>)
 


### PR DESCRIPTION
In #465 we added a Neon implementation of motionErrorLumaInt8, however this was not covered by any of the existing unit tests. To try and ensure that the behaviour of the x86 and Arm kernels continues to match, add a unit test covering these kernels.

To enable the tests to call the optimized kernels in a way matching how we previously did this for `TCoeffOps`, mark the MCTF member kernels as public members of the class and pass a new `enableOpt` member to allow us to compare the optimized and fallback scalar implementations.

Also add `-Wno-sign-compare` when compiling unit tests with GCC to avoid warnings from `Common.h` and `Slice.h`, since this flag is already present when building the library.