### PR TITLE
Convert CTS and DTS to (signed) int64_t in external interface

### DIFF
--- a/include/vvenc/vvenc.h.in
+++ b/include/vvenc/vvenc.h.in
@@ -135,7 +135,7 @@ typedef struct vvencYUVBuffer
 {
   vvencYUVPlane planes[ 3 ];           // plane buffer for 3 components (yuv)
   uint64_t      sequenceNumber;        // sequence number of the picture
-  uint64_t      cts;                   // composition time stamp in TicksPerSecond
+  int64_t       cts;                   // composition time stamp in TicksPerSecond
   bool          ctsValid;              // composition time stamp valid flag (true: valid, false: CTS not set)
 #if VVENC_USE_UNSTABLE_API
   void*         userData;              // user data to be returned in corresponding access unit
@@ -188,8 +188,8 @@ typedef struct vvencAccessUnit
   int             payloadSize;         // size of the allocated buffer in bytes
   int             payloadUsedSize;     // length of the coded data in bytes
 
-  uint64_t        cts;                 // composition time stamp in TicksPerSecond (see vvenc_config)
-  uint64_t        dts;                 // decoding time stamp in TicksPerSecond (see vvenc_config)
+  int64_t         cts;                 // composition time stamp in TicksPerSecond (see vvenc_config)
+  int64_t         dts;                 // decoding time stamp in TicksPerSecond (see vvenc_config)
   bool            ctsValid;            // composition time stamp valid flag (true: valid, false: CTS not set)
   bool            dtsValid;            // decoding time stamp valid flag (true: valid, false: DTS not set)
   bool            rap;                 // random access point flag (true: AU is random access point, false: sequential access)

--- a/source/Lib/CommonLib/Nal.h
+++ b/source/Lib/CommonLib/Nal.h
@@ -192,8 +192,8 @@ public:
     std::list<NALUnitEBSP*>::clear();
   }
 
-  uint64_t        cts;                                   ///< composition time stamp
-  uint64_t        dts;                                   ///< decoding time stamp
+  int64_t         cts;                                   ///< composition time stamp
+  int64_t         dts;                                   ///< decoding time stamp
   uint64_t        poc;                                   ///< picture order count
   vvencSliceType  sliceType;                              ///< slice type (I/P/B) */
   int             temporalLayer;                          ///< temporal layer

--- a/test/vvenclibtest/vvenclibtest.cpp
+++ b/test/vvenclibtest/vvenclibtest.cpp
@@ -898,8 +898,8 @@ int checkSDKStringApiInvalid()
 
 static int runEncoder( vvenc_config& c, uint64_t framesToEncode, bool emulateMissingFrames = false ) 
 {
-  uint64_t ctsDiff   = (c.m_TicksPerSecond > 0) ? (uint64_t)c.m_TicksPerSecond * (uint64_t)c.m_FrameScale / (uint64_t)c.m_FrameRate : 1;  // expected cts diff between frames
-  uint64_t ctsOffset = (c.m_TicksPerSecond > 0) ? (uint64_t)c.m_TicksPerSecond : (uint64_t)c.m_FrameRate/(uint64_t)c.m_FrameScale;        // start with offset 1sec, to generate  cts/dts > 0
+  int64_t ctsDiff   = (c.m_TicksPerSecond > 0) ? c.m_TicksPerSecond * c.m_FrameScale / c.m_FrameRate : 1;  // expected cts diff between frames
+  int64_t ctsOffset = (c.m_TicksPerSecond > 0) ? c.m_TicksPerSecond : c.m_FrameRate  / c.m_FrameScale;     // start with offset 1sec, to generate  cts/dts > 0
   //std::cout << "test framerate " << c.m_FrameRate << "/" << c.m_FrameScale << " TicksPerSecond  " << c.m_TicksPerSecond << " ctsDiff " << ctsDiff << " framesToEncode " << framesToEncode  << std::endl;
   vvencEncoder *enc = vvenc_encoder_create();
   if( nullptr == enc )
@@ -918,7 +918,7 @@ static int runEncoder( vvenc_config& c, uint64_t framesToEncode, bool emulateMis
   vvenc_YUVBuffer_alloc_buffer( yuvPicture, c.m_internChromaFormat, c.m_SourceWidth, c.m_SourceHeight );
   fillInputPic( yuvPicture );
   
-  uint64_t lastDts=0;
+  int64_t lastDts=0;
   uint64_t auCount=0;
   bool eof       = false;
   bool encodeDone = false;
@@ -935,7 +935,7 @@ static int runEncoder( vvenc_config& c, uint64_t framesToEncode, bool emulateMis
     if ( ! eof )
     {
       inputPtr             = yuvPicture;
-      yuvPicture->cts      = (c.m_TicksPerSecond > 0) ? (ctsOffset + (framesRcvd * (uint64_t)c.m_TicksPerSecond * (uint64_t)c.m_FrameScale / (uint64_t)c.m_FrameRate)) : (ctsOffset + framesRcvd);
+      yuvPicture->cts      = (c.m_TicksPerSecond > 0) ? (ctsOffset + (framesRcvd * c.m_TicksPerSecond * c.m_FrameScale / c.m_FrameRate)) : (ctsOffset + framesRcvd);
       yuvPicture->ctsValid = true;
 #if VVENC_USE_UNSTABLE_API
       yuvPicture->userData   = new int(framesRcvd);


### PR DESCRIPTION
When POC0IDR is not set, VVenC creates leading pictures for the first IDR, which have a negative DTS, so the interface should reflect that in the types.