### PR TITLE
Improve BiOptFlowCoreARMSIMD and enable for 32-bit Arm platforms

### DIFF
--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -55,6 +55,18 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace vvenc
 {
 
+static inline int16_t horizontal_add_s16x8( const int16x8_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddvq_s16( a );
+#else
+  const int16x4_t b = vpadd_s16( vget_low_s16( a ), vget_high_s16( a ) );
+  const int16x4_t c = vpadd_s16( b, b );
+  const int16x4_t d = vpadd_s16( c, c );
+  return vget_lane_s16( d, 0 );
+#endif
+}
+
 static inline int horizontal_add_s32x4( const int32x4_t a )
 {
 #if REAL_TARGET_AARCH64


### PR DESCRIPTION
The existing implementation of `BiOptFlowCoreARMSIMD` can be improved in a number of small ways:

* The calculations of `packTempX` and `packTempY` are done with an addition and a right shift by one, however Neon has an explicit "halving addition" (SHADD) instruction for this already.

* The calculation of the sign of `packTempX` and `packTempY` is currently done with two comparisons and a subtraction, however the same is achievable with a pair of shifts instead, saving one instruction.

* The accumulations in `calcBIOSums_neon` can be done with accumulating instructions like SABA and MLA, avoiding the need for a separate addition.

* The application of the 6-element mask at the end of the `calcBIOSums_neon` loop can be done with AND rather than MUL, since the former has slightly better performance.

* The horizontal reductions at the end of `calcBIOSums` are the only thing that is not available in AArch32, so add a new `horizontal_add_s16x8` to the existing `sum_neon.h` header to provide compatibility.

* In `addBIOAvg4_neon`, we know that `vibdimin` will always be zero so we can use `vqmovun_s32` to clamp with zero as part of the narrowing.

Additionally re-roll the loops and clean up formatting to more closely match other kernels.

Compared to the existing Neon implementation, this new version runs about 20-25% faster when benchmarked on Neoverse V-series micro-architectures with LLVM 20.