### PR TITLE
Add Neon implementation of lumaWeightedSSE

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@
 * George Steed, @georges-arm, Arm
 * Yiqun Liu, , Fraunhofer HHI
 * Mehrdad Ghafari, , Fraunhofer HHI
+* Athulya Raj Raji Mohini, @athulya-arm, Arm

--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -132,6 +132,15 @@ static inline int32x4_t pairwise_add_s32x4( const int32x4_t a, const int32x4_t b
 #endif
 }
 
+static inline int64_t horizontal_add_s64x2( const int64x2_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddvq_s64( a );
+#else
+  return vgetq_lane_s64( a, 0 ) + vgetq_lane_s64( a, 1 );
+#endif
+}
+
 }  // namespace vvenc
 
 #endif


### PR DESCRIPTION
* Add new Neon implementation for RdCost::lumaWeightedSSE function.

The SIMDe implementation of lumaWeightedSSE function can be improved
in the following ways:

- Rewrite WeightedMSE calculation in the loops from:
     ( a * ( b * b ) ) >> 16
  to:
     ( ( a * b ) * ( b << 15 ) ) >> 31
  to reduce multiply instructions by making use of mulh instruction
  and thus avoiding 64 bit shifts.

- Simplify the loops for handling width conditions 4, 2 and 1.

Performance is improved by approximately 35% compared to the SIMDe
version.

* Add myself (athulya-arm) to AUTHORS.md