### PR TITLE
Add unit tests for lumaWeightedSSE

### DIFF
--- a/source/Lib/CommonLib/RdCost.cpp
+++ b/source/Lib/CommonLib/RdCost.cpp
@@ -82,7 +82,7 @@ void RdCost::setLambda( double dLambda, const BitDepths &bitDepths )
 
 
 // Initialize Function Pointer by [eDFunc]
-void RdCost::create()
+void RdCost::create( bool enableOpt )
 {
   m_signalType                 = RESHAPE_SIGNAL_NULL;
   m_chromaWeight               = 1.0;
@@ -138,12 +138,15 @@ void RdCost::create()
   m_afpDistortFuncX5[1] = RdCost::xGetSAD16X5;
 
 #if ENABLE_SIMD_OPT_DIST
+  if( enableOpt )
+  {
 #ifdef TARGET_SIMD_X86
-  initRdCostX86();
+    initRdCostX86();
 #endif
 #ifdef TARGET_SIMD_ARM
-  initRdCostARM();
+    initRdCostARM();
 #endif
+  }
 #endif
 
   m_costMode      = VVENC_COST_STANDARD_LOSSY;

--- a/source/Lib/CommonLib/RdCost.h
+++ b/source/Lib/CommonLib/RdCost.h
@@ -113,12 +113,14 @@ public:
 /// RD cost computation class
 class RdCost
 {
+public:
+  Distortion ( *m_wtdPredPtr[2] )( const DistParam& dp, ChromaFormat chmFmt, const uint32_t* lumaWeights );
+
 private:
   // for distortion
 
   FpDistFunc              m_afpDistortFunc[2][DF_TOTAL_FUNCTIONS]; // [eDFunc]
   FpDistFuncX5            m_afpDistortFuncX5[2]; // [eDFunc]
-  Distortion           ( *m_wtdPredPtr[2] )  ( const DistParam& dp, ChromaFormat chmFmt, const uint32_t *lumaWeights );
   Distortion           ( *m_fxdWtdPredPtr )  ( const DistParam& dp, uint32_t fixedWeight );
   vvencCostMode           m_costMode;
   double                  m_distortionWeight[MAX_NUM_COMP]; // only chroma values are used.
@@ -145,13 +147,13 @@ public:
   RdCost();
   virtual ~RdCost();
 
-  void          create();
+  void          create( bool enableOpt = true );
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_DIST
   void          initRdCostX86();
   template <X86_VEXT vext>
   void          _initRdCostX86();
 #endif
-	
+
 #if defined(TARGET_SIMD_ARM)  && ENABLE_SIMD_OPT_DIST
 
   void initRdCostARM();


### PR DESCRIPTION
Add unit tests for lumaWeightedSSE

Add unit tests for lumaWeightedSSE functions. Modify the RdCost::create
function to include a new 'enableOpt' parameter to create a reference
object and an optimized object to test.