### PR TITLE
Arm: Fix incorrect index in lumaWeightedSSE_neon

### DIFF
--- a/source/Lib/CommonLib/arm/RdCostARM.h
+++ b/source/Lib/CommonLib/arm/RdCostARM.h
@@ -1257,7 +1257,7 @@ Distortion lumaWeightedSSE_neon( const DistParam& rcDtParam, ChromaFormat chmFmt
     do
     {
       int16_t orgData[4] = { piOrg[0], piOrg[1], piOrg[iStrideOrg], piOrg[iStrideOrg + 1] };
-      int16_t currData[4] = { piCur[0], piCur[1], piCur[iStrideOrg], piCur[iStrideOrg + 1] };
+      int16_t currData[4] = { piCur[0], piCur[1], piCur[iStrideCur], piCur[iStrideCur + 1] };
       int16x4_t org = vld1_s16( orgData );   // 14 bit
       int16x4_t curr = vld1_s16( currData ); // 14 bit
       const uint32_t lweights[4] = { lumaWeights[piOrgLuma[0]], lumaWeights[piOrgLuma[1 << csx]],

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -479,10 +479,12 @@ static bool check_lumaWeightedSSE( RdCost* ref, RdCost* opt, unsigned num_cases,
   bool passed = true;
   for( unsigned i = 0; i < num_cases; i++ )
   {
-    int stride = rng.get( width, 1024 );
-    std::vector<Pel> orgBuf( stride * height );
-    std::vector<Pel> curBuf( stride * height );
-    std::vector<Pel> orgLumaBuf( stride * height * 2 );
+    int org_stride = rng.get( width, 1024 );
+    int cur_stride = rng.get( width, 1024 );
+    int luma_stride = rng.get( width, 1024 );
+    std::vector<Pel> orgBuf( org_stride * height );
+    std::vector<Pel> curBuf( cur_stride * height );
+    std::vector<Pel> orgLumaBuf( luma_stride * height * 2 );
     std::vector<uint32_t> lumaWeights( 1024 );
 
     DistParam dtParam;
@@ -490,11 +492,11 @@ static bool check_lumaWeightedSSE( RdCost* ref, RdCost* opt, unsigned num_cases,
     dtParam.cur.buf = curBuf.data();
     dtParam.org.width = width;
     dtParam.org.height = height;
-    dtParam.cur.stride = stride;
-    dtParam.org.stride = stride;
+    dtParam.cur.stride = cur_stride;
+    dtParam.org.stride = org_stride;
     CPelBuf pelBuf;
     pelBuf.buf = orgLumaBuf.data();
-    pelBuf.stride = stride;
+    pelBuf.stride = luma_stride;
     dtParam.orgLuma = &pelBuf;
     dtParam.bitDepth = 10;
     dtParam.compID = COMP_Y;


### PR DESCRIPTION
- Fix incorrect index handling in the Neon implementation of the RdCost::lumaWeightedSSE function. 
- Also update corresponding unit test to detect such issues.