### PR TITLE
Add unit test for AffineGradientSearch::EqualCoeffComputer and use residueStride for scalar and x86 implementations

### DIFF
--- a/source/Lib/CommonLib/AffineGradientSearch.cpp
+++ b/source/Lib/CommonLib/AffineGradientSearch.cpp
@@ -61,7 +61,7 @@ namespace vvenc {
   // Private member functions
   // ====================================================================================================================
 
-  AffineGradientSearch::AffineGradientSearch()
+  AffineGradientSearch::AffineGradientSearch( bool enableOpt )
   {
     m_HorizontalSobelFilter = xHorizontalSobelFilter;
     m_VerticalSobelFilter   = xVerticalSobelFilter;
@@ -69,10 +69,13 @@ namespace vvenc {
     m_EqualCoeffComputer[1] = xEqualCoeffComputer<true>;
 
 #if ENABLE_SIMD_OPT_AFFINE_ME
+    if( enableOpt )
+    {
 #ifdef TARGET_SIMD_X86
-    initAffineGradientSearchX86();
+      initAffineGradientSearchX86();
 #endif
-#endif
+    }
+#endif // ENABLE_SIMD_OPT_AFFINE_ME
   }
 
   void AffineGradientSearch::xHorizontalSobelFilter(Pel* const pPred, const int predStride, Pel *const pDerivate, const int derivateBufStride, const int width, const int height)

--- a/source/Lib/CommonLib/AffineGradientSearch.cpp
+++ b/source/Lib/CommonLib/AffineGradientSearch.cpp
@@ -152,23 +152,24 @@ namespace vvenc {
       {
         int iC[6];
 
-        int idx = j * derivateBufStride + k;
+        int drvIdx = j * derivateBufStride + k;
+        int resIdx = j * residueStride + k;
         int cx = ((k >> 2) << 2) + 2;
         if (!b6Param)
         {
-          iC[0] = ppDerivate[0][idx];
-          iC[1] = cx * ppDerivate[0][idx] + cy * ppDerivate[1][idx];
-          iC[2] = ppDerivate[1][idx];
-          iC[3] = cy * ppDerivate[0][idx] - cx * ppDerivate[1][idx];
+          iC[0] = ppDerivate[0][drvIdx];
+          iC[1] = cx * ppDerivate[0][drvIdx] + cy * ppDerivate[1][drvIdx];
+          iC[2] = ppDerivate[1][drvIdx];
+          iC[3] = cy * ppDerivate[0][drvIdx] - cx * ppDerivate[1][drvIdx];
         }
         else
         {
-          iC[0] = ppDerivate[0][idx];
-          iC[1] = cx * ppDerivate[0][idx];
-          iC[2] = ppDerivate[1][idx];
-          iC[3] = cx * ppDerivate[1][idx];
-          iC[4] = cy * ppDerivate[0][idx];
-          iC[5] = cy * ppDerivate[1][idx];
+          iC[0] = ppDerivate[0][drvIdx];
+          iC[1] = cx * ppDerivate[0][drvIdx];
+          iC[2] = ppDerivate[1][drvIdx];
+          iC[3] = cx * ppDerivate[1][drvIdx];
+          iC[4] = cy * ppDerivate[0][drvIdx];
+          iC[5] = cy * ppDerivate[1][drvIdx];
         }
         for (int col = 0; col < affineParamNum; col++)
         {
@@ -176,7 +177,7 @@ namespace vvenc {
           {
             pEqualCoeff[col + 1][row] += (int64_t)iC[col] * iC[row];
           }
-          pEqualCoeff[col + 1][affineParamNum] += ((int64_t)iC[col] * pResidue[idx]) *(1<< 3);
+          pEqualCoeff[col + 1][affineParamNum] += ((int64_t)iC[col] * pResidue[resIdx]) *(1<< 3);
         }
       }
     }

--- a/source/Lib/CommonLib/AffineGradientSearch.h
+++ b/source/Lib/CommonLib/AffineGradientSearch.h
@@ -69,7 +69,7 @@ using namespace x86_simd;
     template<bool b6Param>
     static void xEqualCoeffComputer   ( Pel* const pResi, const int resiStride, Pel **const ppDerivate, const int derivateBufStride, const int width, const int height, int64_t(*pEqualCoeff)[7]);
 
-    AffineGradientSearch();
+    AffineGradientSearch( bool enableOpt = true );
     ~AffineGradientSearch() {}
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_AFFINE_ME

--- a/source/Lib/CommonLib/x86/AffineGradientSearchX86.h
+++ b/source/Lib/CommonLib/x86/AffineGradientSearchX86.h
@@ -189,6 +189,8 @@ inter3 = _mm_add_epi64(inter0, inter3);                                         
     static constexpr int n = b6Param ? 6 : 4;
     int idx1 = -2 * derivateBufStride - 4;
     int idx2 = -    derivateBufStride - 4;
+    int resIdx1 = -2 * residueStride - 4;
+    int resIdx2 = -    residueStride - 4;
 
     for (int j = 0; j < height; j += 2)
     {
@@ -197,11 +199,15 @@ inter3 = _mm_add_epi64(inter0, inter3);                                         
       mmIndxK = _mm_set1_epi32(-2);
       idx1 += (derivateBufStride << 1);
       idx2 += (derivateBufStride << 1);
+      resIdx1 += (residueStride << 1);
+      resIdx2 += (residueStride << 1);
 
       for (int k = 0; k < width; k += 4)
       {
         idx1 += 4;
         idx2 += 4;
+        resIdx1 += 4;
+        resIdx2 += 4;
         mmIndxK = _mm_add_epi32(mmIndxK, mmFour);
 
         if (b6Param)
@@ -246,8 +252,8 @@ inter3 = _mm_add_epi64(inter0, inter3);                                         
         }
 
         // Residue
-        mmResidue[0] = _vv_loadl_epi64((const __m128i*)&pResidue[idx1]);
-        mmResidue[1] = _vv_loadl_epi64((const __m128i*)&pResidue[idx2]);
+        mmResidue[0] = _vv_loadl_epi64((const __m128i*)&pResidue[resIdx1]);
+        mmResidue[1] = _vv_loadl_epi64((const __m128i*)&pResidue[resIdx2]);
         mmResidue[0] = _mm_cvtepi16_epi32(mmResidue[0]);
         mmResidue[1] = _mm_cvtepi16_epi32(mmResidue[1]);
         mmResidue[0] = _mm_slli_epi32(mmResidue[0], 3);
@@ -279,6 +285,8 @@ inter3 = _mm_add_epi64(inter0, inter3);                                         
 
       idx1 -= (width);
       idx2 -= (width);
+      resIdx1 -= (width);
+      resIdx2 -= (width);
     }
   }
 
@@ -318,6 +326,8 @@ res    = _mm_add_epi64(res, _mm256_extracti128_si256(inter3, 1));               
     static constexpr int n = b6Param ? 6 : 4;
     int idx1 = -2 * derivateBufStride - 8;
     int idx2 = -    derivateBufStride - 8;
+    int resIdx1 = -2 * residueStride - 8;
+    int resIdx2 = -    residueStride - 8;
 
     for (int j = 0; j < height; j += 2)
     {
@@ -326,11 +336,15 @@ res    = _mm_add_epi64(res, _mm256_extracti128_si256(inter3, 1));               
       mmIndxK = _mm256_inserti128_si256( _mm256_castsi128_si256( _mm_set1_epi32( -6 ) ), _mm_set1_epi32( -2 ), 1 );
       idx1 += (derivateBufStride << 1);
       idx2 += (derivateBufStride << 1);
+      resIdx1 += (residueStride << 1);
+      resIdx2 += (residueStride << 1);
 
       for (int k = 0; k < width; k += 8)
       {
         idx1 += 8;
         idx2 += 8;
+        resIdx1 += 8;
+        resIdx2 += 8;
         mmIndxK = _mm256_add_epi32(mmIndxK, mmFour);
         mmIndxK = _mm256_add_epi32(mmIndxK, mmFour);
 
@@ -343,7 +357,7 @@ res    = _mm_add_epi64(res, _mm256_extracti128_si256(inter3, 1));               
           mmC[3] = _mm256_mullo_epi32(mmIndxK, mmC[2]);
           mmC[4] = _mm256_mullo_epi32(mmIndxJ, mmC[0]);
           mmC[5] = _mm256_mullo_epi32(mmIndxJ, mmC[2]);
-        
+
           // mmC[6-11] for iC[0-5] of 2nd row of pixels
           mmC[6] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&ppDerivate[0][idx2]));
           mmC[8] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&ppDerivate[1][idx2]));
@@ -376,8 +390,8 @@ res    = _mm_add_epi64(res, _mm256_extracti128_si256(inter3, 1));               
         }
 
         // Residue
-        mmResidue[0] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&pResidue[idx1]));
-        mmResidue[1] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&pResidue[idx2]));
+        mmResidue[0] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&pResidue[resIdx1]));
+        mmResidue[1] = _mm256_cvtepi16_epi32(_mm_loadu_si128((const __m128i*)&pResidue[resIdx2]));
         mmResidue[0] = _mm256_slli_epi32(mmResidue[0], 3);
         mmResidue[1] = _mm256_slli_epi32(mmResidue[1], 3);
 
@@ -407,6 +421,8 @@ res    = _mm_add_epi64(res, _mm256_extracti128_si256(inter3, 1));               
 
       idx1 -= (width);
       idx2 -= (width);
+      resIdx1 -= (width);
+      resIdx2 -= (width);
     }
   }
 #endif


### PR DESCRIPTION
- Add unit test for `AffineGradientSearch::EqualCoeffComputer`.
Add unit test for the EqualCoeffComputer function. Modify the
AffineGradientSearch constructor to include a new 'enableOpt' member,
which allows enabling or disabling the optimized version of the kernels.

- Use `residueStride` for `pResidue` in `xEqualCoeffComputer` and x86 `simdEqualCoeffComputer`.
Currently, the scalar and x86 implementation of EqualCoeffComputer uses
derivateBufStride for both ppDerivate and pResidue. This pull request corrects that 
by using residueStride specifically for pResidue.
The output behavior remains unchanged, as the only call to this function
passes the same width value to both derivateBufStride and residueStride.

I am submitting this PR as a preface to my upcoming Neon implementation PR for this function.