### PR TITLE
Add unit test for IntraPrediction::IntraPredAngleLuma

### DIFF
--- a/source/Lib/CommonLib/IntraPrediction.cpp
+++ b/source/Lib/CommonLib/IntraPrediction.cpp
@@ -248,7 +248,7 @@ void IntraPredAngleChroma_Core(Pel* pDstBuf,const ptrdiff_t dstStride,int16_t* p
 // Constructor / destructor / initialize
 // ====================================================================================================================
 
-IntraPrediction::IntraPrediction()
+IntraPrediction::IntraPrediction( bool enableOpt )
 :  m_pMdlmTemp( nullptr )
 ,  m_currChromaFormat( NUM_CHROMA_FORMAT )
 {
@@ -258,6 +258,18 @@ IntraPrediction::IntraPrediction()
   IntraHorVerPDPC       = IntraHorVerPDPC_Core;
   IntraPredSampleFilter = IntraPredSampleFilter_Core;
   xPredIntraPlanar      = xPredIntraPlanar_Core;
+
+#if ENABLE_SIMD_OPT_INTRAPRED
+  if( enableOpt )
+  {
+#if defined( TARGET_SIMD_X86 )
+    initIntraPredictionX86();
+#endif
+#if defined( TARGET_SIMD_ARM )
+    initIntraPredictionARM();
+#endif
+  }
+#endif // ENABLE_SIMD_OPT_INTRAPRED
 }
 
 IntraPrediction::~IntraPrediction()
@@ -279,12 +291,6 @@ void IntraPrediction::init(ChromaFormat chromaFormatIDC, const unsigned bitDepth
   {
     m_pMdlmTemp = new Pel[(2 * MAX_TB_SIZEY + 1)*(2 * MAX_TB_SIZEY + 1)];//MDLM will use top-above and left-below samples.
   }
-#if ENABLE_SIMD_OPT_INTRAPRED && defined( TARGET_SIMD_X86 )
-  initIntraPredictionX86();
-#endif
-#if ENABLE_SIMD_OPT_INTRAPRED && defined( TARGET_SIMD_ARM )
-  initIntraPredictionARM();
-#endif
 }
 
 // ====================================================================================================================

--- a/source/Lib/CommonLib/IntraPrediction.h
+++ b/source/Lib/CommonLib/IntraPrediction.h
@@ -124,7 +124,6 @@ private:
   static int getWideAngle         ( int width, int height, int predMode );
 
   // prediction
-  void (*xPredIntraPlanar)        ( PelBuf& pDst, const CPelBuf& pSrc );
   void xPredIntraDc               ( PelBuf& pDst, const CPelBuf& pSrc );
   void xPredIntraAng              ( PelBuf& pDst, const CPelBuf& pSrc, const ChannelType channelType, const ClpRng& clpRng);
   Pel  xGetPredValDc              ( const CPelBuf& pSrc, const Size& dstSize );
@@ -133,12 +132,6 @@ private:
   void xFillReferenceSamples      ( const CPelBuf& recoBuf,      Pel* refBufUnfiltered, const CompArea& area, const CodingUnit &cu );
   void xFilterReferenceSamples    ( const Pel* refBufUnfiltered, Pel* refBufFiltered, const CompArea& area, const SPS &sps, int multiRefIdx, int predStride = 0 );
   void xGetLMParameters(const CodingUnit& cu, const ComponentID compID, const CompArea& chromaArea, int& a, int& b, int& iShift);
-
-  void ( *IntraPredAngleLuma )    ( Pel* pDstBuf, const ptrdiff_t dstStride, Pel* refMain, int width, int height, int deltaPos, int intraPredAngle, const TFilterCoeff *ff, const bool useCubicFilter, const ClpRng& clpRng);
-  void ( *IntraPredAngleChroma )  ( Pel* pDst,    const ptrdiff_t dstStride, Pel* pBorder, int width, int height, int deltaPos, int intraPredAngle);
-  void ( *IntraAnglePDPC )        ( Pel* pDsty, const int dstStride, Pel* refSide, const int width, const int height, int scale, int invAngle);
-  void ( *IntraHorVerPDPC )       ( Pel* pDsty, const int dstStride, Pel* refSide, const int width, const int height, int scale, const Pel* refMain, const ClpRng& clpRng);
-  void ( *IntraPredSampleFilter)  ( PelBuf& piPred, const CPelBuf& pSrc );
 
 #if ENABLE_SIMD_OPT_INTRAPRED && defined( TARGET_SIMD_X86 )
   void initIntraPredictionX86();
@@ -153,7 +146,7 @@ private:
 #endif
 
 public:
-  IntraPrediction();
+  IntraPrediction( bool enableOpt = true );
   virtual ~IntraPrediction();
 
   void init                   ( ChromaFormat chromaFormatIDC, const unsigned bitDepthY);
@@ -191,6 +184,12 @@ public:
     return numIntra;
   }
 
+  void ( *IntraPredAngleLuma )    ( Pel* pDstBuf, const ptrdiff_t dstStride, Pel* refMain, int width, int height, int deltaPos, int intraPredAngle, const TFilterCoeff* ff, const bool useCubicFilter, const ClpRng& clpRng );
+  void ( *IntraPredAngleChroma )  ( Pel* pDst, const ptrdiff_t dstStride, Pel* pBorder, int width, int height, int deltaPos, int intraPredAngle );
+  void ( *IntraAnglePDPC )        ( Pel* pDsty, const int dstStride, Pel* refSide, const int width, const int height, int scale, int invAngle );
+  void ( *IntraHorVerPDPC )       ( Pel* pDsty, const int dstStride, Pel* refSide, const int width, const int height, int scale, const Pel* refMain, const ClpRng& clpRng );
+  void ( *IntraPredSampleFilter ) ( PelBuf& piPred, const CPelBuf& pSrc );
+  void ( *xPredIntraPlanar )      ( PelBuf& pDst, const CPelBuf& pSrc );
 };
 
 } // namespace vvenc


### PR DESCRIPTION
Add unit test for the IntraPredAngleLuma function. Modify the IntraPrediction constructor to include a new 'enableOpt' member, which allows enabling or disabling the optimized version of the kernels.

Also, move the function pointers from private to public so they can be referenced in the unit tests.