### PR TITLE
Add unit tests for PelBufferOps::addAvg

### DIFF
--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -445,7 +445,7 @@ uint64_t AvgHighPassWithDownsamplingDiff2ndCore (const int width,const int heigh
   return (taAct);
 }
 
-PelBufferOps::PelBufferOps()
+PelBufferOps::PelBufferOps( bool enableOpt )
 {
   isInitX86Done = false;
 
@@ -495,6 +495,18 @@ PelBufferOps::PelBufferOps()
   AvgHighPassWithDownsamplingDiff2nd = AvgHighPassWithDownsamplingDiff2ndCore;
   HDHighPass = HDHighPassCore;
   HDHighPass2 = HDHighPass2Core;
+
+#if ENABLE_SIMD_OPT_BUFFER
+  if( enableOpt )
+  {
+  #ifdef TARGET_SIMD_X86
+    initPelBufOpsX86();
+  #endif
+  #ifdef TARGET_SIMD_ARM
+    initPelBufOpsARM();
+  #endif
+  }
+#endif // ENABLE_SIMD_OPT_BUFFER
 }
 
 PelBufferOps g_pelBufOP = PelBufferOps();

--- a/source/Lib/CommonLib/Buffer.h
+++ b/source/Lib/CommonLib/Buffer.h
@@ -80,7 +80,7 @@ using namespace arm_simd;
 
 struct PelBufferOps
 {
-  PelBufferOps();
+  PelBufferOps( bool enableOpt = true );
 
   bool isInitX86Done;
 

--- a/source/Lib/vvenc/vvencimpl.cpp
+++ b/source/Lib/vvenc/vvencimpl.cpp
@@ -842,15 +842,6 @@ const char* VVEncImpl::setSIMDExtension( const char* simdId )
     }
 # endif  // defined( TARGET_SIMD_X86 )
 
-# if ENABLE_SIMD_OPT_BUFFER
-#  if defined( TARGET_SIMD_X86 )
-    g_pelBufOP.initPelBufOpsX86();
-#  endif
-#  if defined( TARGET_SIMD_ARM )
-    g_pelBufOP.initPelBufOpsARM();
-#  endif
-# endif   // ENABLE_SIMD_OPT_BUFFER
-
 # if ENABLE_SIMD_TRAFO
 #  if defined( TARGET_SIMD_X86 )
     g_tCoeffOps.initTCoeffOpsX86();


### PR DESCRIPTION
Add unit tests for both the no stride and strided versions of addAvg.

Modify the PelBufferOps constructor to include a new 'enableOpt' member, which allows enabling or disabling the optimized version of the kernels.

---
Hello! I have included all the widths that seem to show up during **ctest** for both the `no stride` and `strided` versions.
The `no stride` seems to be restricted to only powers-of-two numSamples, while the `strided` version has some non-powers-of-two widths.

Please correct me if my assumptions are wrong or if there needs more width values.

Thank you.