### PR TITLE
Delete pcEncApp when config err is found or help is shown

### DIFF
--- a/source/App/vvencFFapp/encmain.cpp
+++ b/source/App/vvencFFapp/encmain.cpp
@@ -86,11 +86,13 @@ int main(int argc, char* argv[])
   // parse configuration
   if ( ! pcEncApp->parseCfg( argc, argv ) )
   {
+    delete pcEncApp;
     return 1;
   }
 
   if( pcEncApp->isShowVersionHelp() )
   {
+    delete pcEncApp;
     return 0;
   }
 


### PR DESCRIPTION
fixes #558 