### PR TITLE
Arm: Fix CHECK condition of addAvg_neon (no stride)

### DIFF
--- a/source/Lib/CommonLib/arm/neon/Buffer_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Buffer_neon.cpp
@@ -66,7 +66,7 @@ namespace vvenc
 void addAvg_neon( const Pel* src0, const Pel* src1, Pel* dest, int numSamples, unsigned rshift, int offset,
                   const ClpRng& clpRng )
 {
-  CHECK( ( numSamples & ( numSamples - 1 ) ) != 0 || numSamples < 4, "numSamples must be power of two >= 4" );
+  CHECK( numSamples < 4, "numSamples must be >= 4" );
   CHECK( offset > 16448, "Offset must be <= 16448" ); // Max: (1 << (rshift - 1)) + 2 * (1 << 13), where rshift=7.
 
   const int lshift = -static_cast<int>( rshift );
@@ -108,7 +108,7 @@ void addAvg_neon( const Pel* src0, const Pel* src1, Pel* dest, int numSamples, u
 
     vst1q_s16( dest, vreinterpretq_s16_u16( d ) );
   }
-  else // numSamples == 4
+  else if( numSamples == 4 )
   {
     uint16x4_t s1 = vreinterpret_u16_s16( vld1_s16( src0 ) );
     uint16x4_t s2 = vreinterpret_u16_s16( vld1_s16( src1 ) );
@@ -119,6 +119,10 @@ void addAvg_neon( const Pel* src0, const Pel* src1, Pel* dest, int numSamples, u
     d = vmin_u16( d, vdup_n_u16( clpRng.max() ) );
 
     vst1_s16( dest, vreinterpret_s16_u16( d ) );
+  }
+  else
+  {
+    THROW( "Unsupported size. numSamples must be 4 or 8 or a multiple of 16" );
   }
 }
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -869,30 +869,26 @@ static bool check_addAvg( PelBufferOps* ref, PelBufferOps* opt, unsigned num_cas
   bool passed = true;
 
   // Test addAvg with no strides.
-  // Set height and width to powers of two >= 2.
-  for( int height : { 2, 4, 8, 16, 32, 64, 128 } )
+  for( int size : { 4, 8, 16, 32, 48, 64, 128, 192 } )
   {
-    for( int width : { 2, 4, 8, 16, 32, 64, 128 } )
+    std::ostringstream sstm_test;
+    sstm_test << "PelBufferOps::addAvg" << " size=" << size;
+    std::cout << "Testing " << sstm_test.str() << std::endl;
+
+    for( unsigned n = 0; n < num_cases; n++ )
     {
-      std::ostringstream sstm_test;
-      sstm_test << "PelBufferOps::addAvg" << " w=" << width << " h=" << height;
-      std::cout << "Testing " << sstm_test.str() << std::endl;
+      // Fill input buffers with unsigned 10-bit data from generator.
+      std::generate( src0, src0 + buf_size, inp_gen );
+      std::generate( src1, src1 + buf_size, inp_gen );
 
-      for( unsigned n = 0; n < num_cases; n++ )
-      {
-        // Fill input buffers with unsigned 10-bit data from generator.
-        std::generate( src0, src0 + buf_size, inp_gen );
-        std::generate( src1, src1 + buf_size, inp_gen );
+      // Clear output blocks.
+      memset( dest_ref, 0, buf_size * sizeof( Pel ) );
+      memset( dest_opt, 0, buf_size * sizeof( Pel ) );
 
-        // Clear output blocks.
-        memset( dest_ref, 0, buf_size * sizeof( Pel ) );
-        memset( dest_opt, 0, buf_size * sizeof( Pel ) );
+      ref->addAvg( src0, src1, dest_ref, size, shiftNum, offset, clpRng );
+      opt->addAvg( src0, src1, dest_opt, size, shiftNum, offset, clpRng );
 
-        ref->addAvg( src0, src1, dest_ref, width * height, shiftNum, offset, clpRng );
-        opt->addAvg( src0, src1, dest_opt, width * height, shiftNum, offset, clpRng );
-
-        passed = compare_values_2d( sstm_test.str(), dest_ref, dest_opt, height, width ) && passed;
-      }
+      passed = compare_values_1d( sstm_test.str(), dest_ref, dest_opt, buf_size ) && passed;
     }
   }
 


### PR DESCRIPTION
Arm: Fix CHECK condition of addAvg_neon (no stride)
- The current CHECK condition throws an error for non-power-of-two sizes, but the Neon implementation should work for sizes of 4, 8, or any multiple of 16.
- Update the CHECK to remove the overly strict restriction and instead THROW an error at the end of the if-else logic for invalid values, aligning behavior with the x86 implementation.

Improve unit test of addAvg (no stride)
- The unit test for the no-stride case only covers power-of-two heights and widths, but running a real encode shows this is insufficient.
- Update the unit test to use a single size parameter instead of separate height and width, and include non-power-of-two (but multiple of 16) values observed in real-world encodes.
- Also, verify the entire destination buffer instead of just the specified size to catch any potential out-of-bounds writes.

This pull request addresses issue #562.