### PR TITLE
Unit Test: Fix index stride in compare_values_2d

### DIFF
--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -104,8 +104,8 @@ static inline bool compare_values_2d( const std::string& context, const T* ref, 
       if( ref[idx] != opt[idx] )
       {
         std::cout << "failed: " << context << "\n"
-                  << "  mismatch:  ref[" << row << "*" << cols << "+" << col << "]=" << ref[idx]
-                  << "  opt[" << row << "*" << cols << "+" << col << "]=" << opt[idx] << "\n";
+                  << "  mismatch:  ref[" << row << "*" << stride << "+" << col << "]=" << ref[idx]
+                  << "  opt[" << row << "*" << stride << "+" << col << "]=" << opt[idx] << "\n";
         return false;
       }
     }


### PR DESCRIPTION
This fixes the index to print `row * stride + col` instead of `row * cols + col`.