### PR TITLE
Arm: Add Neon implementations of TCoeffOps::roundClip kernels

### DIFF
--- a/source/Lib/CommonLib/arm/neon/Trafo_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Trafo_neon.cpp
@@ -53,6 +53,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "TrQuant_EMT.h"
 #include "sum_neon.h"
 
+#include <cstdint>
+
 //! \ingroup CommonLib
 //! \{
 
@@ -112,6 +114,67 @@ void cpyCoeff_neon<8>( const Pel* src, ptrdiff_t srcStride, TCoeff* dst, unsigne
 
     src += srcStride;
     dst += width;
+  } while( --height != 0 );
+}
+
+template<int W>
+void roundClip_neon( TCoeff* dst, unsigned width, unsigned height, unsigned stride, const TCoeff outputMin,
+                     const TCoeff outputMax, const TCoeff round, const TCoeff shift );
+
+template<>
+void roundClip_neon<4>( TCoeff* dst, unsigned width, unsigned height, unsigned stride, const TCoeff outputMin,
+                        const TCoeff outputMax, const TCoeff round, const TCoeff shift )
+{
+  CHECK( height < 1, "Height must be >= 1" );
+  CHECK( width != 4, "Width must be 4" );
+  CHECK( round != 1 << ( shift - 1 ), "Round must be 1 << ( shift - 1 )" );
+  CHECK( outputMin != INT16_MIN, "OutputMin should be -32768" );
+  CHECK( outputMax != INT16_MAX, "OutputMax should be 32767" );
+
+  // Current call to this function guarantees a minimum rshift of 7.
+  // If dst max bit-depth is 23-bit, we do not need to do clipping to int16 range.
+  CHECK( shift < 7, "Shift must be >= 7" );
+
+  do
+  {
+    int32x4_t d = vld1q_s32( dst );
+    d = vrshlq_s32( d, vdupq_n_s32( -shift ) );
+    vst1q_s32( dst, d );
+
+    dst += stride;
+  } while( --height != 0 );
+}
+
+template<>
+void roundClip_neon<8>( TCoeff* dst, unsigned width, unsigned height, unsigned stride, const TCoeff outputMin,
+                        const TCoeff outputMax, const TCoeff round, const TCoeff shift )
+{
+  CHECK( height < 1, "Height must be >= 1" );
+  CHECK( width < 8 || width & 7, "Width must be >= 8 and a multiple of 8" );
+  CHECK( round != 1 << ( shift - 1 ), "Round must be 1 << ( shift - 1 )" );
+  CHECK( outputMin != INT16_MIN, "OutputMin should be -32768" );
+  CHECK( outputMax != INT16_MAX, "OutputMax should be 32767" );
+
+  // Current call to this function guarantees a minimum rshift of 7.
+  // If dst max bit-depth is 23-bit, we do not need to do clipping to int16 range.
+  CHECK( shift < 7, "Shift must be >= 7" );
+
+  do
+  {
+    unsigned w = 0;
+    do
+    {
+      int32x4_t d_lo = vld1q_s32( dst + w + 0 );
+      int32x4_t d_hi = vld1q_s32( dst + w + 4 );
+      d_lo = vrshlq_s32( d_lo, vdupq_n_s32( -shift ) );
+      d_hi = vrshlq_s32( d_hi, vdupq_n_s32( -shift ) );
+      vst1q_s32( dst + w + 0, d_lo );
+      vst1q_s32( dst + w + 4, d_hi );
+
+      w += 8;
+    } while( w != width );
+
+    dst += stride;
   } while( --height != 0 );
 }
 
@@ -313,8 +376,10 @@ static void fastFwdCore_neon( const TMatrixCoeff* tc, const TCoeff* src, TCoeff*
 template<>
 void TCoeffOps::_initTCoeffOpsARM<NEON>()
 {
-  cpyCoeff4 = cpyCoeff_neon<4>;
-  cpyCoeff8 = cpyCoeff_neon<8>;
+  cpyCoeff4  = cpyCoeff_neon<4>;
+  cpyCoeff8  = cpyCoeff_neon<8>;
+  roundClip4 = roundClip_neon<4>;
+  roundClip8 = roundClip_neon<8>;
 
   fastInvCore[ 0 ]    = fastInvCore_neon<4>;
   fastInvCore[ 1 ]    = fastInvCore_neon<8>;


### PR DESCRIPTION
Add Neon implementations of roundClip8 for widths that are multiples of 8, and roundClip4 for widths of 4.

The calls to these functions only pass widths and heights that are powers of two.

These Neon implementations are around 1.67x faster than the SIMDe versions when benchmarked on Neoverse N/V-series microarchitectures using LLVM 20.

-----
The Neon implementations are specialized to handle the current use case, where:

* Input data are expected to be within signed 23-bit.
* Minimum right shift is 7.
* outputMax is INT16_MAX.
* outputMin is INT16_MIN.

If all of these are satisfied, the min/max clipping operations can be removed and only rounding shift is needed.