### PR TITLE
Add missing "using namespace arm_simd" in IntraPrediction.h

### DIFF
--- a/source/Lib/CommonLib/IntraPrediction.h
+++ b/source/Lib/CommonLib/IntraPrediction.h
@@ -57,6 +57,9 @@ namespace vvenc {
 #if ENABLE_SIMD_OPT_INTRAPRED && defined( TARGET_SIMD_X86 )
 using namespace x86_simd;
 #endif
+#if ENABLE_SIMD_OPT_INTRAPRED && defined( TARGET_SIMD_ARM )
+using namespace arm_simd;
+#endif
 
 // ====================================================================================================================
 // Class definition


### PR DESCRIPTION
The `IntraPrediction.h` includes uses of the `ARM_SIMD` type but does not import the namespace that defines these types like the other headers do. This previously worked by virtue of other includes in the relevant .cpp files aliasing the namespace ahead of this header being included, however this fails when selectively disabling some SIMD implementations.

To fix this we can simply enable the namespace import, copying the style that is already used in the other headers.