### PR TITLE
Replace vmlaq_f32 with vfmaq_f32 in applyBlock Neon implementation

### DIFF
--- a/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
@@ -285,8 +285,8 @@ void applyPlanarCorrection_neon( const Pel* refPel, const ptrdiff_t refStride, P
 inline static void fastExp( float32x4_t num1, float32x4_t num2, float32x4_t denom, float32x4_t* x1, float32x4_t* x2 )
 {
   // Apply fast exp with 10 iterations.
-  float32x4_t x_lo = vmlaq_f32( vdupq_n_f32( 1.0f ), num1, denom );
-  float32x4_t x_hi = vmlaq_f32( vdupq_n_f32( 1.0f ), num2, denom );
+  float32x4_t x_lo = vfmaq_f32( vdupq_n_f32( 1.0f ), num1, denom );
+  float32x4_t x_hi = vfmaq_f32( vdupq_n_f32( 1.0f ), num2, denom );
 
   x_lo = vmulq_f32( x_lo, x_lo );
   x_hi = vmulq_f32( x_hi, x_hi );
@@ -560,8 +560,8 @@ void applyBlock_neon( const CPelBuf& src, PelBuf& dst, const CompArea& blk, cons
           float32x4_t weight_lo = vmulq_f32( x_lo, vww_val );
           float32x4_t weight_hi = vmulq_f32( x_hi, vww_val );
 
-          newVal_lo = vmlaq_f32( newVal_lo, weight_lo, refVal_lo );
-          newVal_hi = vmlaq_f32( newVal_hi, weight_hi, refVal_hi );
+          newVal_lo = vfmaq_f32( newVal_lo, weight_lo, refVal_lo );
+          newVal_hi = vfmaq_f32( newVal_hi, weight_hi, refVal_hi );
 
           tws_lo = vaddq_f32( tws_lo, weight_lo );
           tws_hi = vaddq_f32( tws_hi, weight_hi );
@@ -621,8 +621,8 @@ void applyBlock_neon( const CPelBuf& src, PelBuf& dst, const CompArea& blk, cons
         float32x4_t weight0 = vmulq_f32( x0, vww_val );
         float32x4_t weight1 = vmulq_f32( x1, vww_val );
 
-        newVal0 = vmlaq_f32( newVal0, weight0, vcvtq_f32_s32( vmovl_s16( refVal0 ) ) );
-        newVal1 = vmlaq_f32( newVal1, weight1, vcvtq_f32_s32( vmovl_s16( refVal1 ) ) );
+        newVal0 = vfmaq_f32( newVal0, weight0, vcvtq_f32_s32( vmovl_s16( refVal0 ) ) );
+        newVal1 = vfmaq_f32( newVal1, weight1, vcvtq_f32_s32( vmovl_s16( refVal1 ) ) );
 
         tws0 = vaddq_f32( tws0, weight0 );
         tws1 = vaddq_f32( tws1, weight1 );


### PR DESCRIPTION
- The vfmaq_f32 intrinsic performs a true fused MAC even when ffp-contract is disabled, whereas vmlaq_f32 does not.
- No functional change: does not change the checksum of an encoded video and all existing tests continue to pass.
- Improves performance by approximately 5% compared to existing vmlaq_f32 version with ffp-contract disabled.