### PR TITLE
GH-Actions fail on error

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,21 +18,18 @@ jobs:
           - {
               name: "Windows MSVC 64 Bit",
               os: windows-2022,
-              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: x64
             }
           - {
               name: "Windows MSVC 32 Bit",
               os: windows-2022,
-              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: Win32
             }
           - {
               name: "Windows MSVC arm64",
               os: windows-2022,
-              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: arm64,
             }

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -75,9 +75,8 @@ jobs:
     - name: MSVC build
       if: contains( matrix.config.generators, 'Visual Studio' )
       run: |
-        $ErrorActionPreference = 'Stop'
         cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/static --config Release
         cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/shared --config Release
-      shell: pwsh
+      shell: bash

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         $ErrorActionPreference = 'stop'
         $PSNativeCommandUseErrorActionPreference = $true
-        cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
+        cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/static --config Release
-        cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
+        cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/shared --config Release

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -74,9 +74,11 @@ jobs:
 
     - name: MSVC build
       if: contains( matrix.config.generators, 'Visual Studio' )
+      shell: pwsh
       run: |
+        $ErrorActionPreference = 'stop'
+        $PSNativeCommandUseErrorActionPreference = $true
         cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/static --config Release
         cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/shared --config Release
-      shell: bash

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -78,8 +78,9 @@ jobs:
     - name: MSVC build
       if: contains( matrix.config.generators, 'Visual Studio' )
       run: |
+        $ErrorActionPreference = 'Stop'
         cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/static --config Release
         cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_OVERRIDE_COMPILER_CHECK=ON -A "${{ matrix.config.msvc_arch }}"
         cmake --build build/shared --config Release
-      shell: cmd
+      shell: pwsh

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,18 +18,21 @@ jobs:
           - {
               name: "Windows MSVC 64 Bit",
               os: windows-2022,
+              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: x64
             }
           - {
               name: "Windows MSVC 32 Bit",
               os: windows-2022,
+              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: Win32
             }
           - {
               name: "Windows MSVC arm64",
               os: windows-2022,
+              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
               generators: "Visual Studio 17 2022",
               msvc_arch: arm64,
             }

--- a/.gitlab-ci-internal.yml
+++ b/.gitlab-ci-internal.yml
@@ -257,7 +257,6 @@ test_vs2022_Win32:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: Win32
-     CONFIG_OPTIONS: "-DVVENC_OVERRIDE_COMPILER_CHECK=1"
   tags:
     - vs2022
 
@@ -265,7 +264,6 @@ test_vs2022:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: x64
-     CONFIG_OPTIONS: "-DVVENC_OVERRIDE_COMPILER_CHECK=1"
   tags:
     - vs2022
 
@@ -273,7 +271,6 @@ test_vs2022_arm64:
   extends: .build_test_msvc_template
   variables:
      MSVC_ARCH: arm64
-     CONFIG_OPTIONS: "-DVVENC_OVERRIDE_COMPILER_CHECK=1"
   tags:
     - vs2022-arm
 


### PR DESCRIPTION
The windows builds didn't properly fail, when a command failed. So we switch the windows builds to use PowerShell and set `$ErrorActionPreference = 'stop'` and `$PSNativeCommandUseErrorActionPreference = $true`

See: actions/runner-images#6668

Also, `-DVVENC_OVERRIDE_COMPILER_CHECK` is not needed any more, since the Runners use a fixed compiler now.