### PR TITLE
Rename filterXxY to filterWxH and make height a loop parameter in their unit tests

### DIFF
--- a/source/Lib/CommonLib/InterPrediction.cpp
+++ b/source/Lib/CommonLib/InterPrediction.cpp
@@ -849,11 +849,11 @@ void InterPredInterpolation::xPredInterBlk( const ComponentID compID, const Codi
   }
   else if( backupWidth == 16 )
   {
-    m_if.filter16x16( compID, refBufPtr, refBufStride, dstBuf.buf, dstBuf.stride, 16, backupHeight, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
+    m_if.filter16xH( compID, refBufPtr, refBufStride, dstBuf.buf, dstBuf.stride, 16, backupHeight, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
   }
   else if( backupWidth == 8 )
   {
-    m_if.filter8x8( compID, refBufPtr, refBufStride, dstBuf.buf, dstBuf.stride, 8, backupHeight, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
+    m_if.filter8xH( compID, refBufPtr, refBufStride, dstBuf.buf, dstBuf.stride, 8, backupHeight, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
   }
   else
   {

--- a/source/Lib/CommonLib/InterpolationFilter.cpp
+++ b/source/Lib/CommonLib/InterpolationFilter.cpp
@@ -213,20 +213,20 @@ InterpolationFilter::InterpolationFilter()
   m_filterCopy[1][0]   = filterCopy<true, false>;
   m_filterCopy[1][1]   = filterCopy<true, true>;
 
-  m_filter4x4[0][0] = filterXxY_N8<false, 4>;
-  m_filter4x4[0][1] = filterXxY_N8<true , 4>;
-  m_filter4x4[1][0] = filterXxY_N4<false, 4>;
-  m_filter4x4[1][1] = filterXxY_N4<true , 4>;
+  m_filter4x4[0][0] = filterWxH_N8<false, 4>;
+  m_filter4x4[0][1] = filterWxH_N8<true , 4>;
+  m_filter4x4[1][0] = filterWxH_N4<false, 4>;
+  m_filter4x4[1][1] = filterWxH_N4<true , 4>;
   
-  m_filter8x8[0][0] = filterXxY_N8<false, 8>;
-  m_filter8x8[0][1] = filterXxY_N8<true , 8>;
-  m_filter8x8[1][0] = filterXxY_N4<false, 8>;
-  m_filter8x8[1][1] = filterXxY_N4<true , 8>;
+  m_filter8xH[0][0] = filterWxH_N8<false, 8>;
+  m_filter8xH[0][1] = filterWxH_N8<true , 8>;
+  m_filter8xH[1][0] = filterWxH_N4<false, 8>;
+  m_filter8xH[1][1] = filterWxH_N4<true , 8>;
   
-  m_filter16x16[0][0] = filterXxY_N8<false, 16>;
-  m_filter16x16[0][1] = filterXxY_N8<true , 16>;
-  m_filter16x16[1][0] = filterXxY_N4<false, 16>;
-  m_filter16x16[1][1] = filterXxY_N4<true , 16>;
+  m_filter16xH[0][0] = filterWxH_N8<false, 16>;
+  m_filter16xH[0][1] = filterWxH_N8<true , 16>;
+  m_filter16xH[1][0] = filterWxH_N4<false, 16>;
+  m_filter16xH[1][1] = filterWxH_N4<true , 16>;
 
   m_filterN2_2D = scalarFilterN2_2D;
 
@@ -705,7 +705,7 @@ void InterpolationFilter::filter4x4( const ComponentID compID, const Pel* src, i
     THROW( "4x4 interpolation filter does not support bilinear filtering!" );
   }
 }
-void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, int srcStride, Pel* dst, int dstStride, int width, int height,  int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng,bool useAltHpelIf,int nFilterIdx /*= 0*/ )
+void InterpolationFilter::filter8xH( const ComponentID compID, const Pel* src, int srcStride, Pel* dst, int dstStride, int width, int height,  int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng,bool useAltHpelIf,int nFilterIdx /*= 0*/ )
 {
   const int vFilterSize = nFilterIdx == 1 ? 2 : ( isLuma( compID ) ? NTAPS_LUMA : NTAPS_CHROMA );
 
@@ -716,7 +716,7 @@ void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, i
     const TFilterCoeff* vCoeff = (useAltHpelIf && fracY==8) ? m_lumaAltHpelIFilter : m_lumaFilter[fracY];
     const TFilterCoeff* hCoeff = (useAltHpelIf && fracX==8) ? m_lumaAltHpelIFilter : m_lumaFilter[fracX];
 
-    m_filter8x8[0][isLast]( clpRng,src,srcStride, dst,dstStride, width, height, hCoeff, vCoeff);
+    m_filter8xH[0][isLast]( clpRng,src,srcStride, dst,dstStride, width, height, hCoeff, vCoeff);
   }
   else if( vFilterSize == 4 )
   {
@@ -725,7 +725,7 @@ void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, i
     const int csx = getComponentScaleX( compID, fmt );
     const int csy = getComponentScaleY( compID, fmt );
 
-    m_filter8x8[1][isLast]( clpRng, src,srcStride, dst,dstStride, width, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
+    m_filter8xH[1][isLast]( clpRng, src,srcStride, dst,dstStride, width, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
   }
   else
   {
@@ -733,7 +733,7 @@ void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, i
   }
 }
 
-void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng,bool useAltHpelIf, int nFilterIdx /*= 0*/ )
+void InterpolationFilter::filter16xH( const ComponentID compID, const Pel* src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng,bool useAltHpelIf, int nFilterIdx /*= 0*/ )
 {
   const int vFilterSize = nFilterIdx == 1 ? 2 : ( isLuma( compID ) ? NTAPS_LUMA : NTAPS_CHROMA );
 
@@ -744,7 +744,7 @@ void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src,
     const TFilterCoeff* vCoeff = (useAltHpelIf && fracY==8) ? m_lumaAltHpelIFilter : m_lumaFilter[fracY];
     const TFilterCoeff* hCoeff = (useAltHpelIf && fracX==8) ? m_lumaAltHpelIFilter : m_lumaFilter[fracX];
 
-    m_filter16x16[0][isLast]( clpRng, src, srcStride, dst,dstStride, width, height, hCoeff, vCoeff );
+    m_filter16xH[0][isLast]( clpRng, src, srcStride, dst,dstStride, width, height, hCoeff, vCoeff );
   }
   else if( vFilterSize == 4 )
   {
@@ -753,7 +753,7 @@ void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src,
     const int csx = getComponentScaleX( compID, fmt );
     const int csy = getComponentScaleY( compID, fmt );
 
-    m_filter16x16[1][isLast]( clpRng, src,srcStride, dst,dstStride, width, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
+    m_filter16xH[1][isLast]( clpRng, src,srcStride, dst,dstStride, width, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
   }
   else
   {
@@ -762,7 +762,7 @@ void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src,
 }
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N2( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* _dst, int dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void InterpolationFilter::filterWxH_N2( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* _dst, int dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   int row, col;
 
@@ -829,7 +829,7 @@ void InterpolationFilter::filterXxY_N2( const ClpRng& clpRng, Pel const *src, in
 }
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N4( const ClpRng& clpRng, const Pel* src, int srcStride, Pel* _dst, int dstStride, int width, int height, const TFilterCoeff *coeffH, const TFilterCoeff *coeffV )
+void InterpolationFilter::filterWxH_N4( const ClpRng& clpRng, const Pel* src, int srcStride, Pel* _dst, int dstStride, int width, int height, const TFilterCoeff *coeffH, const TFilterCoeff *coeffV )
 {
   int row, col;
 
@@ -905,7 +905,7 @@ void InterpolationFilter::filterXxY_N4( const ClpRng& clpRng, const Pel* src, in
 
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N8( const ClpRng& clpRng, const Pel* src, int srcStride, Pel* _dst, int dstStride, int width, int h, const TFilterCoeff *coeffH, const TFilterCoeff *coeffV )
+void InterpolationFilter::filterWxH_N8( const ClpRng& clpRng, const Pel* src, int srcStride, Pel* _dst, int dstStride, int width, int h, const TFilterCoeff *coeffH, const TFilterCoeff *coeffV )
 {
   int row, col;
 

--- a/source/Lib/CommonLib/InterpolationFilter.h
+++ b/source/Lib/CommonLib/InterpolationFilter.h
@@ -89,11 +89,11 @@ public:
   void filterVer        (const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride, int width, int height, bool isFirst, bool isLast, TFilterCoeff const *coeff);
 
   template<bool isLast, int w>
-  static void filterXxY_N2     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N2     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
   template<bool isLast, int w>
-  static void filterXxY_N4     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N4     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
   template<bool isLast, int w>
-  static void filterXxY_N8     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N8     (const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
 
   static void scalarFilterN2_2D(const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *ch,     TFilterCoeff const *cv);
 
@@ -109,10 +109,10 @@ public:
   void( *m_filterN2_2D        )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *ch, TFilterCoeff const *cv );
   void( *m_filterHor[4][2][2] )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeff);
   void( *m_filterVer[4][2][2] )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeff);
-  void( *m_filterCopy[2][2] )  ( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, bool biMCForDMVR);
-  void( *m_filter4x4  [2][2] ) ( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
-  void( *m_filter8x8  [3][2] ) ( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
-  void( *m_filter16x16[3][2] ) ( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_filterCopy[2][2]   )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, bool biMCForDMVR);
+  void( *m_filter4x4 [2][2]   )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_filter8xH [3][2]   )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_filter16xH[3][2]   )( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
   void (*m_weightedGeoBlk)(const ClpRngs &clpRngs, const CodingUnit& cu, const uint32_t width, const uint32_t height,
                            const ComponentID compIdx, const uint8_t splitDir, PelUnitBuf &predDst, PelUnitBuf &predSrc0,
                            PelUnitBuf &predSrc1);
@@ -132,8 +132,8 @@ public:
 
   void filterN2_2D(const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,                                        const ClpRng& clpRng);
   void filter4x4  (const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,   bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0);
-  void filter8x8  (const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,   bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0);
-  void filter16x16(const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,   bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0);
+  void filter8xH  (const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,   bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0);
+  void filter16xH (const ComponentID compID, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, int fracX, int fracY,   bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0);
   void filterHor  (const ComponentID compID, Pel const* src, int srcStride, Pel* dst, int dstStride, int width, int height, int frac,               bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0, int reduceTap = 0);
   void filterVer  (const ComponentID compID, Pel const* src, int srcStride, Pel* dst, int dstStride, int width, int height, int frac, bool isFirst, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false, int nFilterIdx = 0, int reduceTap = 0);
 

--- a/source/Lib/CommonLib/arm/neon/InterpolationFilter_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/InterpolationFilter_neon.cpp
@@ -146,7 +146,7 @@ static void simdInterpolateN2_2D_neon( const ClpRng& clpRng, const Pel* src, con
   }
 }
 
-static int16x4_t filter4xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x4_t filter4xH_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
   int16x8_t vsrca0 = vld1q_s16( src + 0 );
   int16x8_t vsrca1 = vld1q_s16( src + 1 );
@@ -169,23 +169,23 @@ static int16x4_t filter4xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voff
   return vqmovn_s32( vsuma );
 }
 
-static int16x8_t filter8xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x8_t filter8xH_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
-  int16x4_t lo = filter4xX_N8_neon( src + 0, ch, voffset1, invshift1st );
-  int16x4_t hi = filter4xX_N8_neon( src + 4, ch, voffset1, invshift1st );
+  int16x4_t lo = filter4xH_N8_neon( src + 0, ch, voffset1, invshift1st );
+  int16x4_t hi = filter4xH_N8_neon( src + 4, ch, voffset1, invshift1st );
   return vcombine_s16( lo, hi );
 }
 
-static int16x8x2_t filter16xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x8x2_t filter16xH_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
   int16x8x2_t result;
-  result.val[0] = filter8xX_N8_neon( src + 0, ch, voffset1, invshift1st );
-  result.val[1] = filter8xX_N8_neon( src + 8, ch, voffset1, invshift1st );
+  result.val[0] = filter8xH_N8_neon( src + 0, ch, voffset1, invshift1st );
+  result.val[1] = filter8xH_N8_neon( src + 8, ch, voffset1, invshift1st );
   return result; // explicit return since MSVC for arm64 does not support direct return with typecast
 }
 
 template<bool isLast>
-static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
+static void simdFilter4xH_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
                                    int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -217,24 +217,24 @@ static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, int src
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x4_t vsrcv0 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv0 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv1 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv1 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv2 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv2 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv3 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv3 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv4 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv4 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv5 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv5 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv6 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv6 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x4_t vsrcv7 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x4_t vsrcv7 = filter4xH_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -272,7 +272,7 @@ static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, int src
 }
 
 template<bool isLast>
-static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
+static void simdFilter8xH_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
                                    int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -304,24 +304,24 @@ static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, int src
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x8_t vsrcv0 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv0 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv1 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv1 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv2 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv2 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv3 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv3 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv4 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv4 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv5 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv5 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv6 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv6 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x8_t vsrcv7 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x8_t vsrcv7 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -379,7 +379,7 @@ static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, int src
 }
 
 template<bool isLast>
-static void simdFilter16xX_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
+static void simdFilter16xH_N8_neon( const ClpRng& clpRng, Pel const* src, int srcStride, Pel* dst, int dstStride,
                                     int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -411,24 +411,24 @@ static void simdFilter16xX_N8_neon( const ClpRng& clpRng, Pel const* src, int sr
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x8x2_t vsrcv0 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv0 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv1 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv1 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv2 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv2 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv3 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv3 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv4 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv4 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv5 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv5 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv6 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv6 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x8x2_t vsrcv7 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x8x2_t vsrcv7 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -1029,14 +1029,14 @@ void simdFilterCopy_neon( const ClpRng& clpRng, const Pel* src, int srcStride, P
 template<>
 void InterpolationFilter::_initInterpolationFilterARM<NEON>()
 {
-  m_filter4x4[ 0 ][ 0 ] = simdFilter4xX_N8_neon<false>;
-  m_filter4x4[ 0 ][ 1 ] = simdFilter4xX_N8_neon<true>;
+  m_filter4x4[0][0] = simdFilter4xH_N8_neon<false>;
+  m_filter4x4[0][1] = simdFilter4xH_N8_neon<true>;
 
-  m_filter8x8[ 0 ][ 0 ] = simdFilter8xX_N8_neon<false>;
-  m_filter8x8[ 0 ][ 1 ] = simdFilter8xX_N8_neon<true>;
+  m_filter8xH[0][0] = simdFilter8xH_N8_neon<false>;
+  m_filter8xH[0][1] = simdFilter8xH_N8_neon<true>;
 
-  m_filter16x16[ 0 ][ 0 ] = simdFilter16xX_N8_neon<false>;
-  m_filter16x16[ 0 ][ 1 ] = simdFilter16xX_N8_neon<true>;
+  m_filter16xH[0][0] = simdFilter16xH_N8_neon<false>;
+  m_filter16xH[0][1] = simdFilter16xH_N8_neon<true>;
 
   m_filterN2_2D = simdInterpolateN2_2D_neon;
 

--- a/source/Lib/CommonLib/x86/InterpolationFilterX86.h
+++ b/source/Lib/CommonLib/x86/InterpolationFilterX86.h
@@ -2206,7 +2206,7 @@ void simdFilter4x4_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel*
 
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter16xX_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter16xH_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   src-=3;
   src-=3*srcStride;
@@ -2476,7 +2476,7 @@ void simdFilter16xX_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter16xX_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter16xH_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   src-=1;
   src-=srcStride;
@@ -2523,7 +2523,7 @@ void simdFilter16xX_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter8xX_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter8xH_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   src-=3;
   src-=3*srcStride;
@@ -2760,7 +2760,7 @@ void simdFilter8xX_N8( const ClpRng& clpRng, Pel const *src, int srcStride, Pel*
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter8xX_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter8xH_N4( const ClpRng& clpRng, Pel const *src, int srcStride, Pel* dst, int dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   src-=1;
   src-=srcStride;
@@ -3459,16 +3459,16 @@ void InterpolationFilter::_initInterpolationFilterX86()
   m_filter4x4[1][0]    = simdFilter4x4_N4<vext, false>;
   m_filter4x4[1][1]    = simdFilter4x4_N4<vext, true>;
   
-  m_filter8x8[0][0]    = simdFilter8xX_N8<vext, false>;
-  m_filter8x8[0][1]    = simdFilter8xX_N8<vext, true>;
-  m_filter8x8[1][0]    = simdFilter8xX_N4<vext, false>;
-  m_filter8x8[1][1]    = simdFilter8xX_N4<vext, true>;
+  m_filter8xH[0][0]    = simdFilter8xH_N8<vext, false>;
+  m_filter8xH[0][1]    = simdFilter8xH_N8<vext, true>;
+  m_filter8xH[1][0]    = simdFilter8xH_N4<vext, false>;
+  m_filter8xH[1][1]    = simdFilter8xH_N4<vext, true>;
 
-  m_filter16x16[0][0]  = simdFilter16xX_N8<vext, false>;
-  m_filter16x16[0][1]  = simdFilter16xX_N8<vext, true>;
+  m_filter16xH[0][0]  = simdFilter16xH_N8<vext, false>;
+  m_filter16xH[0][1]  = simdFilter16xH_N8<vext, true>;
 
-  m_filter16x16[1][0]  = simdFilter16xX_N4<vext, false>;
-  m_filter16x16[1][1]  = simdFilter16xX_N4<vext, true>;
+  m_filter16xH[1][0]  = simdFilter16xH_N4<vext, false>;
+  m_filter16xH[1][1]  = simdFilter16xH_N4<vext, true>;
 
   m_filterN2_2D        = simdInterpolateN2_2D<vext>;
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -1324,7 +1324,7 @@ static bool test_PelBufferOps()
 
 #if ENABLE_SIMD_OPT_MCIF
 template<bool isLast, unsigned width>
-static bool check_filterXxY_N8( InterpolationFilter* ref, InterpolationFilter* opt, unsigned height, unsigned num_cases )
+static bool check_filterWxH_N8( InterpolationFilter* ref, InterpolationFilter* opt, unsigned height, unsigned num_cases )
 {
   static_assert( width == 4 || width == 8 || width == 16, "Width must be either 4, 8, or 16" );
 
@@ -1345,8 +1345,8 @@ static bool check_filterXxY_N8( InterpolationFilter* ref, InterpolationFilter* o
     InputGenerator<Pel> inp_gen{ bd, /*is_signed=*/false };
 
     std::ostringstream sstm_test;
-    sstm_test << "InterpolationFilter::filter" << width << "x" << width << "[0][" << isLast << "]"
-              << " bitDepth=" << bd << " height=" << height;
+    sstm_test << "InterpolationFilter::filter" << width << "x" << height << "[0][" << isLast << "]"
+              << " bitDepth=" << bd;
     std::cout << "Testing " << sstm_test.str() << std::endl;
 
     for( unsigned n = 0; n < num_cases; n++ )
@@ -1392,16 +1392,16 @@ static bool check_filterXxY_N8( InterpolationFilter* ref, InterpolationFilter* o
       }
       else if( width == 8 )
       {
-        ref->m_filter8x8[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
+        ref->m_filter8xH[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
                                      ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
-        opt->m_filter8x8[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
+        opt->m_filter8xH[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
                                      ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
       }
       else // width == 16
       {
-        ref->m_filter16x16[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
+        ref->m_filter16xH[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
                                        ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
-        opt->m_filter16x16[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
+        opt->m_filter16xH[0][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
                                        ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
       }
 
@@ -1417,7 +1417,7 @@ static bool check_filterXxY_N8( InterpolationFilter* ref, InterpolationFilter* o
 }
 
 template<bool isLast, unsigned width>
-static bool check_filterXxY_N4( InterpolationFilter* ref, InterpolationFilter* opt, unsigned height, unsigned num_cases )
+static bool check_filterWxH_N4( InterpolationFilter* ref, InterpolationFilter* opt, unsigned height, unsigned num_cases )
 {
   static_assert( width == 4 || width == 8 || width == 16, "Width must be either 4, 8, or 16" );
 
@@ -1437,8 +1437,8 @@ static bool check_filterXxY_N4( InterpolationFilter* ref, InterpolationFilter* o
     InputGenerator<Pel> inp_gen{ bd, /*is_signed=*/false };
 
     std::ostringstream sstm_test;
-    sstm_test << "InterpolationFilter::filter" << width << "x" << width << "[1][" << isLast << "]"
-              << " bitDepth=" << bd << " height=" << height;
+    sstm_test << "InterpolationFilter::filter" << width << "x" << height << "[1][" << isLast << "]"
+              << " bitDepth=" << bd;
     std::cout << "Testing " << sstm_test.str() << std::endl;
 
     for( unsigned n = 0; n < num_cases; n++ )
@@ -1469,16 +1469,16 @@ static bool check_filterXxY_N4( InterpolationFilter* ref, InterpolationFilter* o
       }
       else if( width == 8 )
       {
-        ref->m_filter8x8[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
+        ref->m_filter8xH[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
                                      ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
-        opt->m_filter8x8[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
+        opt->m_filter8xH[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
                                      ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
       }
       else // width == 16
       {
-        ref->m_filter16x16[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
+        ref->m_filter16xH[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_ref.data(),
                                        ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
-        opt->m_filter16x16[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
+        opt->m_filter16xH[1][isLast]( clpRng, src.data() + src_offset, ( int )srcStride, dst_opt.data(),
                                        ( int )dstStride, ( int )width, ( int )height, pCoeffH, pCoeffV );
       }
 
@@ -1560,25 +1560,25 @@ static bool test_InterpolationFilter()
   bool passed = true;
 
   // The width = 4 case is only called with height = 4.
-  passed = check_filterXxY_N8<false, 4>( &ref, &opt, 4, num_cases ) && passed;
-  passed = check_filterXxY_N8<true, 4>( &ref, &opt, 4, num_cases ) && passed;
+  passed = check_filterWxH_N8<false, 4>( &ref, &opt, 4, num_cases ) && passed;
+  passed = check_filterWxH_N8<true, 4>( &ref, &opt, 4, num_cases ) && passed;
   for( unsigned height : { 4, 8, 16, 32, 64, 128 } )
   {
-    passed = check_filterXxY_N8<false, 8>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N8<true, 8>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N8<false, 16>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N8<true, 16>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N8<false, 8>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N8<true, 8>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N8<false, 16>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N8<true, 16>( &ref, &opt, height, num_cases ) && passed;
   }
 
   // The width = 4 case is only called with height = 4.
-  passed = check_filterXxY_N4<false, 4>( &ref, &opt, 4, num_cases ) && passed;
-  passed = check_filterXxY_N4<true, 4>( &ref, &opt, 4, num_cases ) && passed;
+  passed = check_filterWxH_N4<false, 4>( &ref, &opt, 4, num_cases ) && passed;
+  passed = check_filterWxH_N4<true, 4>( &ref, &opt, 4, num_cases ) && passed;
   for( unsigned height : { 2, 4, 8, 16, 32 } )
   {
-    passed = check_filterXxY_N4<false, 8>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N4<true, 8>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N4<false, 16>( &ref, &opt, height, num_cases ) && passed;
-    passed = check_filterXxY_N4<true, 16>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N4<false, 8>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N4<true, 8>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N4<false, 16>( &ref, &opt, height, num_cases ) && passed;
+    passed = check_filterWxH_N4<true, 16>( &ref, &opt, height, num_cases ) && passed;
   }
 
   passed = check_filterCopy<0, 0>( &ref, &opt, num_cases, false ) && passed;


### PR DESCRIPTION
Make height a loop parameter in the filterXxY unit tests
- Use height as a primary loop parameter instead of a randomized variable to ensure all height values are tested.
- Also, add 2 to the list of heights being tested in N4.

Rename filterXxY to filterWxH
- Replace `XxY` with `WxH` to reflect width and height more explicitly, improving code readability and consistency with common dimension notation.
- Also replace 8x8 and 16x16 with 8xH and 16xH, respectively, to indicate that they process inputs of varying heights.

----
Hello,

I suppose this unit test fix should merge first before my Neon patch #593.