### PR TITLE
Add unit tests for RdCost::GetSADwMask

### DIFF
--- a/source/Lib/CommonLib/RdCost.h
+++ b/source/Lib/CommonLib/RdCost.h
@@ -117,11 +117,11 @@ public:
   Distortion ( *m_fxdWtdPredPtr )( const DistParam& dp, uint32_t fixedWeight );
   Distortion ( *m_wtdPredPtr[2] )( const DistParam& dp, ChromaFormat chmFmt, const uint32_t* lumaWeights );
 
-private:
   // for distortion
-
   FpDistFunc              m_afpDistortFunc[2][DF_TOTAL_FUNCTIONS]; // [eDFunc]
   FpDistFuncX5            m_afpDistortFuncX5[2]; // [eDFunc]
+
+private:
   vvencCostMode           m_costMode;
   double                  m_distortionWeight[MAX_NUM_COMP]; // only chroma values are used.
   double                  m_dLambda;


### PR DESCRIPTION
This function is only called for powers of two widths and heights of at least 8. The mask parameter elements are either zero or one. The `applyWeight` parameter appears to be always zero, so hard-code this in the test.