### PR TITLE
Add Neon implementation for applyFrac6Tap functions

### DIFF
--- a/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
@@ -59,6 +59,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_MCTF
 
 #include "MCTF_neon.h"
+#include "mem_neon.h"
 
 namespace vvenc
 {
@@ -471,6 +472,369 @@ void applyBlock_neon( const CPelBuf& src, PelBuf& dst, const CompArea& blk, cons
                      weightScaling, sigmaSq );
 }
 
+enum class FilterCoeffType
+{
+  NoOp = 1,          // No-op filter.
+  FullSymmetric,     // Fully symmetric around center: coeff[1] == coeff[6], coeff[2] == coeff[5], coeff[3] == coeff[4].
+  AddLeft,           // Left side addition: coeff[1] == 1, coeff[6] == 0.
+  AddRight,          // Right side addition: coeff[6] == 1, coeff[1] == 0.
+  AddSymmetric,      // Symmetric addition taps: coeff[1] == coeff[6] == 1.
+  ShiftLeft,         // Shift Left: coeff[1] == 2, coeff[6] != 2.
+  ShiftRight,        // Shift Right: coeff[6] == 2, coeff[1] != 2.
+  MultiplySymmetric, // Partially symmetric: coeff[1] == coeff[6], but coeff[2] != coeff[5] or coeff[3] != coeff[4].
+};
+
+enum class FilterDirection
+{
+  Horizontal = 1,
+  Vertical
+};
+
+using ApplyFrac6TapFunc = void ( * )( const Pel*, ptrdiff_t, Pel*, ptrdiff_t, int, int, const int16_t*, const int16_t*,
+                                      int );
+
+static inline FilterCoeffType selectFilterType( const int16_t* coeff )
+{
+  if( coeff[1] == 0 && coeff[2] == 0 && coeff[4] == 0 && coeff[5] == 0 && coeff[6] == 0 )
+    return FilterCoeffType::NoOp;
+  if( coeff[1] == coeff[6] && coeff[2] == coeff[5] && coeff[3] == coeff[4] )
+    return FilterCoeffType::FullSymmetric;
+  if( coeff[1] == 1 && coeff[6] == 1 )
+    return FilterCoeffType::AddSymmetric;
+  if( coeff[1] == 1 && coeff[6] == 0 )
+    return FilterCoeffType::AddLeft;
+  if( coeff[6] == 1 && coeff[1] == 0 )
+    return FilterCoeffType::AddRight;
+  if( coeff[1] == coeff[6] )
+    return FilterCoeffType::MultiplySymmetric;
+  if( coeff[1] == 2 )
+    return FilterCoeffType::ShiftLeft;
+  if( coeff[6] == 2 )
+    return FilterCoeffType::ShiftRight;
+
+  CHECK( true, "Invalid filter coefficients!" );
+  return FilterCoeffType::NoOp; // Fallback dummy.
+};
+
+static inline void applyFrac6Tap_8x_copy_neon( const Pel* org, const ptrdiff_t origStride, Pel* dst,
+                                               const ptrdiff_t dstStride, int w, int h )
+{
+  CHECKD( w % 8 != 0, "Width must be multiple of 8!" );
+  CHECKD( h % 4 != 0, "Height must be multiple of 4!" );
+
+  h >>= 2;
+
+  do
+  {
+    int width = w >> 3;
+    do
+    {
+      const int16x8_t src0 = vld1q_s16( org + 0 * origStride );
+      const int16x8_t src1 = vld1q_s16( org + 1 * origStride );
+      const int16x8_t src2 = vld1q_s16( org + 2 * origStride );
+      const int16x8_t src3 = vld1q_s16( org + 3 * origStride );
+      vst1q_s16( dst + 0 * dstStride, src0 );
+      vst1q_s16( dst + 1 * dstStride, src1 );
+      vst1q_s16( dst + 2 * dstStride, src2 );
+      vst1q_s16( dst + 3 * dstStride, src3 );
+
+      org += 8;
+      dst += 8;
+    } while( --width != 0 );
+
+    org += 4 * origStride - w;
+    dst += 4 * dstStride - w;
+  } while( --h != 0 );
+}
+
+template<FilterDirection direction, FilterCoeffType Type>
+static inline int16x8_t applyFrac6Tap_8x_filter1D_neon( const int16x8_t* src, const int16x8_t filterVal )
+{
+  // Filter weight is 64.
+  constexpr int filterBits = 6;
+
+  int16x8_t acc_s16 = vdupq_n_s16( 0 );
+  int32x4_t acc_s32_lo, acc_s32_hi;
+
+  // Accumulate outer taps (1, 2, 5, 6) in 16-bit, and central taps (3, 4) in 32-bit precision.
+  if( Type == FilterCoeffType::FullSymmetric )
+  {
+    const int16x8_t sum05 = vaddq_s16( src[0], src[5] );
+    const int16x8_t sum14 = vaddq_s16( src[1], src[4] );
+    const int16x8_t sum23 = vaddq_s16( src[2], src[3] );
+
+    acc_s32_lo = vmull_lane_s16( vget_low_s16( sum05 ), vget_low_s16( filterVal ), 1 );
+    acc_s32_hi = vmull_lane_s16( vget_high_s16( sum05 ), vget_low_s16( filterVal ), 1 );
+    acc_s32_lo = vmlal_lane_s16( acc_s32_lo, vget_low_s16( sum14 ), vget_low_s16( filterVal ), 2 );
+    acc_s32_hi = vmlal_lane_s16( acc_s32_hi, vget_high_s16( sum14 ), vget_low_s16( filterVal ), 2 );
+    acc_s32_lo = vmlal_lane_s16( acc_s32_lo, vget_low_s16( sum23 ), vget_low_s16( filterVal ), 3 );
+    acc_s32_hi = vmlal_lane_s16( acc_s32_hi, vget_high_s16( sum23 ), vget_low_s16( filterVal ), 3 );
+
+    if( direction == FilterDirection::Horizontal )
+    {
+      return vcombine_s16( vrshrn_n_s32( acc_s32_lo, filterBits ), vrshrn_n_s32( acc_s32_hi, filterBits ) );
+    }
+    else // Vertical.
+    {
+      const uint16x8_t ysum =
+          vcombine_u16( vqrshrun_n_s32( acc_s32_lo, filterBits ), vqrshrun_n_s32( acc_s32_hi, filterBits ) );
+      return vreinterpretq_s16_u16( ysum );
+    }
+  }
+  else if( Type == FilterCoeffType::AddLeft )
+  {
+    acc_s16 = vmlaq_lane_s16( src[0], src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+  }
+  else if( Type == FilterCoeffType::AddRight )
+  {
+    acc_s16 = vmlaq_lane_s16( src[5], src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+  }
+  else if( Type == FilterCoeffType::AddSymmetric )
+  {
+    acc_s16 = vaddq_s16( src[0], src[5] );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+  }
+  else if( Type == FilterCoeffType::ShiftLeft )
+  {
+    acc_s16 = vshlq_n_s16( src[0], 1 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[5], vget_high_s16( filterVal ), 2 );
+  }
+  else if( Type == FilterCoeffType::ShiftRight )
+  {
+    acc_s16 = vshlq_n_s16( src[5], 1 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[0], vget_low_s16( filterVal ), 1 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+  }
+  else if( Type == FilterCoeffType::MultiplySymmetric )
+  {
+    int16x8_t sum05 = vaddq_s16( src[0], src[5] );
+    acc_s16 = vmulq_lane_s16( sum05, vget_low_s16( filterVal ), 1 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[1], vget_low_s16( filterVal ), 2 );
+    acc_s16 = vmlaq_lane_s16( acc_s16, src[4], vget_high_s16( filterVal ), 1 );
+  }
+
+  acc_s32_lo = vmovl_s16( vget_low_s16( acc_s16 ) );
+  acc_s32_hi = vmovl_s16( vget_high_s16( acc_s16 ) );
+  acc_s32_lo = vmlal_lane_s16( acc_s32_lo, vget_low_s16( src[2] ), vget_low_s16( filterVal ), 3 );
+  acc_s32_hi = vmlal_lane_s16( acc_s32_hi, vget_high_s16( src[2] ), vget_low_s16( filterVal ), 3 );
+  acc_s32_lo = vmlal_lane_s16( acc_s32_lo, vget_low_s16( src[3] ), vget_high_s16( filterVal ), 0 );
+  acc_s32_hi = vmlal_lane_s16( acc_s32_hi, vget_high_s16( src[3] ), vget_high_s16( filterVal ), 0 );
+
+  if( direction == FilterDirection::Horizontal )
+  {
+    return vcombine_s16( vrshrn_n_s32( acc_s32_lo, filterBits ), vrshrn_n_s32( acc_s32_hi, filterBits ) );
+  }
+  else // Vertical.
+  {
+    const uint16x8_t ysum =
+        vcombine_u16( vqrshrun_n_s32( acc_s32_lo, filterBits ), vqrshrun_n_s32( acc_s32_hi, filterBits ) );
+    return vreinterpretq_s16_u16( ysum );
+  }
+}
+
+template<FilterCoeffType xType, FilterCoeffType yType>
+static inline void applyFrac6Tap_8x_filter2D_neon( const Pel* org, const ptrdiff_t origStride, Pel* dst,
+                                                   const ptrdiff_t dstStride, int w, int h, const int16_t* xFilter,
+                                                   const int16_t* yFilter, const int bitDepth )
+{
+  constexpr int numFilterTaps = 6;
+  const int maxValue = ( 1 << bitDepth ) - 1;
+
+  CHECKD( w % 8 != 0, "Width must be multiple of 8!" );
+  CHECKD( h % 4 != 0, "Height must be multiple of 4!" );
+
+  const Pel* sourceRow = org - ( numFilterTaps / 2 - 1 ) * origStride - ( numFilterTaps / 2 - 1 );
+
+  int16x8_t v_src[numFilterTaps + 3]; // Extra 3 elements needed because the height loop is unrolled 4 times.
+  int16x8_t h_src[numFilterTaps];
+
+  const int16x8_t xFilterVal = vld1q_s16( xFilter );
+  const int16x8_t yFilterVal = vld1q_s16( yFilter );
+
+  h >>= 2;
+
+  do
+  {
+    if( xType == FilterCoeffType::NoOp )
+    {
+      // If yType == FilterCoeffType::NoOp, skip v_src[0] and v_src[1].
+      if( yType != FilterCoeffType::NoOp )
+      {
+        v_src[0] = vld1q_s16( sourceRow + 0 * origStride + 2 );
+        v_src[1] = vld1q_s16( sourceRow + 1 * origStride + 2 );
+      }
+      v_src[2] = vld1q_s16( sourceRow + 2 * origStride + 2 );
+      v_src[3] = vld1q_s16( sourceRow + 3 * origStride + 2 );
+      v_src[4] = vld1q_s16( sourceRow + 4 * origStride + 2 );
+    }
+    else
+    {
+      if( yType != FilterCoeffType::NoOp )
+      {
+        load_s16_16x8x6( sourceRow + 0 * origStride, 1, h_src );
+        v_src[0] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+        load_s16_16x8x6( sourceRow + 1 * origStride, 1, h_src );
+        v_src[1] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+      }
+      load_s16_16x8x6( sourceRow + 2 * origStride, 1, h_src );
+      v_src[2] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+      load_s16_16x8x6( sourceRow + 3 * origStride, 1, h_src );
+      v_src[3] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+      load_s16_16x8x6( sourceRow + 4 * origStride, 1, h_src );
+      v_src[4] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+    }
+
+    const Pel* sourceCol = sourceRow + 5 * origStride;
+    Pel* dstCol = dst;
+
+    int height = h;
+    do
+    {
+      if( xType == FilterCoeffType::NoOp )
+      {
+        v_src[5] = vld1q_s16( sourceCol + 0 * origStride + 2 );
+        v_src[6] = vld1q_s16( sourceCol + 1 * origStride + 2 );
+        v_src[7] = vld1q_s16( sourceCol + 2 * origStride + 2 );
+        v_src[8] = vld1q_s16( sourceCol + 3 * origStride + 2 );
+      }
+      else
+      {
+        load_s16_16x8x6( sourceCol + 0 * origStride, 1, h_src );
+        v_src[5] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+        load_s16_16x8x6( sourceCol + 1 * origStride, 1, h_src );
+        v_src[6] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+        load_s16_16x8x6( sourceCol + 2 * origStride, 1, h_src );
+        v_src[7] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+        load_s16_16x8x6( sourceCol + 3 * origStride, 1, h_src );
+        v_src[8] = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Horizontal, xType>( h_src, xFilterVal );
+      }
+
+      int16x8_t dstSum0, dstSum1, dstSum2, dstSum3;
+      if( yType == FilterCoeffType::NoOp )
+      {
+        dstSum0 = vmaxq_s16( v_src[2], vdupq_n_s16( 0 ) );
+        dstSum1 = vmaxq_s16( v_src[3], vdupq_n_s16( 0 ) );
+        dstSum2 = vmaxq_s16( v_src[4], vdupq_n_s16( 0 ) );
+        dstSum3 = vmaxq_s16( v_src[5], vdupq_n_s16( 0 ) );
+      }
+      else
+      {
+        dstSum0 = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Vertical, yType>( &v_src[0], yFilterVal );
+        dstSum1 = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Vertical, yType>( &v_src[1], yFilterVal );
+        dstSum2 = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Vertical, yType>( &v_src[2], yFilterVal );
+        dstSum3 = applyFrac6Tap_8x_filter1D_neon<FilterDirection::Vertical, yType>( &v_src[3], yFilterVal );
+      }
+
+      dstSum0 = vminq_s16( dstSum0, vdupq_n_s16( maxValue ) );
+      dstSum1 = vminq_s16( dstSum1, vdupq_n_s16( maxValue ) );
+      dstSum2 = vminq_s16( dstSum2, vdupq_n_s16( maxValue ) );
+      dstSum3 = vminq_s16( dstSum3, vdupq_n_s16( maxValue ) );
+
+      vst1q_s16( dstCol + 0 * dstStride, dstSum0 );
+      vst1q_s16( dstCol + 1 * dstStride, dstSum1 );
+      vst1q_s16( dstCol + 2 * dstStride, dstSum2 );
+      vst1q_s16( dstCol + 3 * dstStride, dstSum3 );
+
+      if( yType != FilterCoeffType::NoOp )
+      {
+        v_src[0] = v_src[4];
+        v_src[1] = v_src[5];
+      }
+      v_src[2] = v_src[6];
+      v_src[3] = v_src[7];
+      v_src[4] = v_src[8];
+
+      dstCol += 4 * dstStride;
+      sourceCol += 4 * origStride;
+    } while( --height != 0 );
+
+    sourceRow += 8;
+    dst += 8;
+    w -= 8;
+  } while( w != 0 );
+}
+
+template<FilterCoeffType xType>
+static inline ApplyFrac6TapFunc applyFrac6Tap_8x_getYEntry( FilterCoeffType yType )
+{
+  switch( yType )
+  {
+  case FilterCoeffType::NoOp:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::NoOp>;
+  case FilterCoeffType::FullSymmetric:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::FullSymmetric>;
+  case FilterCoeffType::AddLeft:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::AddLeft>;
+  case FilterCoeffType::AddRight:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::AddRight>;
+  case FilterCoeffType::AddSymmetric:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::AddSymmetric>;
+  case FilterCoeffType::ShiftLeft:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::ShiftLeft>;
+  case FilterCoeffType::ShiftRight:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::ShiftRight>;
+  case FilterCoeffType::MultiplySymmetric:
+    return &applyFrac6Tap_8x_filter2D_neon<xType, FilterCoeffType::MultiplySymmetric>;
+  }
+
+  CHECK( true, "Invalid filter coefficients!" );
+  return nullptr;
+}
+
+void applyFrac6Tap_8x_neon( const Pel* org, const ptrdiff_t origStride, Pel* dst, const ptrdiff_t dstStride,
+                            const int w, const int h, const int16_t* xFilter, const int16_t* yFilter,
+                            const int bitDepth )
+{
+  const FilterCoeffType xType = selectFilterType( xFilter );
+  const FilterCoeffType yType = selectFilterType( yFilter );
+
+  if( xType == FilterCoeffType::NoOp && yType == FilterCoeffType::NoOp )
+  {
+    applyFrac6Tap_8x_copy_neon( org, origStride, dst, dstStride, w, h );
+    return;
+  }
+
+  ApplyFrac6TapFunc func{ nullptr };
+
+  switch( xType )
+  {
+  case FilterCoeffType::NoOp:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::NoOp>( yType );
+    break;
+  case FilterCoeffType::FullSymmetric:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::FullSymmetric>( yType );
+    break;
+  case FilterCoeffType::AddLeft:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::AddLeft>( yType );
+    break;
+  case FilterCoeffType::AddRight:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::AddRight>( yType );
+    break;
+  case FilterCoeffType::AddSymmetric:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::AddSymmetric>( yType );
+    break;
+  case FilterCoeffType::ShiftLeft:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::ShiftLeft>( yType );
+    break;
+  case FilterCoeffType::ShiftRight:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::ShiftRight>( yType );
+    break;
+  case FilterCoeffType::MultiplySymmetric:
+    func = applyFrac6Tap_8x_getYEntry<FilterCoeffType::MultiplySymmetric>( yType );
+    break;
+  }
+
+  CHECKD( func == nullptr, "Invalid filter type!" );
+
+  func( org, origStride, dst, dstStride, w, h, xFilter, yFilter, bitDepth );
+}
+
 template<>
 void MCTF::_initMCTF_ARM<NEON>()
 {
@@ -478,6 +842,7 @@ void MCTF::_initMCTF_ARM<NEON>()
   m_motionErrorLumaInt8     = motionErrorLumaInt_neon;
   m_applyPlanarCorrection   = applyPlanarCorrection_neon;
   m_applyBlock              = applyBlock_neon;
+  m_applyFrac[0][0]         = applyFrac6Tap_8x_neon;
 }
 
 } // namespace vvenc

--- a/source/Lib/CommonLib/arm/neon/mem_neon.h
+++ b/source/Lib/CommonLib/arm/neon/mem_neon.h
@@ -55,6 +55,21 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace vvenc
 {
 
+static inline void load_s16x4x6( const int16_t* src, const ptrdiff_t p, int16x4_t s[6] )
+{
+  s[0] = vld1_s16( src );
+  src += p;
+  s[1] = vld1_s16( src);
+  src += p;
+  s[2] = vld1_s16( src );
+  src += p;
+  s[3] = vld1_s16( src );
+  src += p;
+  s[4] = vld1_s16( src );
+  src += p;
+  s[5] = vld1_s16( src );
+}
+
 static inline void load_s16_16x8x6( const int16_t* src, const ptrdiff_t p, int16x8_t s[6] )
 {
   s[0] = vld1q_s16( src );

--- a/source/Lib/CommonLib/arm/neon/mem_neon.h
+++ b/source/Lib/CommonLib/arm/neon/mem_neon.h
@@ -1,0 +1,75 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2025, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/** \file     mem_neon.h
+    \brief    Helper functions for loading vectors
+*/
+
+#pragma once
+
+#include "CommonDef.h"
+
+#if defined( TARGET_SIMD_ARM )
+
+#include <arm_neon.h>
+
+namespace vvenc
+{
+
+static inline void load_s16_16x8x6( const int16_t* src, const ptrdiff_t p, int16x8_t s[6] )
+{
+  s[0] = vld1q_s16( src );
+  src += p;
+  s[1] = vld1q_s16( src);
+  src += p;
+  s[2] = vld1q_s16( src );
+  src += p;
+  s[3] = vld1q_s16( src );
+  src += p;
+  s[4] = vld1q_s16( src );
+  src += p;
+  s[5] = vld1q_s16( src );
+}
+
+} // namespace vvenc
+
+#endif


### PR DESCRIPTION
- Add Neon implementation for `MCTF::applyFrac6Tap_8x`. This new implementation improves performance by approximately 65% compared to the SIMDe version.
- Add Neon implementation for `MCTF::applyFrac6Tap_4x`. This new  implementation improves performance by approximately 60% compared to the SIMDe version.