### PR TITLE
sub_SSE: Use stores that don't require aligned access

### DIFF
--- a/source/Lib/CommonLib/x86/BufferX86.h
+++ b/source/Lib/CommonLib/x86/BufferX86.h
@@ -1252,7 +1252,7 @@ void sub_SSE( const Pel* src0, int src0Stride, const Pel* src1, int src1Stride, 
         __m128i vsrc1 = _mm_load_si128( ( const __m128i* ) &src1[x] );
         __m128i vdest = _mm_sub_epi16 ( vsrc0, vsrc1 );
 
-        _mm_store_si128( ( __m128i* ) &dest[x], vdest );
+        _mm_storeu_si128( ( __m128i* ) &dest[x], vdest );
       }
 
       src0 += src0Stride;


### PR DESCRIPTION
The W==8 path for `sub_SSE` uses `_mm_store_si128`, which requires 16-byte pointer alignment of the store address.

When building for 32-bit Arm platforms using the x86 intrinsics through SIMDe, for some versions of LLVM this is emitted as a store instruction with a 16-byte alignment hint. At runtime the pointer is observed to only have 8-byte alignment, causing an alignment fault on 32-bit Arm platforms with alignment checks enabled.

To work around this, switch to `_mm_storeu_si128` which does not have the alignment requirement, allowing the unit tests on 32-bit Arm platforms to pass successfully.