### PR TITLE
Arm: Update motionErrorLumaFrac_loRes_neon

### DIFF
--- a/source/Lib/CommonLib/arm/neon/mem_neon.h
+++ b/source/Lib/CommonLib/arm/neon/mem_neon.h
@@ -70,6 +70,17 @@ static inline void load_s16x4x6( const int16_t* src, const ptrdiff_t p, int16x4_
   s[5] = vld1_s16( src );
 }
 
+static inline void load_s16_16x8x4( const int16_t* src, const ptrdiff_t p, int16x8_t s[4] )
+{
+  s[0] = vld1q_s16( src );
+  src += p;
+  s[1] = vld1q_s16( src);
+  src += p;
+  s[2] = vld1q_s16( src );
+  src += p;
+  s[3] = vld1q_s16( src );
+}
+
 static inline void load_s16_16x8x6( const int16_t* src, const ptrdiff_t p, int16x8_t s[6] )
 {
   s[0] = vld1q_s16( src );


### PR DESCRIPTION
Update Neon implementation of MCTF motionErrorLumaFrac_loRes. 
This improved implementation is approximately 36% faster than the existing Neon version.