### PR TITLE
Add unit tests for InterpolationFilter::filter

### DIFF
--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -208,6 +208,9 @@ class DimensionGenerator
 public:
   unsigned get( unsigned min, unsigned max, unsigned mod = 1 ) const
   {
+    CHECK( max < min, "max should be >= min" );
+    CHECK( mod == 0, "mod must be >= 1" );                   // Avoids div by 0.
+    CHECK( min == 0 && max == UINT_MAX, "range too large" ); // Avoids (max-min+1)==0.
     unsigned ret = rand() % ( max - min + 1 ) + min;
     ret -= ret % mod;
     return ret;


### PR DESCRIPTION
Add unit tests for filterHor and filterVer to verify the following specialized SIMD cases for taps and block widths:

- N6: M16, M8, M4, M1
- N8: M16, M8, M4
- N4: M16, M8, M4, M2, M1
- N2: M4

The isFirst and isLast parameters are configured as:
- Horizontal: isFirst = true, isLast = both
- Vertical:   isFirst = both, isLast = both
- N2:         isFirst = true, isLast = false