### PR TITLE
Optimize the Neon implementation of xGetSAD_NxN

### DIFF
--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -67,6 +67,18 @@ static inline int16_t horizontal_add_s16x8( const int16x8_t a )
 #endif
 }
 
+static inline uint32_t horizontal_add_u32x4( const uint32x4_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddvq_u32( a );
+#else
+  const uint64x2_t b = vpaddlq_u32( a );
+  const uint32x2_t c =
+      vadd_u32( vreinterpret_u32_u64( vget_low_u64( b ) ), vreinterpret_u32_u64( vget_high_u64( b ) ) );
+  return vget_lane_u32( c, 0 );
+#endif
+}
+
 static inline int horizontal_add_s32x4( const int32x4_t a )
 {
 #if REAL_TARGET_AARCH64


### PR DESCRIPTION
Optimize and simplify the Neon implementation of xGetSAD_NxN.  Use a generic function that can take a runtime-defined value for width so that it can also be used in xGetHAD2SADs_neon.
Remove the logic around early exit since the equivalent scalar functions (xGetSAD<width>) do not make use of it.

These optimizations also allow these functions to be used even when TARGET_SIMD_X86 is not defined.

These changes make the getSAD functions 1.1x faster on average depending on the block size, when measured on a Neoverse V2 machine with LLVM-21.