### PR TITLE
Dont go to MMVD if the merge list is empty (might be caused by IFP)

### DIFF
--- a/source/Lib/EncoderLib/EncCu.cpp
+++ b/source/Lib/EncoderLib/EncCu.cpp
@@ -1864,7 +1864,7 @@ void EncCu::xCheckRDCostUnifiedMerge( CodingStructure *&tempCS, CodingStructure 
     addCiipCandsToPruningList( mergeCtx, localUnitArea, sqrtLambdaForFirstPass, ctxStart, distParam, *cu, sameMV );
   }
 
-  if( sps.MMVD && !( m_pcEncCfg->m_useFastMrg >= 2 && m_mergeItemList.size() <= 1 ) )
+  if( sps.MMVD && !!m_mergeItemList.size() && !( m_pcEncCfg->m_useFastMrg >= 2 && m_mergeItemList.size() <= 1 ) )
   {
     addMmvdCandsToPruningList( mergeCtx, localUnitArea, sqrtLambdaForFirstPass, ctxStart, distParam, *cu );
   }


### PR DESCRIPTION
When IFP is enabled, all merge candidates might be sorted out. Thus, when entering MMVD search, it cannot be assumed that at least one merge candidate is available in the merge list. When no candidates are available, for now skip the MMVD search (alternatively might adapt MMVD search but that would require changes in a few places). For now I assume if all the merge candidates are outside of the available area MMVD will only help a bit (could eventually be tested though).

Fixes #640.