### PR TITLE
Use explicit `[this]` in lambda captures

### DIFF
--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -157,7 +157,7 @@ struct BlockingBarrier
     BlockingBarrier* nonconst = const_cast<BlockingBarrier*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
-    nonconst->m_cond.wait( l, [=] { return !m_intBarrier.isBlocked(); } );
+    nonconst->m_cond.wait( l, [this] { return !m_intBarrier.isBlocked(); } );
   }
 
   BlockingBarrier()  = default;
@@ -210,7 +210,7 @@ struct WaitCounter
     WaitCounter* nonconst = const_cast<WaitCounter*>(this);
 
     std::unique_lock<std::mutex> l( nonconst->m_lock );
-    nonconst->m_cond.wait( l, [=] { return m_count == 0; } );
+    nonconst->m_cond.wait( l, [this] { return m_count == 0; } );
   }
 
   WaitCounter() = default;


### PR DESCRIPTION
Implicit `this` capture via `[=]` is deprecated since C++20 and generates warnings if the library is compiled in C++20 mode or later. Replace those captures with explicit `[this]`, since the lambda bodies don't use any variables other than the class members.