### PR TITLE
Arm: Add a Neon implementation for xGetSAD

### DIFF
--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -55,6 +55,11 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace vvenc
 {
 
+static inline uint16x8_t vvenc_vabaq_s16( uint16x8_t acc, int16x8_t x, int16x8_t y )
+{
+  return vreinterpretq_u16_s16( vabaq_s16( vreinterpretq_s16_u16( acc ), x, y ) );
+}
+
 static inline int16_t horizontal_add_s16x8( const int16x8_t a )
 {
 #if REAL_TARGET_AARCH64


### PR DESCRIPTION
Add a new NEON implementation of xGetSAD. This implementation improves performance by approximately 15–20% compared to the SIMDe version on Neoverse V2 when built with LLVM 21. Merge the new xGetSAD implementation with the previously used xGetSAD_generic_neon.