### PR TITLE
work around issue in VS2026 ARM64 compiler

### DIFF
--- a/.gitlab-ci-internal.yml
+++ b/.gitlab-ci-internal.yml
@@ -240,43 +240,58 @@ test_ubuntu2204:
    image: $CI_REGISTRY/pub/dockerimages/ubuntu_2204_full:latest
 
 test_vs2017:
-   extends: .build_test_msvc_template
-   variables:
-      MSVC_ARCH: x64
-      # use VS 2017 compilers:
-      CONFIG_OPTIONS: -T v141
-   tags:
-      - vs2022
-
-test_vs2019:
-   extends: .build_test_msvc_template
-   variables:
-      MSVC_ARCH: x64
-      # use VS 2019 compilers:
-      CONFIG_OPTIONS: -T v142
-   tags:
-      - vs2022
-
-test_vs2022_Win32:
   extends: .build_test_msvc_template
   variables:
-     MSVC_ARCH: Win32
+    MSVC_ARCH: x64
+    # use VS 2017 compilers:
+    CONFIG_OPTIONS: -T v141
   tags:
-    - vs2022
+    - vs-latest
+
+test_vs2019:
+  extends: .build_test_msvc_template
+  variables:
+    MSVC_ARCH: x64
+    # use VS 2019 compilers:
+    CONFIG_OPTIONS: -T v142
+  tags:
+    - vs-latest
 
 test_vs2022:
   extends: .build_test_msvc_template
   variables:
-     MSVC_ARCH: x64
+    MSVC_ARCH: x64
+    # use VS 2022 compilers:
+    CONFIG_OPTIONS: -T v143
   tags:
-    - vs2022
+    - vs-latest
 
-build_vs2022_arm64:
-  extends: .build_msvc_template
+test_vs2026:
+  extends: .build_test_msvc_template
   variables:
-     MSVC_ARCH: arm64
+    MSVC_ARCH: x64
+    # use VS 2026 compilers:
+    CONFIG_OPTIONS: -T v145
   tags:
-    - vs2022
+    - vs-latest
+
+test_vs2026_Win32:
+  extends: .build_test_msvc_template
+  variables:
+    MSVC_ARCH: Win32
+    # use VS 2026 compilers:
+    CONFIG_OPTIONS: -T v145
+  tags:
+    - vs-latest
+
+test_vs2026_arm64:
+  extends: .build_test_msvc_template
+  variables:
+    MSVC_ARCH: arm64
+    # use VS 2026 compilers:
+    CONFIG_OPTIONS: -T v145
+  tags:
+    - vs-arm-latest
 
 test_macos-x86_64:
    extends: .build_test_macos_template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,14 @@ if( VVENC_TARGET_ARCH STREQUAL "AARCH64" )
     message( STATUS "AArch64 SVE2 intrinsics enabled" )
     add_compile_definitions( TARGET_SIMD_ARM_SVE2=1 )
   endif()
+
+  if( MSVC AND MSVC_VERSION GREATER_EQUAL 1950 )
+    message( WARNING "This version (>= 19.50) of the Microsoft ARM compiler was seen to produce"
+             " incorrect code in VVdeC with SIMD-Everywhere. Here the specific problematic functions"
+             " are implemented directly using NEON intrinsics (when VVENC_ENABLE_ARM_SIMD=1), which"
+             " seem to work fine, but if you experience further problems on ARM64 Windows, try using"
+             " an older toolset (<= v143)." )
+   endif()
 endif()
 
 if( VVENC_TARGET_ARCH STREQUAL "ARM" )

--- a/source/Lib/CommonLib/x86/InterpolationFilterX86.h
+++ b/source/Lib/CommonLib/x86/InterpolationFilterX86.h
@@ -3451,7 +3451,11 @@ void InterpolationFilter::_initInterpolationFilterX86()
   m_filterVer[3][1][1] = simdFilter<vext, 6, true, true, true>;
   
   m_filterCopy[0][0]   = simdFilterCopy<vext, false, false>;
+#if _MSC_VER >= 1950 && _M_ARM64
+  // simdFilterCopy<vext, false, true>() disabled on ARM64 VS2026 due to buggy compiler producing incorrect code
+#else
   m_filterCopy[0][1]   = simdFilterCopy<vext, false, true>;
+#endif
   m_filterCopy[1][0]   = simdFilterCopy<vext, true, false>;
   m_filterCopy[1][1]   = simdFilterCopy<vext, true, true>;
   


### PR DESCRIPTION
The current VS2026 ARM64 compiler produces wrong code for the SIMD-Everywhere translated implementation of simdFilterCopy<vext, false, true>() in InterpolationFilterX86. This disables that specific function and emits a warning. Since a native NEON implementation exists for that function, this is only relevant, when building for Windows on ARM with `-DVVENC_ENABLE_ARM_SIMD=0`.