### PR TITLE
GithubActions: remove VC v141 toolset

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -25,10 +25,6 @@ jobs:
             msvc_arch: x64
 
           - toolset: v143
-            os: windows-latest
-            msvc_arch: x64
-
-          - toolset: v143
             os: windows-11-arm
             msvc_arch: arm64
             run_unit_test: true


### PR DESCRIPTION
it's not available any more, because the windows-2019 image has been removed