### PR TITLE
Fix parity tracking in DQ SIMD

### DIFF
--- a/source/Lib/CommonLib/DepQuant.cpp
+++ b/source/Lib/CommonLib/DepQuant.cpp
@@ -931,7 +931,7 @@ namespace DQIntern
 
       if( decision.absLevel )
       {
-        m_sbb.absLevels[scanInfo.insidePos] = ( uint8_t ) std::min<TCoeff>( 254 + ( decision.absLevel & 1 ), decision.absLevel );
+        m_sbb.absLevels[scanInfo.insidePos] = ( uint8_t ) std::min<TCoeff>( 126 + ( decision.absLevel & 1 ), decision.absLevel );
         
         if( scanInfo.currNbInfoSbb.numInv )
         {
@@ -1024,7 +1024,7 @@ namespace DQIntern
         ::memset( m_sbb.absLevels, 0, sizeof( m_sbb.absLevels ) );
       }
 
-      m_sbb.absLevels[ scanInfo.insidePos ] = (uint8_t)std::min<TCoeff>( 254 + ( decision.absLevel & 1 ), decision.absLevel );
+      m_sbb.absLevels[ scanInfo.insidePos ] = (uint8_t)std::min<TCoeff>( 126 + ( decision.absLevel & 1 ), decision.absLevel );
 
       m_commonCtx.update( scanInfo, prvState, *this );
 

--- a/source/Lib/CommonLib/x86/DepQuantX86.h
+++ b/source/Lib/CommonLib/x86/DepQuantX86.h
@@ -257,7 +257,7 @@ namespace DQIntern
     {
       int8_t s[4] = { 0 }, t[4] = { 0 }, l[4] = { 0 };
 
-      __m128i v254_4 = _mm_setr_epi16( 254, 254, 254, 254,  4,  4,  4,  4 );
+      __m128i v126_4 = _mm_setr_epi16( 126, 126, 126, 126,  4,  4,  4,  4 );
       __m128i v01    = _mm_setr_epi16(   1,   1,   1,   1,  1,  1,  1,  1 );
       __m128i v032   = _mm_setr_epi8 (   0,   0,   0,   0, 32, 32, 32, 32, 0, 0, 0, 0, 0, 0, 0, 0 );
       __m128i vn1    = _mm_set1_epi8 (  -1 );
@@ -273,7 +273,7 @@ namespace DQIntern
       p = _mm_shuffle_epi32( p, 0 ); 
       __m128i n2  = _mm_cmplt_epi8( p, vn1 );
       __m128i a_1 = _mm_and_si128( v, v01 );
-      __m128i a_m = _mm_min_epi16( v, _mm_add_epi16( v254_4, a_1 ) );
+      __m128i a_m = _mm_min_epi16( v, _mm_add_epi16( v126_4, a_1 ) );
       a_m = _mm_packs_epi16( a_m, vn1 );
       a_m = _mm_or_si128   ( a_m, _mm_sign_epi8( v032, a_m ) );
       a_m = _mm_andnot_si128( n2, a_m );
@@ -402,7 +402,7 @@ namespace DQIntern
       for( int i = 0; i < 4; ++i )
       {
         s[i]              = decisions.prevId[i] >= 4 ? -2 : decisions.prevId[i];
-        l[i]              = s[i] > -2 ? std::min<int>( decisions.absLevel[i], 254 + ( decisions.absLevel[i] & 1 ) ) : 0;
+        l[i]              = s[i] > -2 ? std::min<int>( decisions.absLevel[i], 126 + ( decisions.absLevel[i] & 1 ) ) : 0;
         z[i]              = 3 - decisions.prevId[i];
         curr.rdCost[i]    = decisions.rdCost[i];
       }


### PR DESCRIPTION
The `_mm_packs_epi16` clamps to int8 range. While only the absolute value up to 51 is really needed to be tracked, it is necessary to properly track the parity (for proper context selection). This fixes the range during clamping.

C code changes are not necessary, but applied to improve readability.

Fixes #654 

@athulya-arm could you confirm the issues is herewith fixed?