### PR TITLE
Add unit tests for DepQuant functions and refactor findFirstPos

### DIFF
--- a/source/Lib/CommonLib/DepQuant.cpp
+++ b/source/Lib/CommonLib/DepQuant.cpp
@@ -1410,7 +1410,7 @@ void DepQuant::xDequantDQ( const TransformUnit& tu,  CoeffBuf& recCoeff, const C
   m_quant.dequantBlock( tu, compID, cQP, recCoeff, enableScalingLists, piDequantCoef );
 }
 
-DepQuant::DepQuant( const Quant* other, bool enc, bool useScalingLists ) : QuantRDOQ2( other, useScalingLists ), RateEstimator(), m_commonCtx()
+DepQuant::DepQuant( const Quant* other, bool enc, bool useScalingLists, bool enableOpt ) : QuantRDOQ2( other, useScalingLists ), RateEstimator(), m_commonCtx()
 {
   const DepQuant* dq = dynamic_cast<const DepQuant*>( other );
   CHECK( other && !dq, "The DepQuant cast must be successfull!" );
@@ -1436,9 +1436,12 @@ DepQuant::DepQuant( const Quant* other, bool enc, bool useScalingLists ) : Quant
   m_updateStates        = DQIntern::updateStates;
   m_findFirstPos        = nullptr;
 
+  if( enableOpt )
+  {
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_QUANT
-  initDepQuantX86();
+    initDepQuantX86();
 #endif
+  }
 }
 
 DepQuant::~DepQuant()

--- a/source/Lib/CommonLib/DepQuant.cpp
+++ b/source/Lib/CommonLib/DepQuant.cpp
@@ -55,6 +55,23 @@ namespace vvenc {
 
 namespace DQIntern
 {
+  static void findFirstPos( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh,
+                            bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight )
+  {
+    for( ; firstTestPos >= 0; firstTestPos-- )
+    {
+      if( zeroOutForThres && ( tuPars.m_scanId2BlkPos[firstTestPos].x >= zeroOutWidth ||
+                              tuPars.m_scanId2BlkPos[firstTestPos].y >= zeroOutHeight ) )
+      {
+        continue;
+      }
+      if( abs( tCoeff[tuPars.m_scanId2BlkPos[firstTestPos].idx] ) > defaultTh )
+      {
+        break;
+      }
+    }
+  }
+
   void Rom::xInitScanArrays()
   {
     if( m_scansInitialized )
@@ -1169,16 +1186,7 @@ void DepQuant::xQuantDQ( TransformUnit& tu, const CCoeffBuf& srcCoeff, const Com
   {
     const TCoeff defaultTh = TCoeff( thres / ( defaultQuantisationCoefficient << 2 ) );
 
-    if( m_findFirstPos )
-    {
-      m_findFirstPos( firstTestPos, tCoeff, tuPars, defaultTh, zeroOutforThres, zeroOutWidth, zeroOutHeight );
-    }
-
-    for( ; firstTestPos >= 0; firstTestPos-- )
-    {
-      if( zeroOutforThres && ( tuPars.m_scanId2BlkPos[firstTestPos].x >= zeroOutWidth || tuPars.m_scanId2BlkPos[firstTestPos].y >= zeroOutHeight ) ) continue;
-      if( abs( tCoeff[tuPars.m_scanId2BlkPos[firstTestPos].idx] ) > defaultTh ) break;
-    }
+    m_findFirstPos( firstTestPos, tCoeff, tuPars, defaultTh, zeroOutforThres, zeroOutWidth, zeroOutHeight );
   }
 
   if( firstTestPos < 0 )
@@ -1434,7 +1442,7 @@ DepQuant::DepQuant( const Quant* other, bool enc, bool useScalingLists, bool ena
   m_checkAllRdCostsOdd1 = DQIntern::checkAllRdCostsOdd1;
   m_updateStatesEOS     = DQIntern::updateStatesEOS;
   m_updateStates        = DQIntern::updateStates;
-  m_findFirstPos        = nullptr;
+  m_findFirstPos        = DQIntern::findFirstPos;
 
   if( enableOpt )
   {

--- a/source/Lib/CommonLib/DepQuant.h
+++ b/source/Lib/CommonLib/DepQuant.h
@@ -362,8 +362,6 @@ private:
 
   // has to be called as a first check, assumes no decision has been made yet!!!
   void( *m_checkAllRdCosts )( const DQIntern::ScanPosType spt, const DQIntern::PQData* pqData, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
-  // has to be called as a first check, assumes no decision has been made yet!!!
-  void( *m_checkAllRdCostsOdd1 )( const DQIntern::ScanPosType spt, const int64_t pq_a_dist, const int64_t pq_b_dist, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
   void( *m_findFirstPos )( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh, bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_QUANT
@@ -373,6 +371,8 @@ private:
 #endif
 
 public:
+  // has to be called as a first check, assumes no decision has been made yet!!!
+  void( *m_checkAllRdCostsOdd1 )( const DQIntern::ScanPosType spt, const int64_t pq_a_dist, const int64_t pq_b_dist, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
   void( *m_updateStates )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, DQIntern::StateMem& curr );
   void( *m_updateStatesEOS )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, const DQIntern::StateMem& skip, DQIntern::StateMem& curr, DQIntern::CommonCtx& commonCtx );
 

--- a/source/Lib/CommonLib/DepQuant.h
+++ b/source/Lib/CommonLib/DepQuant.h
@@ -337,7 +337,7 @@ namespace DQIntern
 class DepQuant : public QuantRDOQ2, DQIntern::RateEstimator
 {
 public:
-  DepQuant( const Quant* other, bool enc, bool useScalingLists );
+  DepQuant( const Quant* other, bool enc, bool useScalingLists, bool enableOpt = true );
   virtual ~DepQuant();
 
   virtual void quant  (       TransformUnit& tu, const ComponentID compID, const CCoeffBuf& pSrc, TCoeff &uiAbsSum, const QpParam& cQP, const Ctx& ctx );
@@ -365,7 +365,6 @@ private:
   // has to be called as a first check, assumes no decision has been made yet!!!
   void( *m_checkAllRdCostsOdd1 )( const DQIntern::ScanPosType spt, const int64_t pq_a_dist, const int64_t pq_b_dist, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
   void( *m_updateStatesEOS )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, const DQIntern::StateMem& skip, DQIntern::StateMem& curr, DQIntern::CommonCtx& commonCtx );
-  void( *m_updateStates )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, DQIntern::StateMem& curr );
   void( *m_findFirstPos )( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh, bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_QUANT
@@ -373,6 +372,9 @@ private:
   template <X86_VEXT vext>
   void _initDepQuantX86();
 #endif
+
+public:
+  void( *m_updateStates )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, DQIntern::StateMem& curr );
 };
 
 } // namespace vvenc

--- a/source/Lib/CommonLib/DepQuant.h
+++ b/source/Lib/CommonLib/DepQuant.h
@@ -362,7 +362,6 @@ private:
 
   // has to be called as a first check, assumes no decision has been made yet!!!
   void( *m_checkAllRdCosts )( const DQIntern::ScanPosType spt, const DQIntern::PQData* pqData, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
-  void( *m_findFirstPos )( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh, bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_QUANT
   void initDepQuantX86();
@@ -375,6 +374,7 @@ public:
   void( *m_checkAllRdCostsOdd1 )( const DQIntern::ScanPosType spt, const int64_t pq_a_dist, const int64_t pq_b_dist, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
   void( *m_updateStates )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, DQIntern::StateMem& curr );
   void( *m_updateStatesEOS )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, const DQIntern::StateMem& skip, DQIntern::StateMem& curr, DQIntern::CommonCtx& commonCtx );
+  void( *m_findFirstPos )( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh, bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight );
 
 };
 

--- a/source/Lib/CommonLib/DepQuant.h
+++ b/source/Lib/CommonLib/DepQuant.h
@@ -364,7 +364,6 @@ private:
   void( *m_checkAllRdCosts )( const DQIntern::ScanPosType spt, const DQIntern::PQData* pqData, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
   // has to be called as a first check, assumes no decision has been made yet!!!
   void( *m_checkAllRdCostsOdd1 )( const DQIntern::ScanPosType spt, const int64_t pq_a_dist, const int64_t pq_b_dist, DQIntern::Decisions& decisions, const DQIntern::StateMem& state );
-  void( *m_updateStatesEOS )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, const DQIntern::StateMem& skip, DQIntern::StateMem& curr, DQIntern::CommonCtx& commonCtx );
   void( *m_findFirstPos )( int& firstTestPos, const TCoeff* tCoeff, const DQIntern::TUParameters& tuPars, int defaultTh, bool zeroOutForThres, int zeroOutWidth, int zeroOutHeight );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_QUANT
@@ -375,6 +374,8 @@ private:
 
 public:
   void( *m_updateStates )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, DQIntern::StateMem& curr );
+  void( *m_updateStatesEOS )( const DQIntern::ScanInfo& scanInfo, const DQIntern::Decisions& decisions, const DQIntern::StateMem& skip, DQIntern::StateMem& curr, DQIntern::CommonCtx& commonCtx );
+
 };
 
 } // namespace vvenc

--- a/source/Lib/CommonLib/x86/DepQuantX86.h
+++ b/source/Lib/CommonLib/x86/DepQuantX86.h
@@ -797,8 +797,21 @@ namespace vvenc {
         if( firstTestPos >= 0 )
         {
           // if a coefficient was found, advance the pointer to the end of the current subblock
-          // for the subsequent coefficient-wise refinement (C-impl after endif)
+          // for the subsequent coefficient-wise refinement.
           firstTestPos += sbbSize - 1;
+        }
+      }
+
+      for( ; firstTestPos >= 0; firstTestPos-- )
+      {
+        if( zeroOutForThres && ( tuPars.m_scanId2BlkPos[firstTestPos].x >= zeroOutWidth ||
+                                tuPars.m_scanId2BlkPos[firstTestPos].y >= zeroOutHeight ) )
+        {
+          continue;
+        }
+        if( abs( tCoeff[tuPars.m_scanId2BlkPos[firstTestPos].idx] ) > defaultTh )
+        {
+          break;
         }
       }
     }

--- a/test/vvenc_unit_test/CMakeLists.txt
+++ b/test/vvenc_unit_test/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -fdiagnostics-show-option -Wno-ignored-attributes -Wno-sign-compare>
 
-                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4251 /wd4996>)
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4100 /wd4244 /wd4251 /wd4996>)
 
 target_include_directories( ${EXE_NAME} PRIVATE ${VVENC_LIB_DIR} )
 target_link_libraries( ${EXE_NAME} Threads::Threads vvenc )

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -372,6 +372,159 @@ static bool check_updateStates( DepQuant* ref, DepQuant* opt, unsigned num_cases
   return passed;
 }
 
+static bool check_updateStatesEOS( DepQuant* ref, DepQuant* opt, unsigned num_cases )
+{
+  printf( "Testing DepQuant::updateStatesEOS\n" );
+
+  InputGenerator<TCoeff> g4{ 4, /*is_signed=*/false };
+  InputGenerator<TCoeff> g6{ 6, /*is_signed=*/false };
+  InputGenerator<TCoeff> g8{ 8, /*is_signed=*/false };
+  InputGenerator<TCoeff> g11{ 11 };
+  InputGenerator<TCoeff> g31{ 31 };
+  DimensionGenerator rng;
+
+  std::ostringstream sstm;
+  sstm << "DepQuant updateStatesEOS";
+
+  DQIntern::ScanInfo scanInfo;
+  DQIntern::Decisions decisions;
+  DQIntern::StateMem skip;
+  DQIntern::StateMem curr_ref;
+  DQIntern::StateMem curr_opt;
+  DQIntern::CommonCtx commonCtx_ref;
+  DQIntern::CommonCtx commonCtx_opt;
+
+  DQIntern::Rom rom;
+  rom.init();
+  DQIntern::TUParameters tuPars( rom, 16, 16, CH_C );
+
+  FracBitsAccess fracBitsAccess{ 1 };
+  CodingUnit cu;
+  TransformUnit tu;
+  tu.cu = &cu;
+
+  DQIntern::RateEstimator rateEst;
+  rateEst.initCtx( tuPars, tu, COMP_Cb, fracBitsAccess );
+
+  commonCtx_ref.reset( tuPars, rateEst );
+  commonCtx_ref.swap();
+  commonCtx_ref.reset( tuPars, rateEst ); // Rebinds m_currSbbCtx/m_prevSbbCtx entries to parts of m_memory.
+
+  commonCtx_opt.reset( tuPars, rateEst );
+  commonCtx_opt.swap();
+  commonCtx_opt.reset( tuPars, rateEst );
+
+  bool passed = true;
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    std::memset( &curr_ref, 0xCD, sizeof( curr_ref ) );
+    std::memset( &curr_opt, 0xCD, sizeof( curr_opt ) );
+
+    scanInfo.scanIdx = rng.get( 16, 128, 16 );
+    scanInfo.sbbSize = rng.getOneOf<int8_t>( { 4, 16 } );
+    scanInfo.numSbb = 16;
+
+    scanInfo.sbbPos = rng.get( 0, scanInfo.numSbb - 1 );
+    scanInfo.nextSbbRight = 0;
+    scanInfo.nextSbbBelow = 0;
+
+    scanInfo.insidePos = 0;
+    scanInfo.nextInsidePos = 15;
+    scanInfo.gtxCtxOffsetNext = ( int8_t )rng.get( 0, 200 );
+    scanInfo.sigCtxOffsetNext = ( int8_t )rng.get( 0, 200 );
+    scanInfo.currNbInfoSbb.numInv = 0;
+    std::generate( scanInfo.currNbInfoSbb.invInPos, scanInfo.currNbInfoSbb.invInPos + 5, g4 );
+
+    for( int idx = 0; idx < 4; ++idx )
+    {
+      // prevId >= 4 implies prevId - 4 == idx.
+      decisions.prevId[idx] = rng.getOneOf<int8_t>( { -2, -1, 0, 1, 2, 3, int8_t( idx + 4 ) } );
+
+      curr_ref.refSbbCtxId[idx] = rng.getOneOf<int8_t>( { -1, 0, 1, 2, 3 } );
+      if( decisions.prevId[idx] >= 4 )
+      {
+        decisions.absLevel[idx] = 0;
+      }
+      else
+      {
+        // prevId == -1 indicates this would be the first non-zero coefficient (thus absVal > 0).
+        int minLevel = decisions.prevId[idx] >= 0 ? 0 : 1;
+        decisions.absLevel[idx] = ( TCoeffSig )rng.get( minLevel, 127 );
+      }
+    }
+    std::generate( decisions.rdCost, decisions.rdCost + 4, g31 );
+
+    curr_ref.initRemRegBins = 4;
+    std::generate( curr_ref.numSig, curr_ref.numSig + 4, g6 );
+    std::generate( curr_ref.remRegBins, curr_ref.remRegBins + 4, g11 );
+    for( int idx = 0; idx < 16; ++idx )
+    {
+      std::generate( curr_ref.tplAcc[idx], curr_ref.tplAcc[idx] + 4, g8 );
+      std::generate( curr_ref.sum1st[idx], curr_ref.sum1st[idx] + 4, g8 );
+    }
+
+    std::generate( skip.remRegBins, skip.remRegBins + 4, g11 );
+
+    std::fill_n( &curr_ref.absVal[0][0], 16 * 4, 0 ); // AbsVal is always set to 0 prior to updateStates.
+
+    curr_opt = curr_ref;
+
+    ref->m_updateStatesEOS( scanInfo, decisions, skip, curr_ref, commonCtx_ref );
+    opt->m_updateStatesEOS( scanInfo, decisions, skip, curr_opt, commonCtx_opt );
+
+    uint8_t* refLevels[4];
+    uint8_t* optLevels[4];
+    commonCtx_ref.getLevelPtrs( scanInfo, refLevels[0], refLevels[1], refLevels[2], refLevels[3] );
+    commonCtx_opt.getLevelPtrs( scanInfo, optLevels[0], optLevels[1], optLevels[2], optLevels[3] );
+
+    passed = compare_value( sstm.str() + " cffBitsCtxOffset", curr_ref.cffBitsCtxOffset, curr_opt.cffBitsCtxOffset ) &&
+             passed;
+    passed = compare_value( sstm.str() + " anyRemRegBinsLt4", curr_ref.anyRemRegBinsLt4, curr_opt.anyRemRegBinsLt4 ) &&
+             passed;
+    passed =
+        compare_value( sstm.str() + " initRemRegBins", curr_ref.initRemRegBins, curr_opt.initRemRegBins ) && passed;
+
+    for( int idx = 0; idx < 4; ++idx )
+    {
+      passed = compare_value( sstm.str() + " rdCost", curr_ref.rdCost[idx], curr_opt.rdCost[idx] ) && passed;
+
+      if( decisions.prevId[idx] == -2 )
+      {
+        continue;
+      }
+
+      passed = compare_value( sstm.str() + " numSig", curr_ref.numSig[idx], curr_opt.numSig[idx] ) && passed;
+      passed =
+          compare_value( sstm.str() + " refSbbCtxId", curr_ref.refSbbCtxId[idx], curr_opt.refSbbCtxId[idx] ) && passed;
+
+      if( curr_ref.remRegBins[idx] >= 4 )
+      {
+        passed =
+            compare_value( sstm.str() + " remRegBins", curr_ref.remRegBins[idx], curr_opt.remRegBins[idx] ) && passed;
+        passed = compare_value( sstm.str() + " ctx.sig", curr_ref.ctx.sig[idx], curr_opt.ctx.sig[idx] ) && passed;
+        passed = compare_value( sstm.str() + " ctx.cff", curr_ref.ctx.cff[idx], curr_opt.ctx.cff[idx] ) && passed;
+      }
+
+      passed =
+          compare_values_2d( sstm.str() + " tplAcc", &curr_ref.tplAcc[0][idx], &curr_opt.tplAcc[0][idx], 16, 1, 4 ) &&
+          passed;
+      passed =
+          compare_values_2d( sstm.str() + " sum1st", &curr_ref.sum1st[0][idx], &curr_opt.sum1st[0][idx], 16, 1, 4 ) &&
+          passed;
+      passed =
+          compare_values_2d( sstm.str() + " absVal", &curr_ref.absVal[0][idx], &curr_opt.absVal[0][idx], 16, 1, 4 ) &&
+          passed;
+
+      passed = compare_values_1d( sstm.str() + " commonCtx.levels stateId=" + std::to_string( idx ), refLevels[idx],
+                                  optLevels[idx], scanInfo.sbbSize ) &&
+               passed;
+    }
+  }
+
+  return passed;
+}
+
 static bool test_DepQuant()
 {
   auto ref = std::make_unique<DepQuant>( /*other=*/nullptr,
@@ -390,6 +543,7 @@ static bool test_DepQuant()
   bool passed = true;
 
   passed = check_updateStates( ref.get(), opt.get(), num_cases ) && passed;
+  passed = check_updateStatesEOS( ref.get(), opt.get(), num_cases ) && passed;
 
   return passed;
 }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -59,6 +59,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/AdaptiveLoopFilter.h"
 #include "CommonLib/AffineGradientSearch.h"
 #include "CommonLib/CommonDef.h"
+#include "CommonLib/DepQuant.h"
 #include "CommonLib/InterPrediction.h"
 #include "CommonLib/IntraPrediction.h"
 #include "CommonLib/MCTF.h"
@@ -84,7 +85,7 @@ static inline bool compare_value( const std::string& context, const T ref, const
   if( opt != ref )
   {
     std::cerr << "failed: " << context << "\n"
-              << "  mismatch:  ref=" << ref << "  opt=" << opt << "\n";
+              << "  mismatch:  ref=" << +ref << "  opt=" << +opt << "\n";
   }
   return opt == ref;
 }
@@ -97,7 +98,7 @@ static inline bool compare_values_1d( const std::string& context, const T* ref, 
     if( ref[idx] != opt[idx] )
     {
       std::cout << "failed: " << context << "\n"
-                << "  mismatch:  ref[" << idx << "]=" << ref[idx] << "  opt[" << idx << "]=" << opt[idx] << "\n";
+                << "  mismatch:  ref[" << idx << "]=" << +ref[idx] << "  opt[" << idx << "]=" << +opt[idx] << "\n";
       return false;
     }
   }
@@ -120,8 +121,8 @@ static inline bool compare_values_2d( const std::string& context, const T* ref, 
       if( abs_diff( ref[idx], opt[idx] ) > tolerance )
       {
         std::cout << "failed: " << context << "\n"
-                  << "  mismatch:  ref[" << row << "*" << stride << "+" << col << "]=" << ref[idx]
-                  << "  opt[" << row << "*" << stride << "+" << col << "]=" << opt[idx] << "\n";
+                  << "  mismatch:  ref[" << row << "*" << stride << "+" << col << "]=" << +ref[idx] << "  opt[" << row
+                  << "*" << stride << "+" << col << "]=" << +opt[idx] << "\n";
         return false;
       }
     }
@@ -252,6 +253,147 @@ public:
     return values[rand() % values.size()];
   }
 };
+
+#if ENABLE_SIMD_OPT_QUANT
+static bool check_updateStates( DepQuant* ref, DepQuant* opt, unsigned num_cases )
+{
+  printf( "Testing DepQuant::updateStates\n" );
+
+  InputGenerator<TCoeff> g4{ 4, /*is_signed=*/false };
+  InputGenerator<TCoeff> g6{ 6, /*is_signed=*/false };
+  InputGenerator<TCoeff> g7{ 7, /*is_signed=*/false };
+  InputGenerator<TCoeff> g8{ 8, /*is_signed=*/false };
+  InputGenerator<TCoeff> g11{ 11 };
+  InputGenerator<TCoeff> g31{ 31 };
+  DimensionGenerator rng;
+
+  std::ostringstream sstm;
+  sstm << "DepQuant updateStates";
+
+  DQIntern::ScanInfo scanInfo;
+  DQIntern::Decisions decisions;
+  DQIntern::StateMem curr_ref;
+  DQIntern::StateMem curr_opt;
+
+  bool passed = true;
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    std::memset( &curr_ref, 0xCD, sizeof( curr_ref ) );
+    std::memset( &curr_opt, 0xCD, sizeof( curr_opt ) );
+
+    // The settings below are chosen to satisfy the updateStates() constraints:
+    // insidePos = ( nextInsidePos + 1 ) % sbbSize.
+    // All scanInfo.currNbInfoSbb.invInPos are smaller than insidePos.
+    // scanInfo.currNbInfoSbb.numInv <= std::min(insidePos, 5).
+    scanInfo.sbbSize = rng.getOneOf<int8_t>( { 4, 16 } );
+    scanInfo.nextInsidePos = rng.get( 0, scanInfo.sbbSize - 1 );
+    scanInfo.insidePos = ( scanInfo.nextInsidePos + 1 ) % scanInfo.sbbSize;
+    scanInfo.gtxCtxOffsetNext = ( int8_t )rng.get( 0, 200 );
+    scanInfo.sigCtxOffsetNext = ( int8_t )rng.get( 0, 200 );
+    scanInfo.currNbInfoSbb.numInv = ( uint8_t )rng.get( 0, std::min<int>( scanInfo.insidePos, 5 ) );
+
+    for( int inv = 0; inv < 5; ++inv )
+    {
+      scanInfo.currNbInfoSbb.invInPos[inv] = ( uint8_t )rng.get( 0, std::max<int>( 0, scanInfo.insidePos - 1 ) );
+    }
+
+    for( int idx = 0; idx < 4; ++idx )
+    {
+      decisions.prevId[idx] = rng.getOneOf<int8_t>( { -2, -1, 0, 1, 2, 3 } );
+
+      // prevId == -1 indicates this would be the first non-zero coefficient (thus absVal > 0).
+      int minLevel = decisions.prevId[idx] >= 0 ? 0 : 1;
+      decisions.absLevel[idx] = ( TCoeffSig )rng.get( minLevel, 127 );
+
+      curr_ref.refSbbCtxId[idx] = rng.getOneOf<int8_t>( { -1, 0, 1, 2, 3 } );
+    }
+    std::generate( decisions.rdCost, decisions.rdCost + 4, g31 );
+
+    curr_ref.initRemRegBins = 4;
+    std::generate( curr_ref.numSig, curr_ref.numSig + 4, g6 );
+    std::generate( curr_ref.remRegBins, curr_ref.remRegBins + 4, g11 );
+    for( int idx = 0; idx < 16; ++idx )
+    {
+      std::generate( curr_ref.tplAcc[idx], curr_ref.tplAcc[idx] + 4, g8 );
+      std::generate( curr_ref.sum1st[idx], curr_ref.sum1st[idx] + 4, g8 );
+    }
+    // Initialize absVal[i][j] to 0 prior to updateStates() and then seed nonZero for i > insidePos, to
+    // ensure that they are shuffled properly (and zeroed for prevId == -1) during updateStates().
+    std::fill_n( &curr_ref.absVal[0][0], 16 * 4, 0 );
+    for( int pos = scanInfo.insidePos + 1; pos < 16; ++pos )
+    {
+      std::generate( curr_ref.absVal[pos], curr_ref.absVal[pos] + 4, g7 );
+    }
+
+    curr_opt = curr_ref;
+
+    ref->m_updateStates( scanInfo, decisions, curr_ref );
+    opt->m_updateStates( scanInfo, decisions, curr_opt );
+
+    passed = compare_value( sstm.str() + " cffBitsCtxOffset", curr_ref.cffBitsCtxOffset, curr_opt.cffBitsCtxOffset ) &&
+             passed;
+    passed = compare_value( sstm.str() + " anyRemRegBinsLt4", curr_ref.anyRemRegBinsLt4, curr_opt.anyRemRegBinsLt4 ) &&
+             passed;
+    passed =
+        compare_value( sstm.str() + " initRemRegBins", curr_ref.initRemRegBins, curr_opt.initRemRegBins ) && passed;
+
+    for( int idx = 0; idx < 4; ++idx )
+    {
+      if( decisions.prevId[idx] == -2 )
+      {
+        continue;
+      }
+      passed = compare_value( sstm.str() + " rdCost", curr_ref.rdCost[idx], curr_opt.rdCost[idx] ) && passed;
+      passed = compare_value( sstm.str() + " numSig", curr_ref.numSig[idx], curr_opt.numSig[idx] ) && passed;
+      passed =
+          compare_value( sstm.str() + " refSbbCtxId", curr_ref.refSbbCtxId[idx], curr_opt.refSbbCtxId[idx] ) && passed;
+
+      passed =
+          compare_values_2d( sstm.str() + " tplAcc", &curr_ref.tplAcc[0][idx], &curr_opt.tplAcc[0][idx], 16, 1, 4 ) &&
+          passed;
+      passed =
+          compare_values_2d( sstm.str() + " sum1st", &curr_ref.sum1st[0][idx], &curr_opt.sum1st[0][idx], 16, 1, 4 ) &&
+          passed;
+      passed =
+          compare_values_2d( sstm.str() + " absVal", &curr_ref.absVal[0][idx], &curr_opt.absVal[0][idx], 16, 1, 4 ) &&
+          passed;
+
+      if( curr_ref.remRegBins[idx] >= 4 )
+      {
+        passed =
+            compare_value( sstm.str() + " remRegBins", curr_ref.remRegBins[idx], curr_opt.remRegBins[idx] ) && passed;
+        passed = compare_value( sstm.str() + " ctx.sig", curr_ref.ctx.sig[idx], curr_opt.ctx.sig[idx] ) && passed;
+        passed = compare_value( sstm.str() + " ctx.cff", curr_ref.ctx.cff[idx], curr_opt.ctx.cff[idx] ) && passed;
+      }
+    }
+  }
+
+  return passed;
+}
+
+static bool test_DepQuant()
+{
+  auto ref = std::make_unique<DepQuant>( /*other=*/nullptr,
+                                         /*enc=*/true,
+                                         /*useScalingLists=*/false,
+                                         /*enableOpt=*/false );
+  auto opt = std::make_unique<DepQuant>( /*other=*/nullptr,
+                                         /*enc=*/true,
+                                         /*useScalingLists=*/false,
+                                         /*enableOpt=*/true );
+
+  ref->init();
+  opt->init();
+
+  unsigned num_cases = NUM_CASES;
+  bool passed = true;
+
+  passed = check_updateStates( ref.get(), opt.get(), num_cases ) && passed;
+
+  return passed;
+}
+#endif // ENABLE_SIMD_OPT_QUANT
 
 #if ENABLE_SIMD_OPT_INTRAPRED
 static bool check_IntraPredAngleLuma( IntraPrediction* ref, IntraPrediction* opt, unsigned num_cases )
@@ -2633,6 +2775,9 @@ struct UnitTestEntry
 };
 
 static const UnitTestEntry test_suites[] = {
+#if ENABLE_SIMD_OPT_QUANT
+    { "DepQuant", test_DepQuant },
+#endif
 #if ENABLE_SIMD_OPT_INTRAPRED
     { "IntraPred", test_IntraPred },
 #endif

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -699,6 +699,69 @@ static bool check_updateStatesEOS( DepQuant* ref, DepQuant* opt, unsigned num_ca
   return passed;
 }
 
+template<typename G>
+static bool check_one_xFindFirstTestPos( DepQuant* ref, DepQuant* opt, bool zeroOutforThres, G input_generator )
+{
+  std::ostringstream sstm;
+  sstm << "DepQuant xFindFirstTestPos" << " zeroOutforThres=" << std::boolalpha << zeroOutforThres;
+
+  DimensionGenerator rng;
+
+  DQIntern::Rom rom;
+  rom.init();
+  std::vector<TCoeff> tCoeff( 8192 );
+
+  std::generate( tCoeff.begin(), tCoeff.end(), input_generator );
+
+  TCoeff defaultTh = rng.get( 4, 128 );
+  int zeroOutWidth = rng.getOneOf<int>( { 32, 64 } );
+  int zeroOutHeight = rng.getOneOf<int>( { 32, 64 } );
+
+  int width = rng.getOneOf<int>( { 4, 8, 16, 32, 64 } );
+  int height = rng.getOneOf<int>( { 4, 8, 16, 32, 64 } );
+  int pos_ref = std::min( width, JVET_C0024_ZERO_OUT_TH ) * std::min( height, JVET_C0024_ZERO_OUT_TH ) - 1;
+
+  DQIntern::TUParameters tuPars( rom, width, height, CH_C );
+
+  int pos_opt = pos_ref;
+  ref->m_findFirstPos( pos_ref, tCoeff.data(), tuPars, defaultTh, zeroOutforThres, zeroOutWidth, zeroOutHeight );
+  opt->m_findFirstPos( pos_opt, tCoeff.data(), tuPars, defaultTh, zeroOutforThres, zeroOutWidth, zeroOutHeight );
+
+  if( pos_ref < 0 )
+  {
+    // In the not-found case, xQuantDQ only depends on firstTestPos being negative, not on its exact value.
+    return compare_value( sstm.str(), pos_ref < 0, pos_opt < 0 );
+  }
+
+  return compare_value( sstm.str(), pos_ref, pos_opt );
+}
+
+static bool check_xFindFirstTestPos( DepQuant* ref, DepQuant* opt, unsigned num_cases )
+{
+  printf( "Testing DepQuant::xFindFirstTestPos\n" );
+
+  InputGenerator<TCoeff> g12{ 12 };
+  InputGenerator<TCoeff> g6{ 6 };
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    for( bool zeroOutforThres : { false, true } )
+    {
+      if( !check_one_xFindFirstTestPos( ref, opt, zeroOutforThres, g12 ) )
+      {
+        return false;
+      }
+    }
+    // No coefficients found cases from the subblocks.
+    if( !check_one_xFindFirstTestPos( ref, opt, false, g6 ) )
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static bool test_DepQuant()
 {
   auto ref = std::make_unique<DepQuant>( /*other=*/nullptr,
@@ -719,6 +782,7 @@ static bool test_DepQuant()
   passed = check_checkAllRdCostsOdd1( ref.get(), opt.get(), num_cases ) && passed;
   passed = check_updateStates( ref.get(), opt.get(), num_cases ) && passed;
   passed = check_updateStatesEOS( ref.get(), opt.get(), num_cases ) && passed;
+  passed = check_xFindFirstTestPos( ref.get(), opt.get(), num_cases ) && passed;
 
   return passed;
 }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -255,6 +255,180 @@ public:
 };
 
 #if ENABLE_SIMD_OPT_QUANT
+static bool check_one_checkAllRdCostsOdd1( DepQuant* ref, DepQuant* opt, DQIntern::ScanPosType spt, int64_t pq_a_dist,
+                                           int64_t pq_b_dist, DQIntern::Decisions& decisions_ref,
+                                           DQIntern::Decisions& decisions_opt, const DQIntern::StateMem& state,
+                                           const std::string& context )
+{
+  ref->m_checkAllRdCostsOdd1( spt, pq_a_dist, pq_b_dist, decisions_ref, state );
+  opt->m_checkAllRdCostsOdd1( spt, pq_a_dist, pq_b_dist, decisions_opt, state );
+
+  bool passed = true;
+  passed = compare_values_1d( context + " rdCost", decisions_ref.rdCost, decisions_opt.rdCost, 4 ) && passed;
+  passed = compare_values_1d( context + " absLevel", decisions_ref.absLevel, decisions_opt.absLevel, 4 ) && passed;
+  passed = compare_values_1d( context + " prevId", decisions_ref.prevId, decisions_opt.prevId, 4 ) && passed;
+  return passed;
+}
+
+static bool check_checkAllRdCostsOdd1( DepQuant* ref, DepQuant* opt, unsigned num_cases )
+{
+  printf( "Testing DepQuant::checkAllRdCostsOdd1\n" );
+
+  InputGenerator<TCoeff> g4{ 4, /*is_signed=*/false };
+  InputGenerator<TCoeff> g20{ 20, /*is_signed=*/false };
+  InputGenerator<TCoeff> g31{ 31 };
+  InputGenerator<TCoeff> g_dist{ 20 };
+  DimensionGenerator rng;
+
+  DQIntern::Decisions decisions_ref;
+  DQIntern::Decisions decisions_opt;
+  DQIntern::StateMem state;
+  BinFracBits sigBuf[4][DQIntern::RateEstimator::sm_maxNumSigCtx];
+
+  bool passed = true;
+
+  auto setup_state_and_decisions = [&]
+  {
+    for( int j = 0; j < 4; ++j )
+    {
+      // Init state.
+      state.rdCost[j] = DQIntern::rdCostInit;
+      state.ctx.cff[j] = 0;
+      state.ctx.sig[j] = 0;
+      state.numSig[j] = 0;
+      state.refSbbCtxId[j] = -1;
+      state.remRegBins[j] = 4;
+      state.m_goRicePar[j] = 0;
+      state.m_goRiceZero[j] = 0;
+      state.sbbBits0[j] = 0;
+      state.sbbBits1[j] = 0;
+      state.m_sigFracBitsArray[j] = sigBuf[j];
+    }
+
+    state.cffBitsCtxOffset = rng.getOneOf<int>( { 1, 6, 11, 16 } );
+    for( int j = 0; j < 4; ++j )
+    {
+      state.ctx.sig[j] = rng.get( 0, DQIntern::RateEstimator::sm_maxNumSigCtx - 1 );
+      // The X86 implementation assumes that the ctx.cff[i] values are in the range [cffBitsCtxOffset,
+      // cffBitsCtxOffset + 4].
+      state.ctx.cff[j] = rng.get( state.cffBitsCtxOffset, state.cffBitsCtxOffset + 4 );
+
+      for( int k = 0; k < DQIntern::RateEstimator::sm_maxNumSigCtx; ++k )
+      {
+        sigBuf[j][k].intBits[0] = g20();
+        sigBuf[j][k].intBits[1] = g20();
+      }
+    }
+
+    std::generate( state.rdCost, state.rdCost + 4, g31 );
+    std::generate( state.sbbBits1, state.sbbBits1 + 4, g20 );
+    std::generate( state.numSig, state.numSig + 4, g4 );
+    std::generate( state.cffBits1, state.cffBits1 + DQIntern::RateEstimator::sm_maxNumGtxCtx + 3, g20 );
+
+    for( int j = 0; j < 4; ++j )
+    {
+      decisions_ref.rdCost[j] = decisions_opt.rdCost[j] = DQIntern::rdCostInit >> 2;
+
+      // These are expected to be updated by checkAllRdCostsOdd1, so the initial values don't matter.
+      // Assign different values between ref and opt so they will fail by default.
+      decisions_ref.absLevel[j] = decisions_ref.prevId[j] = -1;
+      decisions_opt.absLevel[j] = decisions_opt.prevId[j] = -2;
+    }
+  };
+
+  for( unsigned i = 0; i < std::max( 1u, num_cases / 5 ); ++i )
+  {
+    for( DQIntern::ScanPosType spt : { DQIntern::SCAN_ISCSBB, DQIntern::SCAN_SOCSBB, DQIntern::SCAN_EOCSBB } )
+    {
+      std::ostringstream sstm;
+      const char* spt_str = spt == DQIntern::SCAN_ISCSBB   ? "ISC_SBB"
+                            : spt == DQIntern::SCAN_SOCSBB ? "SOC_SBB"
+                                                           : "EOC_SBB";
+      sstm << "DepQuant checkAllRdCostsOdd1 scanPosType=" << spt_str;
+
+      // Test 1: Test with random inputs.
+      setup_state_and_decisions();
+
+      const int64_t pq_a_dist = g_dist();
+      const int64_t pq_b_dist = g_dist();
+
+      passed = check_one_checkAllRdCostsOdd1( ref, opt, spt, pq_a_dist, pq_b_dist, decisions_ref, decisions_opt, state,
+                                              sstm.str() + " random" ) &&
+               passed;
+
+      // Test 2: Keep the total candidate costs so close that any one small mistake in the accumulated RDCost
+      // calculation can change the selected path. It is not just about closeness, but about the whole sum being
+      // sensitive. Make the final candidate costs (rdCostA and rdCostZ across lanes/destinations) close enough that the
+      // comparison becomes sensitive (differ by 0 or 1 or 2).
+      // Cover mixed close-call cases as well as the three explicit close-sum outcomes: A wins, Z wins, and exact ties.
+      struct SensitiveSumCase
+      {
+        int64_t pq_a_dist;
+        int64_t pq_b_dist;
+        int sig_cost_z;
+        int sig_cost_a;
+        int cff_cost;
+        int offset;
+        const char* name;
+      };
+
+      for( const SensitiveSumCase tc :
+           { SensitiveSumCase{ 1, 1, 4, 2, 0, 0, " A wins" },
+             SensitiveSumCase{ 1, 0, 2, 2, 1, 0, " Z wins" },
+             SensitiveSumCase{ 1, 1, 3, 2, 0, 0, " A and Z ties" },
+             SensitiveSumCase{ 1, 1, 4, 2, 1, 1, " mixed case 1" },
+             SensitiveSumCase{ 1, 2, 4, 2, 0, 1, " mixed case 2" } } )
+      {
+        setup_state_and_decisions();
+
+        // With tc.offset == 0 the input is flat; state.rdCost = { base, base, base, base }.
+        // With tc.offset == 1 the input becomes state.rdCost = { base, base + 1, base + 2, base + 3 }.
+        const int64_t base_rd_cost = g31();
+        for( int j = 0; j < 4; ++j )
+        {
+          state.rdCost[j] = base_rd_cost + j * tc.offset;
+          state.sbbBits1[j] = tc.offset ? ( j & 1 ) : 1;
+          state.numSig[j] = 1;
+
+          state.ctx.sig[j] = 0;
+          state.ctx.cff[j] = state.cffBitsCtxOffset;
+
+          sigBuf[j][0].intBits[0] = tc.sig_cost_z;
+          sigBuf[j][0].intBits[1] = tc.sig_cost_a;
+          state.cffBits1[state.ctx.cff[j]] = tc.cff_cost;
+        }
+
+        passed = check_one_checkAllRdCostsOdd1( ref, opt, spt, tc.pq_a_dist, tc.pq_b_dist, decisions_ref, decisions_opt,
+                                                state, sstm.str() + " sensitive_sum" + tc.name ) &&
+                 passed;
+      }
+    }
+
+    // Test 3: SCAN_EOCSBB cases with mixed numSig == 0 or 1 to verify handling of the numSig == 0 vs. numSig > 0 cases.
+    std::ostringstream sstm;
+    sstm << "DepQuant checkAllRdCostsOdd1 scanPosType=EOC_SBB";
+
+    for( int pattern : { 0, 1 } )
+    {
+      setup_state_and_decisions();
+
+      const int64_t pq_a_dist = g_dist();
+      const int64_t pq_b_dist = g_dist();
+      // pattern 0 -> indices 0 and 2 are zero, pattern 1 -> indices 1 and 3 are zero.
+      for( int j = 0; j < 4; ++j )
+      {
+        state.numSig[j] = ( j & 1 ) ^ pattern; // 0,1,0,1 or 1,0,1,0.
+      }
+
+      passed = check_one_checkAllRdCostsOdd1( ref, opt, DQIntern::SCAN_EOCSBB, pq_a_dist, pq_b_dist, decisions_ref,
+                                              decisions_opt, state, sstm.str() + " numSig-01mixed" ) &&
+               passed;
+    }
+  }
+
+  return passed;
+}
+
 static bool check_updateStates( DepQuant* ref, DepQuant* opt, unsigned num_cases )
 {
   printf( "Testing DepQuant::updateStates\n" );
@@ -542,6 +716,7 @@ static bool test_DepQuant()
   unsigned num_cases = NUM_CASES;
   bool passed = true;
 
+  passed = check_checkAllRdCostsOdd1( ref.get(), opt.get(), num_cases ) && passed;
   passed = check_updateStates( ref.get(), opt.get(), num_cases ) && passed;
   passed = check_updateStatesEOS( ref.get(), opt.get(), num_cases ) && passed;
 


### PR DESCRIPTION
- Add unit test for DepQuant functions `State::updateStates`, `State::updateStatesEOS`, `State::checkAllRdCostsOdd1`, `findFirstPos`.
- Modify the DepQuant constructor to include a new `enableOpt` parameter to create a reference object and an optimized object for testing.
- Move `m_updateStates`, `m_updateStatesEOS`, `m_checkAllRdCostsOdd1`, `m_findFirstPos` from the private to the public section of the class to enable unit test access.
- Add /wd4100 to unit test MSVC flags to suppress unreferenced parameter warnings from Quant.h, matching the existing library build configuration.
- Extract the scalar findFirstPos logic from `xQuantDQ` into a dedicated function `findFirstPos`.
- Call `m_findFirstPos` unconditionally from `xQuantDQ` and move the final coefficient-wise refinement from `xQuantDQ` into `findFirstPos` for both the C and x86 implementations.