### PR TITLE
Arm: Optimize Neon xCalcHAD*

### DIFF
--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -504,7 +504,7 @@ Distortion xCalcHAD16x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg
   return sad;
 }
 
-static Distortion xCalcHAD8x16_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
+Distortion xCalcHAD8x16_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
 {
   int16x8_t diff_s16[16];
   for( int k = 0; k < 16; k++ )
@@ -519,6 +519,7 @@ static Distortion xCalcHAD8x16_neon( const Pel* piOrg, const Pel* piCur, int iSt
   }
 
   int16x8_t m1[16], m2[16];
+  int32x4_t m3[16], m4[32];
 
   // Vertical.
   m2[0] = vaddq_s16( diff_s16[0], diff_s16[8] );
@@ -589,200 +590,118 @@ static Distortion xCalcHAD8x16_neon( const Pel* piOrg, const Pel* piCur, int iSt
   m1[14] = vaddq_s16( m2[14], m2[15] );
   m1[15] = vsubq_s16( m2[14], m2[15] ); // 15-bit
 
-  // Transpose.
-  m2[0] = vzipq_s16( m1[0], m1[4] ).val[0];
-  m2[1] = vzipq_s16( m1[0], m1[4] ).val[1];
-  m2[2] = vzipq_s16( m1[1], m1[5] ).val[0];
-  m2[3] = vzipq_s16( m1[1], m1[5] ).val[1];
-  m2[4] = vzipq_s16( m1[2], m1[6] ).val[0];
-  m2[5] = vzipq_s16( m1[2], m1[6] ).val[1];
-  m2[6] = vzipq_s16( m1[3], m1[7] ).val[0];
-  m2[7] = vzipq_s16( m1[3], m1[7] ).val[1];
-  m2[8] = vzipq_s16( m1[8], m1[12] ).val[0];
-  m2[9] = vzipq_s16( m1[8], m1[12] ).val[1];
-  m2[10] = vzipq_s16( m1[9], m1[13] ).val[0];
-  m2[11] = vzipq_s16( m1[9], m1[13] ).val[1];
-  m2[12] = vzipq_s16( m1[10], m1[14] ).val[0];
-  m2[13] = vzipq_s16( m1[10], m1[14] ).val[1];
-  m2[14] = vzipq_s16( m1[11], m1[15] ).val[0];
-  m2[15] = vzipq_s16( m1[11], m1[15] ).val[1];
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x8( m1[0] ) );
 
-  m1[0] = vzipq_s16( m2[0], m2[4] ).val[0];
-  m1[1] = vzipq_s16( m2[0], m2[4] ).val[1];
-  m1[2] = vzipq_s16( m2[1], m2[5] ).val[0];
-  m1[3] = vzipq_s16( m2[1], m2[5] ).val[1];
-  m1[4] = vzipq_s16( m2[2], m2[6] ).val[0];
-  m1[5] = vzipq_s16( m2[2], m2[6] ).val[1];
-  m1[6] = vzipq_s16( m2[3], m2[7] ).val[0];
-  m1[7] = vzipq_s16( m2[3], m2[7] ).val[1];
-  m1[8] = vzipq_s16( m2[8], m2[12] ).val[0];
-  m1[9] = vzipq_s16( m2[8], m2[12] ).val[1];
-  m1[10] = vzipq_s16( m2[9], m2[13] ).val[0];
-  m1[11] = vzipq_s16( m2[9], m2[13] ).val[1];
-  m1[12] = vzipq_s16( m2[10], m2[14] ).val[0];
-  m1[13] = vzipq_s16( m2[10], m2[14] ).val[1];
-  m1[14] = vzipq_s16( m2[11], m2[15] ).val[0];
-  m1[15] = vzipq_s16( m2[11], m2[15] ).val[1];
+  m2[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
+  m2[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
+  m2[2] = vtrnq_s16( m1[2], m1[3] ).val[0];
+  m2[3] = vtrnq_s16( m1[2], m1[3] ).val[1];
+  m2[4] = vtrnq_s16( m1[4], m1[5] ).val[0];
+  m2[5] = vtrnq_s16( m1[4], m1[5] ).val[1];
+  m2[6] = vtrnq_s16( m1[6], m1[7] ).val[0];
+  m2[7] = vtrnq_s16( m1[6], m1[7] ).val[1];
+  m2[8] = vtrnq_s16( m1[8], m1[9] ).val[0];
+  m2[9] = vtrnq_s16( m1[8], m1[9] ).val[1];
+  m2[10] = vtrnq_s16( m1[10], m1[11] ).val[0];
+  m2[11] = vtrnq_s16( m1[10], m1[11] ).val[1];
+  m2[12] = vtrnq_s16( m1[12], m1[13] ).val[0];
+  m2[13] = vtrnq_s16( m1[12], m1[13] ).val[1];
+  m2[14] = vtrnq_s16( m1[14], m1[15] ).val[0];
+  m2[15] = vtrnq_s16( m1[14], m1[15] ).val[1];
 
-  m2[0] = vzipq_s16( m1[0], m1[4] ).val[0];
-  m2[1] = vzipq_s16( m1[0], m1[4] ).val[1];
-  m2[2] = vzipq_s16( m1[1], m1[5] ).val[0];
-  m2[3] = vzipq_s16( m1[1], m1[5] ).val[1];
-  m2[4] = vzipq_s16( m1[2], m1[6] ).val[0];
-  m2[5] = vzipq_s16( m1[2], m1[6] ).val[1];
-  m2[6] = vzipq_s16( m1[3], m1[7] ).val[0];
-  m2[7] = vzipq_s16( m1[3], m1[7] ).val[1];
-  m2[8] = vzipq_s16( m1[8], m1[12] ).val[0];
-  m2[9] = vzipq_s16( m1[8], m1[12] ).val[1];
-  m2[10] = vzipq_s16( m1[9], m1[13] ).val[0];
-  m2[11] = vzipq_s16( m1[9], m1[13] ).val[1];
-  m2[12] = vzipq_s16( m1[10], m1[14] ).val[0];
-  m2[13] = vzipq_s16( m1[10], m1[14] ).val[1];
-  m2[14] = vzipq_s16( m1[11], m1[15] ).val[0];
-  m2[15] = vzipq_s16( m1[11], m1[15] ).val[1];
+  m3[0] = vreinterpretq_s32_s16( vaddq_s16( m2[0], m2[1] ) );
+  m3[1] = vreinterpretq_s32_s16( vsubq_s16( m2[0], m2[1] ) );
+  m3[2] = vreinterpretq_s32_s16( vaddq_s16( m2[2], m2[3] ) );
+  m3[3] = vreinterpretq_s32_s16( vsubq_s16( m2[2], m2[3] ) );
+  m3[4] = vreinterpretq_s32_s16( vaddq_s16( m2[4], m2[5] ) );
+  m3[5] = vreinterpretq_s32_s16( vsubq_s16( m2[4], m2[5] ) );
+  m3[6] = vreinterpretq_s32_s16( vaddq_s16( m2[6], m2[7] ) );
+  m3[7] = vreinterpretq_s32_s16( vsubq_s16( m2[6], m2[7] ) );
+  m3[8] = vreinterpretq_s32_s16( vaddq_s16( m2[8], m2[9] ) );
+  m3[9] = vreinterpretq_s32_s16( vsubq_s16( m2[8], m2[9] ) );
+  m3[10] = vreinterpretq_s32_s16( vaddq_s16( m2[10], m2[11] ) );
+  m3[11] = vreinterpretq_s32_s16( vsubq_s16( m2[10], m2[11] ) );
+  m3[12] = vreinterpretq_s32_s16( vaddq_s16( m2[12], m2[13] ) );
+  m3[13] = vreinterpretq_s32_s16( vsubq_s16( m2[12], m2[13] ) );
+  m3[14] = vreinterpretq_s32_s16( vaddq_s16( m2[14], m2[15] ) );
+  m3[15] = vreinterpretq_s32_s16( vsubq_s16( m2[14], m2[15] ) ); // 16-bit
 
-  int32x4_t m3[2][16], m4[2][16];
+  m1[0] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[0] );
+  m1[1] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[1] );
+  m1[2] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[0] );
+  m1[3] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[1] );
+  m1[4] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[0] );
+  m1[5] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[1] );
+  m1[6] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[0] );
+  m1[7] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[1] );
+  m1[8] = vreinterpretq_s16_s32( vzipq_s32( m3[8], m3[9] ).val[0] );
+  m1[9] = vreinterpretq_s16_s32( vzipq_s32( m3[8], m3[9] ).val[1] );
+  m1[10] = vreinterpretq_s16_s32( vzipq_s32( m3[10], m3[11] ).val[0] );
+  m1[11] = vreinterpretq_s16_s32( vzipq_s32( m3[10], m3[11] ).val[1] );
+  m1[12] = vreinterpretq_s16_s32( vzipq_s32( m3[12], m3[13] ).val[0] );
+  m1[13] = vreinterpretq_s16_s32( vzipq_s32( m3[12], m3[13] ).val[1] );
+  m1[14] = vreinterpretq_s16_s32( vzipq_s32( m3[14], m3[15] ).val[0] );
+  m1[15] = vreinterpretq_s16_s32( vzipq_s32( m3[14], m3[15] ).val[1] );
 
-  // Horizontal.
-  m3[0][0] = vaddl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[4] ) );
-  m3[1][0] = vaddl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[4] ) );
-  m3[0][1] = vaddl_s16( vget_low_s16( m2[1] ), vget_low_s16( m2[5] ) );
-  m3[1][1] = vaddl_s16( vget_high_s16( m2[1] ), vget_high_s16( m2[5] ) );
-  m3[0][2] = vaddl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[6] ) );
-  m3[1][2] = vaddl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[6] ) );
-  m3[0][3] = vaddl_s16( vget_low_s16( m2[3] ), vget_low_s16( m2[7] ) );
-  m3[1][3] = vaddl_s16( vget_high_s16( m2[3] ), vget_high_s16( m2[7] ) );
-  m3[0][4] = vsubl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[4] ) );
-  m3[1][4] = vsubl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[4] ) );
-  m3[0][5] = vsubl_s16( vget_low_s16( m2[1] ), vget_low_s16( m2[5] ) );
-  m3[1][5] = vsubl_s16( vget_high_s16( m2[1] ), vget_high_s16( m2[5] ) );
-  m3[0][6] = vsubl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[6] ) );
-  m3[1][6] = vsubl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[6] ) );
-  m3[0][7] = vsubl_s16( vget_low_s16( m2[3] ), vget_low_s16( m2[7] ) );
-  m3[1][7] = vsubl_s16( vget_high_s16( m2[3] ), vget_high_s16( m2[7] ) );
-  m3[0][8] = vaddl_s16( vget_low_s16( m2[8] ), vget_low_s16( m2[12] ) );
-  m3[1][8] = vaddl_s16( vget_high_s16( m2[8] ), vget_high_s16( m2[12] ) );
-  m3[0][9] = vaddl_s16( vget_low_s16( m2[9] ), vget_low_s16( m2[13] ) );
-  m3[1][9] = vaddl_s16( vget_high_s16( m2[9] ), vget_high_s16( m2[13] ) );
-  m3[0][10] = vaddl_s16( vget_low_s16( m2[10] ), vget_low_s16( m2[14] ) );
-  m3[1][10] = vaddl_s16( vget_high_s16( m2[10] ), vget_high_s16( m2[14] ) );
-  m3[0][11] = vaddl_s16( vget_low_s16( m2[11] ), vget_low_s16( m2[15] ) );
-  m3[1][11] = vaddl_s16( vget_high_s16( m2[11] ), vget_high_s16( m2[15] ) );
-  m3[0][12] = vsubl_s16( vget_low_s16( m2[8] ), vget_low_s16( m2[12] ) );
-  m3[1][12] = vsubl_s16( vget_high_s16( m2[8] ), vget_high_s16( m2[12] ) );
-  m3[0][13] = vsubl_s16( vget_low_s16( m2[9] ), vget_low_s16( m2[13] ) );
-  m3[1][13] = vsubl_s16( vget_high_s16( m2[9] ), vget_high_s16( m2[13] ) );
-  m3[0][14] = vsubl_s16( vget_low_s16( m2[10] ), vget_low_s16( m2[14] ) );
-  m3[1][14] = vsubl_s16( vget_high_s16( m2[10] ), vget_high_s16( m2[14] ) );
-  m3[0][15] = vsubl_s16( vget_low_s16( m2[11] ), vget_low_s16( m2[15] ) );
-  m3[1][15] = vsubl_s16( vget_high_s16( m2[11] ), vget_high_s16( m2[15] ) );
+  m4[0] = vabsq_s32( vaddl_s16( vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) ) );
+  m4[1] = vabsq_s32( vaddl_s16( vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) ) );
+  m4[2] = vabdl_s16( vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) );
+  m4[3] = vabdl_s16( vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) );
+  m4[4] = vabsq_s32( vaddl_s16( vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) ) );
+  m4[5] = vabsq_s32( vaddl_s16( vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) ) );
+  m4[6] = vabdl_s16( vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) );
+  m4[7] = vabdl_s16( vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) );
+  m4[8] = vabsq_s32( vaddl_s16( vget_low_s16( m1[4] ), vget_low_s16( m1[5] ) ) );
+  m4[9] = vabsq_s32( vaddl_s16( vget_high_s16( m1[4] ), vget_high_s16( m1[5] ) ) );
+  m4[10] = vabdl_s16( vget_low_s16( m1[4] ), vget_low_s16( m1[5] ) );
+  m4[11] = vabdl_s16( vget_high_s16( m1[4] ), vget_high_s16( m1[5] ) );
+  m4[12] = vabsq_s32( vaddl_s16( vget_low_s16( m1[6] ), vget_low_s16( m1[7] ) ) );
+  m4[13] = vabsq_s32( vaddl_s16( vget_high_s16( m1[6] ), vget_high_s16( m1[7] ) ) );
+  m4[14] = vabdl_s16( vget_low_s16( m1[6] ), vget_low_s16( m1[7] ) );
+  m4[15] = vabdl_s16( vget_high_s16( m1[6] ), vget_high_s16( m1[7] ) );
+  m4[16] = vabsq_s32( vaddl_s16( vget_low_s16( m1[8] ), vget_low_s16( m1[9] ) ) );
+  m4[17] = vabsq_s32( vaddl_s16( vget_high_s16( m1[8] ), vget_high_s16( m1[9] ) ) );
+  m4[18] = vabdl_s16( vget_low_s16( m1[8] ), vget_low_s16( m1[9] ) );
+  m4[19] = vabdl_s16( vget_high_s16( m1[8] ), vget_high_s16( m1[9] ) );
+  m4[20] = vabsq_s32( vaddl_s16( vget_low_s16( m1[10] ), vget_low_s16( m1[11] ) ) );
+  m4[21] = vabsq_s32( vaddl_s16( vget_high_s16( m1[10] ), vget_high_s16( m1[11] ) ) );
+  m4[22] = vabdl_s16( vget_low_s16( m1[10] ), vget_low_s16( m1[11] ) );
+  m4[23] = vabdl_s16( vget_high_s16( m1[10] ), vget_high_s16( m1[11] ) );
+  m4[24] = vabsq_s32( vaddl_s16( vget_low_s16( m1[12] ), vget_low_s16( m1[13] ) ) );
+  m4[25] = vabsq_s32( vaddl_s16( vget_high_s16( m1[12] ), vget_high_s16( m1[13] ) ) );
+  m4[26] = vabdl_s16( vget_low_s16( m1[12] ), vget_low_s16( m1[13] ) );
+  m4[27] = vabdl_s16( vget_high_s16( m1[12] ), vget_high_s16( m1[13] ) );
+  m4[28] = vabsq_s32( vaddl_s16( vget_low_s16( m1[14] ), vget_low_s16( m1[15] ) ) );
+  m4[29] = vabsq_s32( vaddl_s16( vget_high_s16( m1[14] ), vget_high_s16( m1[15] ) ) );
+  m4[30] = vabdl_s16( vget_low_s16( m1[14] ), vget_low_s16( m1[15] ) );
+  m4[31] = vabdl_s16( vget_high_s16( m1[14] ), vget_high_s16( m1[15] ) );
 
-  m4[0][0] = vaddq_s32( m3[0][0], m3[0][2] );
-  m4[1][0] = vaddq_s32( m3[1][0], m3[1][2] );
-  m4[0][2] = vsubq_s32( m3[0][0], m3[0][2] );
-  m4[1][2] = vsubq_s32( m3[1][0], m3[1][2] );
-  m4[0][1] = vaddq_s32( m3[0][1], m3[0][3] );
-  m4[1][1] = vaddq_s32( m3[1][1], m3[1][3] );
-  m4[0][3] = vsubq_s32( m3[0][1], m3[0][3] );
-  m4[1][3] = vsubq_s32( m3[1][1], m3[1][3] );
-  m4[0][4] = vaddq_s32( m3[0][4], m3[0][6] );
-  m4[1][4] = vaddq_s32( m3[1][4], m3[1][6] );
-  m4[0][6] = vsubq_s32( m3[0][4], m3[0][6] );
-  m4[1][6] = vsubq_s32( m3[1][4], m3[1][6] );
-  m4[0][5] = vaddq_s32( m3[0][5], m3[0][7] );
-  m4[1][5] = vaddq_s32( m3[1][5], m3[1][7] );
-  m4[0][7] = vsubq_s32( m3[0][5], m3[0][7] );
-  m4[1][7] = vsubq_s32( m3[1][5], m3[1][7] );
-  m4[0][8] = vaddq_s32( m3[0][8], m3[0][10] );
-  m4[1][8] = vaddq_s32( m3[1][8], m3[1][10] );
-  m4[0][10] = vsubq_s32( m3[0][8], m3[0][10] );
-  m4[1][10] = vsubq_s32( m3[1][8], m3[1][10] );
-  m4[0][9] = vaddq_s32( m3[0][9], m3[0][11] );
-  m4[1][9] = vaddq_s32( m3[1][9], m3[1][11] );
-  m4[0][11] = vsubq_s32( m3[0][9], m3[0][11] );
-  m4[1][11] = vsubq_s32( m3[1][9], m3[1][11] );
-  m4[0][12] = vaddq_s32( m3[0][12], m3[0][14] );
-  m4[1][12] = vaddq_s32( m3[1][12], m3[1][14] );
-  m4[0][14] = vsubq_s32( m3[0][12], m3[0][14] );
-  m4[1][14] = vsubq_s32( m3[1][12], m3[1][14] );
-  m4[0][13] = vaddq_s32( m3[0][13], m3[0][15] );
-  m4[1][13] = vaddq_s32( m3[1][13], m3[1][15] );
-  m4[0][15] = vsubq_s32( m3[0][13], m3[0][15] );
-  m4[1][15] = vsubq_s32( m3[1][13], m3[1][15] );
+  const int32x4_t max0 = vmaxq_s32( m4[0], m4[1] );
+  const int32x4_t max1 = vmaxq_s32( m4[2], m4[3] );
+  const int32x4_t max2 = vmaxq_s32( m4[4], m4[5] );
+  const int32x4_t max3 = vmaxq_s32( m4[6], m4[7] );
+  const int32x4_t max4 = vmaxq_s32( m4[8], m4[9] );
+  const int32x4_t max5 = vmaxq_s32( m4[10], m4[11] );
+  const int32x4_t max6 = vmaxq_s32( m4[12], m4[13] );
+  const int32x4_t max7 = vmaxq_s32( m4[14], m4[15] );
+  const int32x4_t max8 = vmaxq_s32( m4[16], m4[17] );
+  const int32x4_t max9 = vmaxq_s32( m4[18], m4[19] );
+  const int32x4_t max10 = vmaxq_s32( m4[20], m4[21] );
+  const int32x4_t max11 = vmaxq_s32( m4[22], m4[23] );
+  const int32x4_t max12 = vmaxq_s32( m4[24], m4[25] );
+  const int32x4_t max13 = vmaxq_s32( m4[26], m4[27] );
+  const int32x4_t max14 = vmaxq_s32( m4[28], m4[29] );
+  const int32x4_t max15 = vmaxq_s32( m4[30], m4[31] );
 
-  m3[0][0] = vabsq_s32( vaddq_s32( m4[0][0], m4[0][1] ) );
-  m3[1][0] = vabsq_s32( vaddq_s32( m4[1][0], m4[1][1] ) );
-  m3[0][1] = vabdq_s32( m4[0][0], m4[0][1] );
-  m3[1][1] = vabdq_s32( m4[1][0], m4[1][1] );
-  m3[0][2] = vabsq_s32( vaddq_s32( m4[0][2], m4[0][3] ) );
-  m3[1][2] = vabsq_s32( vaddq_s32( m4[1][2], m4[1][3] ) );
-  m3[0][3] = vabdq_s32( m4[0][2], m4[0][3] );
-  m3[1][3] = vabdq_s32( m4[1][2], m4[1][3] );
-  m3[0][4] = vabsq_s32( vaddq_s32( m4[0][4], m4[0][5] ) );
-  m3[1][4] = vabsq_s32( vaddq_s32( m4[1][4], m4[1][5] ) );
-  m3[0][5] = vabdq_s32( m4[0][4], m4[0][5] );
-  m3[1][5] = vabdq_s32( m4[1][4], m4[1][5] );
-  m3[0][6] = vabsq_s32( vaddq_s32( m4[0][6], m4[0][7] ) );
-  m3[1][6] = vabsq_s32( vaddq_s32( m4[1][6], m4[1][7] ) );
-  m3[0][7] = vabdq_s32( m4[0][6], m4[0][7] );
-  m3[1][7] = vabdq_s32( m4[1][6], m4[1][7] );
-  m3[0][8] = vabsq_s32( vaddq_s32( m4[0][8], m4[0][9] ) );
-  m3[1][8] = vabsq_s32( vaddq_s32( m4[1][8], m4[1][9] ) );
-  m3[0][9] = vabdq_s32( m4[0][8], m4[0][9] );
-  m3[1][9] = vabdq_s32( m4[1][8], m4[1][9] );
-  m3[0][10] = vabsq_s32( vaddq_s32( m4[0][10], m4[0][11] ) );
-  m3[1][10] = vabsq_s32( vaddq_s32( m4[1][10], m4[1][11] ) );
-  m3[0][11] = vabdq_s32( m4[0][10], m4[0][11] );
-  m3[1][11] = vabdq_s32( m4[1][10], m4[1][11] );
-  m3[0][12] = vabsq_s32( vaddq_s32( m4[0][12], m4[0][13] ) );
-  m3[1][12] = vabsq_s32( vaddq_s32( m4[1][12], m4[1][13] ) );
-  m3[0][13] = vabdq_s32( m4[0][12], m4[0][13] );
-  m3[1][13] = vabdq_s32( m4[1][12], m4[1][13] );
-  m3[0][14] = vabsq_s32( vaddq_s32( m4[0][14], m4[0][15] ) );
-  m3[1][14] = vabsq_s32( vaddq_s32( m4[1][14], m4[1][15] ) );
-  m3[0][15] = vabdq_s32( m4[0][14], m4[0][15] );
-  m3[1][15] = vabdq_s32( m4[1][14], m4[1][15] );
+  const int32x4_t sum0 = horizontal_add_4d_s32x4( max0, max1, max2, max3 );
+  const int32x4_t sum1 = horizontal_add_4d_s32x4( max4, max5, max6, max7 );
+  const int32x4_t sum2 = horizontal_add_4d_s32x4( max8, max9, max10, max11 );
+  const int32x4_t sum3 = horizontal_add_4d_s32x4( max12, max13, max14, max15 );
 
-  uint32_t absDC = vgetq_lane_s32( m3[0][0], 0 );
+  const int32x4_t sum0123 = horizontal_add_4d_s32x4( sum0, sum1, sum2, sum3 );
 
-  m3[0][0] = vaddq_s32( m3[0][0], m3[0][1] );
-  m3[0][2] = vaddq_s32( m3[0][2], m3[0][3] );
-  m3[0][4] = vaddq_s32( m3[0][4], m3[0][5] );
-  m3[0][6] = vaddq_s32( m3[0][6], m3[0][7] );
-  m3[0][8] = vaddq_s32( m3[0][8], m3[0][9] );
-  m3[0][10] = vaddq_s32( m3[0][10], m3[0][11] );
-  m3[0][12] = vaddq_s32( m3[0][12], m3[0][13] );
-  m3[0][14] = vaddq_s32( m3[0][14], m3[0][15] );
-  m3[1][0] = vaddq_s32( m3[1][0], m3[1][1] );
-  m3[1][2] = vaddq_s32( m3[1][2], m3[1][3] );
-  m3[1][4] = vaddq_s32( m3[1][4], m3[1][5] );
-  m3[1][6] = vaddq_s32( m3[1][6], m3[1][7] );
-  m3[1][8] = vaddq_s32( m3[1][8], m3[1][9] );
-  m3[1][10] = vaddq_s32( m3[1][10], m3[1][11] );
-  m3[1][12] = vaddq_s32( m3[1][12], m3[1][13] );
-  m3[1][14] = vaddq_s32( m3[1][14], m3[1][15] );
-
-  m3[0][0] = vaddq_s32( m3[0][0], m3[0][2] );
-  m3[0][4] = vaddq_s32( m3[0][4], m3[0][6] );
-  m3[0][8] = vaddq_s32( m3[0][8], m3[0][10] );
-  m3[0][12] = vaddq_s32( m3[0][12], m3[0][14] );
-  m3[1][0] = vaddq_s32( m3[1][0], m3[1][2] );
-  m3[1][4] = vaddq_s32( m3[1][4], m3[1][6] );
-  m3[1][8] = vaddq_s32( m3[1][8], m3[1][10] );
-  m3[1][12] = vaddq_s32( m3[1][12], m3[1][14] );
-
-  m3[0][0] = vaddq_s32( m3[0][0], m3[0][4] );
-  m3[0][8] = vaddq_s32( m3[0][8], m3[0][12] );
-  m3[1][0] = vaddq_s32( m3[1][0], m3[1][4] );
-  m3[1][8] = vaddq_s32( m3[1][8], m3[1][12] );
-
-  m3[0][0] = vaddq_s32( m3[0][0], m3[0][8] );
-  m3[1][0] = vaddq_s32( m3[1][0], m3[1][8] );
-
-  m3[0][0] = vaddq_s32( m3[0][0], m3[1][0] );
-
-  uint32_t sad = horizontal_add_s32x4( m3[0][0] );
-
+  uint32_t sad = ( uint32_t )horizontal_add_s32x4( sum0123 );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
   sad -= absDC;
   sad += absDC >> 2;
   sad = ( uint32_t )( ( ( double )sad / sqrt( 16.0 * 8.0 ) ) * 2.0 );
@@ -1021,8 +940,8 @@ Distortion xGetHADs_neon( const DistParam& rcDtParam )
       {
         uiSum += xCalcHAD8x16_neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur );
       }
-      piOrg += 16*iStrideOrg;
-      piCur += 16*iStrideCur;
+      piOrg += 16 * iStrideOrg;
+      piCur += 16 * iStrideCur;
     }
   }
   else if( iCols > iRows && ( iCols & 7 ) == 0 && ( iRows & 3 ) == 0 )

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -51,6 +51,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonDefARM.h"
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/RdCost.h"
+#include "permute_neon.h"
 #include "reverse_neon.h"
 #include "sum_neon.h"
 #include "transpose_neon.h"
@@ -1005,74 +1006,58 @@ Distortion xCalcHAD4x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg,
   return sad;
 }
 
-static Distortion xCalcHAD4x4_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
+static const uint8_t k4x4PermuteTbl[] = { 6, 7, 4, 5, 22, 23, 20, 21, 14, 15, 12, 13, 30, 31, 28, 29 };
+
+Distortion xCalcHAD4x4_neon( const Pel* piOrg, const Pel* piCur, const int iStrideOrg, const int iStrideCur )
 {
-  int16x4_t r0 = vld1_s16( piOrg );
-  int16x4_t r1 = vld1_s16( piOrg + iStrideOrg );
-  int16x4_t r2 = vld1_s16( piOrg + 2 * iStrideOrg );
-  int16x4_t r3 = vld1_s16( piOrg + 3 * iStrideOrg );
+  const int16x4_t r0 = vld1_s16( piOrg + 0 * iStrideOrg );
+  const int16x4_t r1 = vld1_s16( piOrg + 1 * iStrideOrg );
+  const int16x4_t r2 = vld1_s16( piOrg + 2 * iStrideOrg );
+  const int16x4_t r3 = vld1_s16( piOrg + 3 * iStrideOrg );
 
-  int16x4_t c0 = vld1_s16( piCur );
-  int16x4_t c1 = vld1_s16( piCur + iStrideCur );
-  int16x4_t c2 = vld1_s16( piCur + 2 * iStrideCur );
-  int16x4_t c3 = vld1_s16( piCur + 3 * iStrideCur );
+  const int16x4_t c0 = vld1_s16( piCur + 0 * iStrideCur );
+  const int16x4_t c1 = vld1_s16( piCur + 1 * iStrideCur );
+  const int16x4_t c2 = vld1_s16( piCur + 2 * iStrideCur );
+  const int16x4_t c3 = vld1_s16( piCur + 3 * iStrideCur );
 
-  int16x4_t m1[4], m2[4];
+  const int16x4_t diff0 = vsub_s16( r0, c0 );
+  const int16x4_t diff1 = vsub_s16( r1, c1 );
+  const int16x4_t diff2 = vsub_s16( r2, c2 );
+  const int16x4_t diff3 = vsub_s16( r3, c3 );
+
+  int16x8_t m1[2], m2[2];
 
   // Vertical.
-  m1[0] = vsub_s16( r0, c0 );
-  m1[1] = vsub_s16( r1, c1 );
-  m1[2] = vsub_s16( r2, c2 );
-  m1[3] = vsub_s16( r3, c3 );
+  m2[0] = vcombine_s16( vadd_s16( diff0, diff3 ), vadd_s16( diff1, diff2 ) ); // 11-bit
+  m2[1] = vcombine_s16( vsub_s16( diff0, diff3 ), vsub_s16( diff1, diff2 ) );
 
-  m2[0] = vadd_s16( m1[0], m1[3] );
-  m2[1] = vadd_s16( m1[1], m1[2] );
-  m2[2] = vsub_s16( m1[0], m1[3] );
-  m2[3] = vsub_s16( m1[1], m1[2] );
+  m1[0] = vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[0];
+  m1[1] = vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[1];
 
-  m1[0] = vadd_s16( m2[0], m2[1] );
-  m1[1] = vsub_s16( m2[0], m2[1] );
-  m1[2] = vsub_s16( m2[2], m2[3] );
-  m1[3] = vadd_s16( m2[2], m2[3] );
+  m2[0] = vaddq_s16( m1[0], m1[1] );
+  m2[1] = vsubq_s16( m1[0], m1[1] ); // 13-bit
 
-  // Transpose.
-  int16x8_t m1q[4];
-  const int16x4_t zero = vdup_n_s16( 0 );
-  m1q[0] = vcombine_s16( m1[0], zero );
-  m1q[1] = vcombine_s16( m1[1], zero );
-  m1q[2] = vcombine_s16( m1[2], zero );
-  m1q[3] = vcombine_s16( m1[3], zero );
+  const int absDC = std::abs( horizontal_add_long_s16x4( vget_low_s16( m2[0] ) ) );
 
-  int16x8_t a0 = vzipq_s16( m1q[0], m1q[2] ).val[0];
-  int16x8_t a1 = vzipq_s16( m1q[1], m1q[3] ).val[0];
+  const uint8x16_t idx0 = vld1q_u8( k4x4PermuteTbl );
+  uint8x16x2_t tbl;
+  tbl.val[0] = vreinterpretq_u8_s16( m2[0] );
+  tbl.val[1] = vreinterpretq_u8_s16( m2[1] );
 
-  int16x8_t b0 = vzipq_s16( a0, a1 ).val[0];
-  int16x8_t b1 = vzipq_s16( a0, a1 ).val[1];
+  m1[0] = vreinterpretq_s16_s32( vtrnq_s32( vreinterpretq_s32_s16( m2[0] ), vreinterpretq_s32_s16( m2[1] ) ).val[0] );
+  m1[1] = vreinterpretq_s16_u8( vvenc_vqtbl2q_u8( tbl, idx0 ) );
 
-  m1[0] = vget_low_s16( b0 );
-  m1[1] = vget_high_s16( b0 );
-  m1[2] = vget_low_s16( b1 );
-  m1[3] = vget_high_s16( b1 );
+  // The last butterfly uses |x+y|+|x-y| = 2*max(|x|,|y|); we delay the "*2".
+  m2[0] = vabsq_s16( vaddq_s16( m1[0], m1[1] ) );
+  m2[1] = vabdq_s16( m1[0], m1[1] ); // 14-bit
 
-  // Horizontal.
-  m2[0] = vadd_s16( m1[0], m1[3] );
-  m2[1] = vadd_s16( m1[1], m1[2] );
-  m2[2] = vsub_s16( m1[0], m1[3] );
-  m2[3] = vsub_s16( m1[1], m1[2] );
+  m1[0] = vtrnq_s16( m2[0], m2[1] ).val[0];
+  m1[1] = vtrnq_s16( m2[0], m2[1] ).val[1];
 
-  m1[0] = vabs_s16( vadd_s16( m2[0], m2[1] ) );
-  m1[1] = vabd_s16( m2[0], m2[1] );
-  m1[2] = vabd_s16( m2[2], m2[3] );
-  m1[3] = vabs_s16( vadd_s16( m2[2], m2[3] ) );
+  int16x8_t max = vmaxq_s16( m1[0], m1[1] );
 
-  uint32_t absDC = ( uint32_t )vget_lane_s16( m1[0], 0 );
-
-  int32x4_t sum0_32 = vaddl_s16( m1[0], m1[1] );
-  int32x4_t sum1_32 = vaddl_s16( m1[2], m1[3] );
-  int32x4_t sum32 = vaddq_s32( sum0_32, sum1_32 );
-
-  uint32_t sad = ( uint32_t )horizontal_add_s32x4( sum32 );
-
+  int sad = horizontal_add_long_s16x8( max );
+  sad <<= 1;
   sad -= absDC;
   sad += absDC >> 2;
   sad = ( sad + 1 ) >> 1;

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -940,7 +940,7 @@ Distortion xCalcHAD8x4_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg,
   return sad;
 }
 
-static Distortion xCalcHAD4x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur, int iBitDepth )
+Distortion xCalcHAD4x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur, int iBitDepth )
 {
   int16x4_t diff[8];
 
@@ -955,79 +955,48 @@ static Distortion xCalcHAD4x8_neon( const Pel* piOrg, const Pel* piCur, int iStr
     piCur += iStrideCur;
   }
 
-  int16x4_t m1[8], m2[8];
+  int16x8_t m1[8], m2[8];
+  int32x4_t m3[4];
 
   // Vertical.
-  m1[0] = vadd_s16( diff[0], diff[4] );
-  m1[1] = vadd_s16( diff[1], diff[5] );
-  m1[2] = vadd_s16( diff[2], diff[6] );
-  m1[3] = vadd_s16( diff[3], diff[7] );
-  m1[4] = vsub_s16( diff[0], diff[4] );
-  m1[5] = vsub_s16( diff[1], diff[5] );
-  m1[6] = vsub_s16( diff[2], diff[6] );
-  m1[7] = vsub_s16( diff[3], diff[7] ); // 12-bit
+  m1[0] = vcombine_s16( vadd_s16( diff[0], diff[1] ), vsub_s16( diff[0], diff[1] ) );
+  m1[1] = vcombine_s16( vadd_s16( diff[2], diff[3] ), vsub_s16( diff[2], diff[3] ) );
+  m1[2] = vcombine_s16( vadd_s16( diff[4], diff[5] ), vsub_s16( diff[4], diff[5] ) );
+  m1[3] = vcombine_s16( vadd_s16( diff[6], diff[7] ), vsub_s16( diff[6], diff[7] ) ); // 12-bit
 
-  m2[0] = vadd_s16( m1[0], m1[2] );
-  m2[1] = vadd_s16( m1[1], m1[3] );
-  m2[2] = vsub_s16( m1[0], m1[2] );
-  m2[3] = vsub_s16( m1[1], m1[3] );
-  m2[4] = vadd_s16( m1[4], m1[6] );
-  m2[5] = vadd_s16( m1[5], m1[7] );
-  m2[6] = vsub_s16( m1[4], m1[6] );
-  m2[7] = vsub_s16( m1[5], m1[7] ); // 13-bit
+  m2[0] = vaddq_s16( m1[0], m1[1] );
+  m2[1] = vsubq_s16( m1[0], m1[1] );
+  m2[2] = vaddq_s16( m1[2], m1[3] );
+  m2[3] = vsubq_s16( m1[2], m1[3] ); // 13-bit
 
-  m1[0] = vadd_s16( m2[0], m2[1] );
-  m1[1] = vsub_s16( m2[0], m2[1] );
-  m1[2] = vadd_s16( m2[2], m2[3] );
-  m1[3] = vsub_s16( m2[2], m2[3] );
-  m1[4] = vadd_s16( m2[4], m2[5] );
-  m1[5] = vsub_s16( m2[4], m2[5] );
-  m1[6] = vadd_s16( m2[6], m2[7] );
-  m1[7] = vsub_s16( m2[6], m2[7] ); // 14-bit
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x4( vget_low_s16( vaddq_s16( m2[0], m2[2] ) ) ) );
 
-  // Transpose.
-  int16x8_t m1q[8];
-  const int16x4_t zero = vdup_n_s16( 0 );
-  m1q[0] = vcombine_s16( m1[0], zero );
-  m1q[1] = vcombine_s16( m1[1], zero );
-  m1q[2] = vcombine_s16( m1[2], zero );
-  m1q[3] = vcombine_s16( m1[3], zero );
-  m1q[4] = vcombine_s16( m1[4], zero );
-  m1q[5] = vcombine_s16( m1[5], zero );
-  m1q[6] = vcombine_s16( m1[6], zero );
-  m1q[7] = vcombine_s16( m1[7], zero );
-
-  int16x8_t m3[4], m4[4];
-  m3[0] = vzipq_s16( m1q[0], m1q[4] ).val[0];
-  m3[1] = vzipq_s16( m1q[2], m1q[6] ).val[0];
-  m3[2] = vzipq_s16( m1q[1], m1q[5] ).val[0];
-  m3[3] = vzipq_s16( m1q[3], m1q[7] ).val[0];
-
-  m4[0] = vzipq_s16( m3[0], m3[1] ).val[0];
-  m4[1] = vzipq_s16( m3[0], m3[1] ).val[1];
-  m4[2] = vzipq_s16( m3[2], m3[3] ).val[0];
-  m4[3] = vzipq_s16( m3[2], m3[3] ).val[1];
-
-  m3[0] = vzipq_s16( m4[0], m4[2] ).val[0];
-  m3[1] = vzipq_s16( m4[0], m4[2] ).val[1];
-  m3[2] = vzipq_s16( m4[1], m4[3] ).val[0];
-  m3[3] = vzipq_s16( m4[1], m4[3] ).val[1];
+  m3[0] = vreinterpretq_s32_s16( vaddq_s16( m2[0], m2[2] ) );
+  m3[1] = vreinterpretq_s32_s16( vaddq_s16( m2[1], m2[3] ) );
+  m3[2] = vreinterpretq_s32_s16( vsubq_s16( m2[0], m2[2] ) );
+  m3[3] = vreinterpretq_s32_s16( vsubq_s16( m2[1], m2[3] ) ); // 14-bit
 
   // Horizontal.
-  m4[0] = vaddq_s16( m3[0], m3[2] );
-  m4[1] = vaddq_s16( m3[1], m3[3] );
-  m4[2] = vsubq_s16( m3[0], m3[2] );
-  m4[3] = vsubq_s16( m3[1], m3[3] );
+  m2[0] = vreinterpretq_s16_s32( vuzpq_s32( m3[0], m3[1] ).val[0] );
+  m2[1] = vreinterpretq_s16_s32( vuzpq_s32( m3[0], m3[1] ).val[1] );
+  m2[2] = vreinterpretq_s16_s32( vuzpq_s32( m3[2], m3[3] ).val[0] );
+  m2[3] = vreinterpretq_s16_s32( vuzpq_s32( m3[2], m3[3] ).val[1] );
 
-  m3[0] = vabsq_s16( vaddq_s16( m4[0], m4[1] ) );
-  m3[1] = vabdq_s16( m4[0], m4[1] );
-  m3[2] = vabsq_s16( vaddq_s16( m4[2], m4[3] ) );
-  m3[3] = vabdq_s16( m4[2], m4[3] );
+  m1[0] = vabsq_s16( vaddq_s16( m2[0], m2[1] ) );
+  m1[1] = vabsq_s16( vaddq_s16( m2[2], m2[3] ) );
+  m1[2] = vabdq_s16( m2[0], m2[1] );
+  m1[3] = vabdq_s16( m2[2], m2[3] ); // 15-bit
 
-  uint32_t absDC = ( uint32_t )vgetq_lane_s16( m3[0], 0 );
+  m2[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
+  m2[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
+  m2[2] = vtrnq_s16( m1[2], m1[3] ).val[0];
+  m2[3] = vtrnq_s16( m1[2], m1[3] ).val[1];
 
-  int32x4_t total = horizontal_add_long_4d_s16x8( m3[0], m3[1], m3[2], m3[3] );
-  uint32_t sad = ( uint32_t )horizontal_add_s32x4( total );
+  const uint16x8_t max0 = vreinterpretq_u16_s16( vmaxq_s16( m2[0], m2[1] ) );
+  const uint16x8_t max1 = vreinterpretq_u16_s16( vmaxq_s16( m2[2], m2[3] ) );
+
+  uint32_t sad = ( uint32_t )horizontal_add_long_u16x8( vaddq_u16( max0, max1 ) );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
 
   sad -= absDC;
   sad += absDC >> 2;

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
     \brief    RD cost computation class, Neon version
 */
 
+#include <cstdlib>
 #include <math.h>
 #include <limits>
 
@@ -59,12 +60,10 @@ namespace vvenc
 
 #if ENABLE_SIMD_OPT_DIST && defined( TARGET_SIMD_ARM )
 
-static uint32_t xCalcHAD16x16_fast_Neon( const Pel *piOrg, const Pel *piCur, const int iStrideOrg, const int iStrideCur, const int iBitDepth )
+Distortion xCalcHAD16x16_fast_neon( const Pel* piOrg, const Pel* piCur, const int iStrideOrg, const int iStrideCur )
 {
   int16x8_t m1[8], m2[8];
-  int32x4x2_t m3[8], m4[8];
-
-  CHECKD( iBitDepth > 10, "Only bit-depths of up to 10 bits supported!" );
+  int32x4_t m3[8];
 
   for( int i = 0; i < 8; i++ )
   {
@@ -125,119 +124,66 @@ static uint32_t xCalcHAD16x16_fast_Neon( const Pel *piOrg, const Pel *piCur, con
   m1[6] = vaddq_s16( m2[6], m2[7] );
   m1[7] = vsubq_s16( m2[6], m2[7] ); // 14-bit
 
-  // Transpose.
-  m2[0] = vzipq_s16( m1[0], m1[2] ).val[0];
-  m2[1] = vzipq_s16( m1[1], m1[3] ).val[0];
-  m2[2] = vzipq_s16( m1[0], m1[2] ).val[1];
-  m2[3] = vzipq_s16( m1[1], m1[3] ).val[1];
-  m2[4] = vzipq_s16( m1[4], m1[6] ).val[0];
-  m2[5] = vzipq_s16( m1[5], m1[7] ).val[0];
-  m2[6] = vzipq_s16( m1[4], m1[6] ).val[1];
-  m2[7] = vzipq_s16( m1[5], m1[7] ).val[1];
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x8( m1[0] ) );
 
-  m1[0] = vzipq_s16( m2[0], m2[1] ).val[0];
-  m1[1] = vzipq_s16( m2[0], m2[1] ).val[1];
-  m1[2] = vzipq_s16( m2[2], m2[3] ).val[0];
-  m1[3] = vzipq_s16( m2[2], m2[3] ).val[1];
-  m1[4] = vzipq_s16( m2[4], m2[5] ).val[0];
-  m1[5] = vzipq_s16( m2[4], m2[5] ).val[1];
-  m1[6] = vzipq_s16( m2[6], m2[7] ).val[0];
-  m1[7] = vzipq_s16( m2[6], m2[7] ).val[1];
+  // Partial transpose to do the first horizontal step.
+  m2[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
+  m2[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
+  m2[2] = vtrnq_s16( m1[2], m1[3] ).val[0];
+  m2[3] = vtrnq_s16( m1[2], m1[3] ).val[1];
+  m2[4] = vtrnq_s16( m1[4], m1[5] ).val[0];
+  m2[5] = vtrnq_s16( m1[4], m1[5] ).val[1];
+  m2[6] = vtrnq_s16( m1[6], m1[7] ).val[0];
+  m2[7] = vtrnq_s16( m1[6], m1[7] ).val[1];
 
-  // Horizontal.
-  int16x8x2_t a = vvenc_vtrnq_s64_to_s16( m1[0], m1[1] );
-  int16x8x2_t b = vvenc_vtrnq_s64_to_s16( m1[2], m1[3] );
+  // First horizontal butterfly.
+  m3[0] = vreinterpretq_s32_s16( vaddq_s16( m2[0], m2[1] ) );
+  m3[1] = vreinterpretq_s32_s16( vsubq_s16( m2[0], m2[1] ) );
+  m3[2] = vreinterpretq_s32_s16( vaddq_s16( m2[2], m2[3] ) );
+  m3[3] = vreinterpretq_s32_s16( vsubq_s16( m2[2], m2[3] ) );
+  m3[4] = vreinterpretq_s32_s16( vaddq_s16( m2[4], m2[5] ) );
+  m3[5] = vreinterpretq_s32_s16( vsubq_s16( m2[4], m2[5] ) );
+  m3[6] = vreinterpretq_s32_s16( vaddq_s16( m2[6], m2[7] ) );
+  m3[7] = vreinterpretq_s32_s16( vsubq_s16( m2[6], m2[7] ) ); // 15-bit
 
-  m2[0] = a.val[0];
-  m2[1] = a.val[1];
-  m2[2] = b.val[0];
-  m2[3] = b.val[1];
+  m1[0] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[0] );
+  m1[1] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[1] );
+  m1[2] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[0] );
+  m1[3] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[1] );
+  m1[4] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[0] );
+  m1[5] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[1] );
+  m1[6] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[0] );
+  m1[7] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[1] );
 
-  m3[0].val[0] = vaddl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[1] ) );
-  m3[1].val[0] = vaddl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[1] ) );
-  m3[2].val[0] = vaddl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[3] ) );
-  m3[3].val[0] = vaddl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[3] ) );
-  m3[4].val[0] = vsubl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[1] ) );
-  m3[5].val[0] = vsubl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[1] ) );
-  m3[6].val[0] = vsubl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[3] ) );
-  m3[7].val[0] = vsubl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[3] ) );
+  // vabs_s16 of -2^15 returns -2^15, which later gets reinterpreted to 2^15.
+  m2[0] = vabsq_s16( vaddq_s16( m1[0], m1[1] ) );
+  m2[1] = vabdq_s16( m1[0], m1[1] );
+  m2[2] = vabsq_s16( vaddq_s16( m1[2], m1[3] ) );
+  m2[3] = vabdq_s16( m1[2], m1[3] );
+  m2[4] = vabsq_s16( vaddq_s16( m1[4], m1[5] ) );
+  m2[5] = vabdq_s16( m1[4], m1[5] );
+  m2[6] = vabsq_s16( vaddq_s16( m1[6], m1[7] ) );
+  m2[7] = vabdq_s16( m1[6], m1[7] ); // 16-bit
 
-  m4[0].val[0] = vaddq_s32( m3[0].val[0], m3[2].val[0] );
-  m4[1].val[0] = vaddq_s32( m3[1].val[0], m3[3].val[0] );
-  m4[2].val[0] = vsubq_s32( m3[0].val[0], m3[2].val[0] );
-  m4[3].val[0] = vsubq_s32( m3[1].val[0], m3[3].val[0] );
-  m4[4].val[0] = vaddq_s32( m3[4].val[0], m3[6].val[0] );
-  m4[5].val[0] = vaddq_s32( m3[5].val[0], m3[7].val[0] );
-  m4[6].val[0] = vsubq_s32( m3[4].val[0], m3[6].val[0] );
-  m4[7].val[0] = vsubq_s32( m3[5].val[0], m3[7].val[0] );
+  const uint16x8_t r0 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[0] );
+  const uint16x8_t r1 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[1] );
+  const uint16x8_t r2 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[2], m2[3] ).val[0] );
+  const uint16x8_t r3 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[2], m2[3] ).val[1] );
+  const uint16x8_t r4 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[4], m2[5] ).val[0] );
+  const uint16x8_t r5 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[4], m2[5] ).val[1] );
+  const uint16x8_t r6 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[6], m2[7] ).val[0] );
+  const uint16x8_t r7 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[6], m2[7] ).val[1] );
 
-  m3[0].val[0] = vabsq_s32( vaddq_s32( m4[0].val[0], m4[1].val[0] ) );
-  m3[1].val[0] = vabdq_s32(m4[0].val[0], m4[1].val[0]);
-  m3[2].val[0] = vabsq_s32( vaddq_s32( m4[2].val[0], m4[3].val[0] ) );
-  m3[3].val[0] = vabdq_s32(m4[2].val[0], m4[3].val[0]);
-  m3[4].val[0] = vabsq_s32( vaddq_s32( m4[4].val[0], m4[5].val[0] ) );
-  m3[5].val[0] = vabdq_s32(m4[4].val[0], m4[5].val[0]);
-  m3[6].val[0] = vabsq_s32( vaddq_s32( m4[6].val[0], m4[7].val[0] ) );
-  m3[7].val[0] = vabdq_s32(m4[6].val[0], m4[7].val[0]);
+  // The last butterfly uses |x+y|+|x-y| = 2*max(|x|,|y|); we delay the "*2".
+  const uint16x8_t max0 = vmaxq_u16( r0, r1 );
+  const uint16x8_t max1 = vmaxq_u16( r2, r3 );
+  const uint16x8_t max2 = vmaxq_u16( r4, r5 );
+  const uint16x8_t max3 = vmaxq_u16( r6, r7 );
 
-  // --------------------------------------------------------------------------------------------
-  int16x8x2_t c = vvenc_vtrnq_s64_to_s16( m1[4], m1[5] );
-  int16x8x2_t d = vvenc_vtrnq_s64_to_s16( m1[6], m1[7] );
+  const uint32x4_t sum = horizontal_add_long_4d_u16x8( max0, max1, max2, max3 );
 
-  m2[4] = c.val[0];
-  m2[5] = c.val[1];
-  m2[6] = d.val[0];
-  m2[7] = d.val[1];
-
-  m3[0].val[1] = vaddl_s16( vget_low_s16( m2[4] ), vget_low_s16( m2[5] ) );
-  m3[1].val[1] = vaddl_s16( vget_high_s16( m2[4] ), vget_high_s16( m2[5] ) );
-  m3[2].val[1] = vaddl_s16( vget_low_s16( m2[6] ), vget_low_s16( m2[7] ) );
-  m3[3].val[1] = vaddl_s16( vget_high_s16( m2[6] ), vget_high_s16( m2[7] ) );
-  m3[4].val[1] = vsubl_s16( vget_low_s16( m2[4] ), vget_low_s16( m2[5] ) );
-  m3[5].val[1] = vsubl_s16( vget_high_s16( m2[4] ), vget_high_s16( m2[5] ) );
-  m3[6].val[1] = vsubl_s16( vget_low_s16( m2[6] ), vget_low_s16( m2[7] ) );
-  m3[7].val[1] = vsubl_s16( vget_high_s16( m2[6] ), vget_high_s16( m2[7] ) );
-
-  m4[0].val[1] = vaddq_s32( m3[0].val[1], m3[2].val[1] );
-  m4[1].val[1] = vaddq_s32( m3[1].val[1], m3[3].val[1] );
-  m4[2].val[1] = vsubq_s32( m3[0].val[1], m3[2].val[1] );
-  m4[3].val[1] = vsubq_s32( m3[1].val[1], m3[3].val[1] );
-  m4[4].val[1] = vaddq_s32( m3[4].val[1], m3[6].val[1] );
-  m4[5].val[1] = vaddq_s32( m3[5].val[1], m3[7].val[1] );
-  m4[6].val[1] = vsubq_s32( m3[4].val[1], m3[6].val[1] );
-  m4[7].val[1] = vsubq_s32( m3[5].val[1], m3[7].val[1] );
-
-  m3[0].val[1] = vabsq_s32( vaddq_s32( m4[0].val[1], m4[1].val[1] ) );
-  m3[1].val[1] = vabdq_s32(m4[0].val[1], m4[1].val[1]);
-  m3[2].val[1] = vabsq_s32( vaddq_s32( m4[2].val[1], m4[3].val[1] ) );
-  m3[3].val[1] = vabdq_s32(m4[2].val[1], m4[3].val[1]);
-  m3[4].val[1] = vabsq_s32( vaddq_s32( m4[4].val[1], m4[5].val[1] ) );
-  m3[5].val[1] = vabdq_s32(m4[4].val[1], m4[5].val[1]);
-  m3[6].val[1] = vabsq_s32( vaddq_s32( m4[6].val[1], m4[7].val[1] ) );
-  m3[7].val[1] = vabdq_s32(m4[6].val[1], m4[7].val[1]);
-
-  m4[0].val[0] = m3[0].val[0];
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[0].val[1] );
-  m3[1].val[0] = vaddq_s32( m3[1].val[0], m3[1].val[1] );
-  m3[2].val[0] = vaddq_s32( m3[2].val[0], m3[2].val[1] );
-  m3[3].val[0] = vaddq_s32( m3[3].val[0], m3[3].val[1] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[4].val[1] );
-  m3[5].val[0] = vaddq_s32( m3[5].val[0], m3[5].val[1] );
-  m3[6].val[0] = vaddq_s32( m3[6].val[0], m3[6].val[1] );
-  m3[7].val[0] = vaddq_s32( m3[7].val[0], m3[7].val[1] );
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[1].val[0] );
-  m3[2].val[0] = vaddq_s32( m3[2].val[0], m3[3].val[0] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[5].val[0] );
-  m3[6].val[0] = vaddq_s32( m3[6].val[0], m3[7].val[0] );
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[2].val[0] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[6].val[0] );
-  int32x4_t iSum = vaddq_s32( m3[0].val[0], m3[4].val[0] );
-
-  uint32_t sad = ( uint32_t ) horizontal_add_s32x4(iSum);
-  uint32_t absDC = vgetq_lane_s32( m4[0].val[0], 0 );
+  uint32_t sad = horizontal_add_u32x4( sum );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
   sad -= absDC;
   sad += absDC >> 2;
   sad = ( sad + 2 ) >> 2;
@@ -1209,17 +1155,19 @@ static Distortion xCalcHAD4x4_neon( const Pel* piOrg, const Pel* piCur, int iStr
 }
 
 template<bool fastHad>
-Distortion xGetHADs_neon( const DistParam &rcDtParam )
+Distortion xGetHADs_neon( const DistParam& rcDtParam )
 {
-  const Pel*  piOrg = rcDtParam.org.buf;
-  const Pel*  piCur = rcDtParam.cur.buf;
+  const Pel* piOrg = rcDtParam.org.buf;
+  const Pel* piCur = rcDtParam.cur.buf;
   const int iRows = rcDtParam.org.height;
   const int iCols = rcDtParam.org.width;
   const int iStrideCur = rcDtParam.cur.stride;
   const int iStrideOrg = rcDtParam.org.stride;
-  const int iBitDepth  = rcDtParam.bitDepth;
+  const int iBitDepth = rcDtParam.bitDepth;
 
-  int  x, y;
+  CHECKD( iBitDepth > 10, "Only bit-depths of up to 10 bits supported!" );
+
+  int x, y;
   Distortion uiSum = 0;
 
   if( iCols > iRows && ( iCols & 15 ) == 0 && ( iRows & 7 ) == 0 )
@@ -1276,7 +1224,7 @@ Distortion xGetHADs_neon( const DistParam &rcDtParam )
     {
       for( x = 0; x < iCols; x += 16 )
       {
-        uiSum += xCalcHAD16x16_fast_Neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur, iBitDepth );
+        uiSum += xCalcHAD16x16_fast_neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur );
       }
       piOrg += 16 * iStrideOrg;
       piCur += 16 * iStrideCur;

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -298,7 +298,7 @@ Distortion xCalcHAD8x8_neon( const Pel* piOrg, const Pel* piCur, const int iStri
   return sad;
 }
 
-static Distortion xCalcHAD16x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
+Distortion xCalcHAD16x8_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
 {
   int16x8_t diff_s16[16];
   for( int k = 0; k < 8; k++ )
@@ -313,6 +313,7 @@ static Distortion xCalcHAD16x8_neon( const Pel* piOrg, const Pel* piCur, int iSt
   }
 
   int16x8_t m1[16], m2[16];
+  int32x4_t m3[16], m4[32];
 
   // Vertical.
   m2[0] = vaddq_s16( diff_s16[0], diff_s16[8] );
@@ -366,217 +367,136 @@ static Distortion xCalcHAD16x8_neon( const Pel* piOrg, const Pel* piCur, int iSt
   m2[14] = vsubq_s16( m1[12], m1[14] );
   m2[15] = vsubq_s16( m1[13], m1[15] ); // 14-bit
 
-  // Transpose.
-  m1[0] = vzipq_s16( m2[0], m2[8] ).val[0];
-  m1[1] = vzipq_s16( m2[0], m2[8] ).val[1];
-  m1[2] = vzipq_s16( m2[2], m2[10] ).val[0];
-  m1[3] = vzipq_s16( m2[2], m2[10] ).val[1];
-  m1[4] = vzipq_s16( m2[4], m2[12] ).val[0];
-  m1[5] = vzipq_s16( m2[4], m2[12] ).val[1];
-  m1[6] = vzipq_s16( m2[6], m2[14] ).val[0];
-  m1[7] = vzipq_s16( m2[6], m2[14] ).val[1];
-  m1[8] = vzipq_s16( m2[1], m2[9] ).val[0];
-  m1[9] = vzipq_s16( m2[1], m2[9] ).val[1];
-  m1[10] = vzipq_s16( m2[3], m2[11] ).val[0];
-  m1[11] = vzipq_s16( m2[3], m2[11] ).val[1];
-  m1[12] = vzipq_s16( m2[5], m2[13] ).val[0];
-  m1[13] = vzipq_s16( m2[5], m2[13] ).val[1];
-  m1[14] = vzipq_s16( m2[7], m2[15] ).val[0];
-  m1[15] = vzipq_s16( m2[7], m2[15] ).val[1];
-
-  m2[0] = vzipq_s16( m1[0], m1[4] ).val[0];
-  m2[1] = vzipq_s16( m1[0], m1[4] ).val[1];
-  m2[2] = vzipq_s16( m1[1], m1[5] ).val[0];
-  m2[3] = vzipq_s16( m1[1], m1[5] ).val[1];
-  m2[4] = vzipq_s16( m1[2], m1[6] ).val[0];
-  m2[5] = vzipq_s16( m1[2], m1[6] ).val[1];
-  m2[6] = vzipq_s16( m1[3], m1[7] ).val[0];
-  m2[7] = vzipq_s16( m1[3], m1[7] ).val[1];
-  m2[8] = vzipq_s16( m1[8], m1[12] ).val[0];
-  m2[9] = vzipq_s16( m1[8], m1[12] ).val[1];
-  m2[10] = vzipq_s16( m1[9], m1[13] ).val[0];
-  m2[11] = vzipq_s16( m1[9], m1[13] ).val[1];
-  m2[12] = vzipq_s16( m1[10], m1[14] ).val[0];
-  m2[13] = vzipq_s16( m1[10], m1[14] ).val[1];
-  m2[14] = vzipq_s16( m1[11], m1[15] ).val[0];
-  m2[15] = vzipq_s16( m1[11], m1[15] ).val[1];
-
-  m1[0] = vzipq_s16( m2[0], m2[4] ).val[0];
-  m1[1] = vzipq_s16( m2[0], m2[4] ).val[1];
-  m1[2] = vzipq_s16( m2[1], m2[5] ).val[0];
-  m1[3] = vzipq_s16( m2[1], m2[5] ).val[1];
-  m1[4] = vzipq_s16( m2[2], m2[6] ).val[0];
-  m1[5] = vzipq_s16( m2[2], m2[6] ).val[1];
-  m1[6] = vzipq_s16( m2[3], m2[7] ).val[0];
-  m1[7] = vzipq_s16( m2[3], m2[7] ).val[1];
-  m1[8] = vzipq_s16( m2[8], m2[12] ).val[0];
-  m1[9] = vzipq_s16( m2[8], m2[12] ).val[1];
-  m1[10] = vzipq_s16( m2[9], m2[13] ).val[0];
-  m1[11] = vzipq_s16( m2[9], m2[13] ).val[1];
-  m1[12] = vzipq_s16( m2[10], m2[14] ).val[0];
-  m1[13] = vzipq_s16( m2[10], m2[14] ).val[1];
-  m1[14] = vzipq_s16( m2[11], m2[15] ).val[0];
-  m1[15] = vzipq_s16( m2[11], m2[15] ).val[1];
-
   // Horizontal.
-  m2[0] = vaddq_s16( m1[0], m1[8] );
-  m2[1] = vaddq_s16( m1[1], m1[9] );
-  m2[2] = vaddq_s16( m1[2], m1[10] );
-  m2[3] = vaddq_s16( m1[3], m1[11] );
-  m2[4] = vaddq_s16( m1[4], m1[12] );
-  m2[5] = vaddq_s16( m1[5], m1[13] );
-  m2[6] = vaddq_s16( m1[6], m1[14] );
-  m2[7] = vaddq_s16( m1[7], m1[15] );
-  m2[8] = vsubq_s16( m1[0], m1[8] );
-  m2[9] = vsubq_s16( m1[1], m1[9] );
-  m2[10] = vsubq_s16( m1[2], m1[10] );
-  m2[11] = vsubq_s16( m1[3], m1[11] );
-  m2[12] = vsubq_s16( m1[4], m1[12] );
-  m2[13] = vsubq_s16( m1[5], m1[13] );
-  m2[14] = vsubq_s16( m1[6], m1[14] );
-  m2[15] = vsubq_s16( m1[7], m1[15] ); // 15-bit
+  m1[0] = vaddq_s16( m2[0], m2[1] );
+  m1[1] = vaddq_s16( m2[2], m2[3] );
+  m1[2] = vaddq_s16( m2[4], m2[5] );
+  m1[3] = vaddq_s16( m2[6], m2[7] );
+  m1[4] = vaddq_s16( m2[8], m2[9] );
+  m1[5] = vaddq_s16( m2[10], m2[11] );
+  m1[6] = vaddq_s16( m2[12], m2[13] );
+  m1[7] = vaddq_s16( m2[14], m2[15] );
+  m1[8] = vsubq_s16( m2[0], m2[1] );
+  m1[9] = vsubq_s16( m2[2], m2[3] );
+  m1[10] = vsubq_s16( m2[4], m2[5] );
+  m1[11] = vsubq_s16( m2[6], m2[7] );
+  m1[12] = vsubq_s16( m2[8], m2[9] );
+  m1[13] = vsubq_s16( m2[10], m2[11] );
+  m1[14] = vsubq_s16( m2[12], m2[13] );
+  m1[15] = vsubq_s16( m2[14], m2[15] ); // 15-bit
 
-  int32x4_t m3[32], m4[32];
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x8( m1[0] ) );
 
-  m3[0] = vaddl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[4] ) );
-  m3[1] = vaddl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[4] ) );
-  m3[2] = vaddl_s16( vget_low_s16( m2[1] ), vget_low_s16( m2[5] ) );
-  m3[3] = vaddl_s16( vget_high_s16( m2[1] ), vget_high_s16( m2[5] ) );
-  m3[4] = vaddl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[6] ) );
-  m3[5] = vaddl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[6] ) );
-  m3[6] = vaddl_s16( vget_low_s16( m2[3] ), vget_low_s16( m2[7] ) );
-  m3[7] = vaddl_s16( vget_high_s16( m2[3] ), vget_high_s16( m2[7] ) );
-  m3[8] = vsubl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[4] ) );
-  m3[9] = vsubl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[4] ) );
-  m3[10] = vsubl_s16( vget_low_s16( m2[1] ), vget_low_s16( m2[5] ) );
-  m3[11] = vsubl_s16( vget_high_s16( m2[1] ), vget_high_s16( m2[5] ) );
-  m3[12] = vsubl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[6] ) );
-  m3[13] = vsubl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[6] ) );
-  m3[14] = vsubl_s16( vget_low_s16( m2[3] ), vget_low_s16( m2[7] ) );
-  m3[15] = vsubl_s16( vget_high_s16( m2[3] ), vget_high_s16( m2[7] ) );
-  m3[16] = vaddl_s16( vget_low_s16( m2[8] ), vget_low_s16( m2[12] ) );
-  m3[17] = vaddl_s16( vget_high_s16( m2[8] ), vget_high_s16( m2[12] ) );
-  m3[18] = vaddl_s16( vget_low_s16( m2[9] ), vget_low_s16( m2[13] ) );
-  m3[19] = vaddl_s16( vget_high_s16( m2[9] ), vget_high_s16( m2[13] ) );
-  m3[20] = vaddl_s16( vget_low_s16( m2[10] ), vget_low_s16( m2[14] ) );
-  m3[21] = vaddl_s16( vget_high_s16( m2[10] ), vget_high_s16( m2[14] ) );
-  m3[22] = vaddl_s16( vget_low_s16( m2[11] ), vget_low_s16( m2[15] ) );
-  m3[23] = vaddl_s16( vget_high_s16( m2[11] ), vget_high_s16( m2[15] ) );
-  m3[24] = vsubl_s16( vget_low_s16( m2[8] ), vget_low_s16( m2[12] ) );
-  m3[25] = vsubl_s16( vget_high_s16( m2[8] ), vget_high_s16( m2[12] ) );
-  m3[26] = vsubl_s16( vget_low_s16( m2[9] ), vget_low_s16( m2[13] ) );
-  m3[27] = vsubl_s16( vget_high_s16( m2[9] ), vget_high_s16( m2[13] ) );
-  m3[28] = vsubl_s16( vget_low_s16( m2[10] ), vget_low_s16( m2[14] ) );
-  m3[29] = vsubl_s16( vget_high_s16( m2[10] ), vget_high_s16( m2[14] ) );
-  m3[30] = vsubl_s16( vget_low_s16( m2[11] ), vget_low_s16( m2[15] ) );
-  m3[31] = vsubl_s16( vget_high_s16( m2[11] ), vget_high_s16( m2[15] ) );
+  m2[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
+  m2[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
+  m2[2] = vtrnq_s16( m1[2], m1[3] ).val[0];
+  m2[3] = vtrnq_s16( m1[2], m1[3] ).val[1];
+  m2[4] = vtrnq_s16( m1[4], m1[5] ).val[0];
+  m2[5] = vtrnq_s16( m1[4], m1[5] ).val[1];
+  m2[6] = vtrnq_s16( m1[6], m1[7] ).val[0];
+  m2[7] = vtrnq_s16( m1[6], m1[7] ).val[1];
+  m2[8] = vtrnq_s16( m1[8], m1[9] ).val[0];
+  m2[9] = vtrnq_s16( m1[8], m1[9] ).val[1];
+  m2[10] = vtrnq_s16( m1[10], m1[11] ).val[0];
+  m2[11] = vtrnq_s16( m1[10], m1[11] ).val[1];
+  m2[12] = vtrnq_s16( m1[12], m1[13] ).val[0];
+  m2[13] = vtrnq_s16( m1[12], m1[13] ).val[1];
+  m2[14] = vtrnq_s16( m1[14], m1[15] ).val[0];
+  m2[15] = vtrnq_s16( m1[14], m1[15] ).val[1];
 
-  m4[0] = vaddq_s32( m3[0], m3[4] );
-  m4[1] = vaddq_s32( m3[1], m3[5] );
-  m4[2] = vaddq_s32( m3[2], m3[6] );
-  m4[3] = vaddq_s32( m3[3], m3[7] );
-  m4[4] = vsubq_s32( m3[0], m3[4] );
-  m4[5] = vsubq_s32( m3[1], m3[5] );
-  m4[6] = vsubq_s32( m3[2], m3[6] );
-  m4[7] = vsubq_s32( m3[3], m3[7] );
-  m4[8] = vaddq_s32( m3[8], m3[12] );
-  m4[9] = vaddq_s32( m3[9], m3[13] );
-  m4[10] = vaddq_s32( m3[10], m3[14] );
-  m4[11] = vaddq_s32( m3[11], m3[15] );
-  m4[12] = vsubq_s32( m3[8], m3[12] );
-  m4[13] = vsubq_s32( m3[9], m3[13] );
-  m4[14] = vsubq_s32( m3[10], m3[14] );
-  m4[15] = vsubq_s32( m3[11], m3[15] );
-  m4[16] = vaddq_s32( m3[16], m3[20] );
-  m4[17] = vaddq_s32( m3[17], m3[21] );
-  m4[18] = vaddq_s32( m3[18], m3[22] );
-  m4[19] = vaddq_s32( m3[19], m3[23] );
-  m4[20] = vsubq_s32( m3[16], m3[20] );
-  m4[21] = vsubq_s32( m3[17], m3[21] );
-  m4[22] = vsubq_s32( m3[18], m3[22] );
-  m4[23] = vsubq_s32( m3[19], m3[23] );
-  m4[24] = vaddq_s32( m3[24], m3[28] );
-  m4[25] = vaddq_s32( m3[25], m3[29] );
-  m4[26] = vaddq_s32( m3[26], m3[30] );
-  m4[27] = vaddq_s32( m3[27], m3[31] );
-  m4[28] = vsubq_s32( m3[24], m3[28] );
-  m4[29] = vsubq_s32( m3[25], m3[29] );
-  m4[30] = vsubq_s32( m3[26], m3[30] );
-  m4[31] = vsubq_s32( m3[27], m3[31] );
+  m3[0] = vreinterpretq_s32_s16( vaddq_s16( m2[0], m2[1] ) );
+  m3[1] = vreinterpretq_s32_s16( vsubq_s16( m2[0], m2[1] ) );
+  m3[2] = vreinterpretq_s32_s16( vaddq_s16( m2[2], m2[3] ) );
+  m3[3] = vreinterpretq_s32_s16( vsubq_s16( m2[2], m2[3] ) );
+  m3[4] = vreinterpretq_s32_s16( vaddq_s16( m2[4], m2[5] ) );
+  m3[5] = vreinterpretq_s32_s16( vsubq_s16( m2[4], m2[5] ) );
+  m3[6] = vreinterpretq_s32_s16( vaddq_s16( m2[6], m2[7] ) );
+  m3[7] = vreinterpretq_s32_s16( vsubq_s16( m2[6], m2[7] ) );
+  m3[8] = vreinterpretq_s32_s16( vaddq_s16( m2[8], m2[9] ) );
+  m3[9] = vreinterpretq_s32_s16( vsubq_s16( m2[8], m2[9] ) );
+  m3[10] = vreinterpretq_s32_s16( vaddq_s16( m2[10], m2[11] ) );
+  m3[11] = vreinterpretq_s32_s16( vsubq_s16( m2[10], m2[11] ) );
+  m3[12] = vreinterpretq_s32_s16( vaddq_s16( m2[12], m2[13] ) );
+  m3[13] = vreinterpretq_s32_s16( vsubq_s16( m2[12], m2[13] ) );
+  m3[14] = vreinterpretq_s32_s16( vaddq_s16( m2[14], m2[15] ) );
+  m3[15] = vreinterpretq_s32_s16( vsubq_s16( m2[14], m2[15] ) ); // 16-bit
 
-  m3[0] = vabsq_s32( vaddq_s32( m4[0], m4[2] ) );
-  m3[1] = vabsq_s32( vaddq_s32( m4[1], m4[3] ) );
-  m3[2] = vabdq_s32( m4[0], m4[2] );
-  m3[3] = vabdq_s32( m4[1], m4[3] );
-  m3[4] = vabsq_s32( vaddq_s32( m4[4], m4[6] ) );
-  m3[5] = vabsq_s32( vaddq_s32( m4[5], m4[7] ) );
-  m3[6] = vabdq_s32( m4[4], m4[6] );
-  m3[7] = vabdq_s32( m4[5], m4[7] );
-  m3[8] = vabsq_s32( vaddq_s32( m4[8], m4[10] ) );
-  m3[9] = vabsq_s32( vaddq_s32( m4[9], m4[11] ) );
-  m3[10] = vabdq_s32( m4[8], m4[10] );
-  m3[11] = vabdq_s32( m4[9], m4[11] );
-  m3[12] = vabsq_s32( vaddq_s32( m4[12], m4[14] ) );
-  m3[13] = vabsq_s32( vaddq_s32( m4[13], m4[15] ) );
-  m3[14] = vabdq_s32( m4[12], m4[14] );
-  m3[15] = vabdq_s32( m4[13], m4[15] );
-  m3[16] = vabsq_s32( vaddq_s32( m4[16], m4[18] ) );
-  m3[17] = vabsq_s32( vaddq_s32( m4[17], m4[19] ) );
-  m3[18] = vabdq_s32( m4[16], m4[18] );
-  m3[19] = vabdq_s32( m4[17], m4[19] );
-  m3[20] = vabsq_s32( vaddq_s32( m4[20], m4[22] ) );
-  m3[21] = vabsq_s32( vaddq_s32( m4[21], m4[23] ) );
-  m3[22] = vabdq_s32( m4[20], m4[22] );
-  m3[23] = vabdq_s32( m4[21], m4[23] );
-  m3[24] = vabsq_s32( vaddq_s32( m4[24], m4[26] ) );
-  m3[25] = vabsq_s32( vaddq_s32( m4[25], m4[27] ) );
-  m3[26] = vabdq_s32( m4[24], m4[26] );
-  m3[27] = vabdq_s32( m4[25], m4[27] );
-  m3[28] = vabsq_s32( vaddq_s32( m4[28], m4[30] ) );
-  m3[29] = vabsq_s32( vaddq_s32( m4[29], m4[31] ) );
-  m3[30] = vabdq_s32( m4[28], m4[30] );
-  m3[31] = vabdq_s32( m4[29], m4[31] );
+  m1[0] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[0] );
+  m1[1] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[1] );
+  m1[2] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[0] );
+  m1[3] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[1] );
+  m1[4] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[0] );
+  m1[5] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[1] );
+  m1[6] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[0] );
+  m1[7] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[1] );
+  m1[8] = vreinterpretq_s16_s32( vzipq_s32( m3[8], m3[9] ).val[0] );
+  m1[9] = vreinterpretq_s16_s32( vzipq_s32( m3[8], m3[9] ).val[1] );
+  m1[10] = vreinterpretq_s16_s32( vzipq_s32( m3[10], m3[11] ).val[0] );
+  m1[11] = vreinterpretq_s16_s32( vzipq_s32( m3[10], m3[11] ).val[1] );
+  m1[12] = vreinterpretq_s16_s32( vzipq_s32( m3[12], m3[13] ).val[0] );
+  m1[13] = vreinterpretq_s16_s32( vzipq_s32( m3[12], m3[13] ).val[1] );
+  m1[14] = vreinterpretq_s16_s32( vzipq_s32( m3[14], m3[15] ).val[0] );
+  m1[15] = vreinterpretq_s16_s32( vzipq_s32( m3[14], m3[15] ).val[1] );
 
-  uint32_t absDC = vgetq_lane_s32( m3[0], 0 );
+  m4[0] = vabsq_s32( vaddl_s16( vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) ) );
+  m4[1] = vabsq_s32( vaddl_s16( vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) ) );
+  m4[2] = vabdl_s16( vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) );
+  m4[3] = vabdl_s16( vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) );
+  m4[4] = vabsq_s32( vaddl_s16( vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) ) );
+  m4[5] = vabsq_s32( vaddl_s16( vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) ) );
+  m4[6] = vabdl_s16( vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) );
+  m4[7] = vabdl_s16( vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) );
+  m4[8] = vabsq_s32( vaddl_s16( vget_low_s16( m1[4] ), vget_low_s16( m1[5] ) ) );
+  m4[9] = vabsq_s32( vaddl_s16( vget_high_s16( m1[4] ), vget_high_s16( m1[5] ) ) );
+  m4[10] = vabdl_s16( vget_low_s16( m1[4] ), vget_low_s16( m1[5] ) );
+  m4[11] = vabdl_s16( vget_high_s16( m1[4] ), vget_high_s16( m1[5] ) );
+  m4[12] = vabsq_s32( vaddl_s16( vget_low_s16( m1[6] ), vget_low_s16( m1[7] ) ) );
+  m4[13] = vabsq_s32( vaddl_s16( vget_high_s16( m1[6] ), vget_high_s16( m1[7] ) ) );
+  m4[14] = vabdl_s16( vget_low_s16( m1[6] ), vget_low_s16( m1[7] ) );
+  m4[15] = vabdl_s16( vget_high_s16( m1[6] ), vget_high_s16( m1[7] ) );
+  m4[16] = vabsq_s32( vaddl_s16( vget_low_s16( m1[8] ), vget_low_s16( m1[9] ) ) );
+  m4[17] = vabsq_s32( vaddl_s16( vget_high_s16( m1[8] ), vget_high_s16( m1[9] ) ) );
+  m4[18] = vabdl_s16( vget_low_s16( m1[8] ), vget_low_s16( m1[9] ) );
+  m4[19] = vabdl_s16( vget_high_s16( m1[8] ), vget_high_s16( m1[9] ) );
+  m4[20] = vabsq_s32( vaddl_s16( vget_low_s16( m1[10] ), vget_low_s16( m1[11] ) ) );
+  m4[21] = vabsq_s32( vaddl_s16( vget_high_s16( m1[10] ), vget_high_s16( m1[11] ) ) );
+  m4[22] = vabdl_s16( vget_low_s16( m1[10] ), vget_low_s16( m1[11] ) );
+  m4[23] = vabdl_s16( vget_high_s16( m1[10] ), vget_high_s16( m1[11] ) );
+  m4[24] = vabsq_s32( vaddl_s16( vget_low_s16( m1[12] ), vget_low_s16( m1[13] ) ) );
+  m4[25] = vabsq_s32( vaddl_s16( vget_high_s16( m1[12] ), vget_high_s16( m1[13] ) ) );
+  m4[26] = vabdl_s16( vget_low_s16( m1[12] ), vget_low_s16( m1[13] ) );
+  m4[27] = vabdl_s16( vget_high_s16( m1[12] ), vget_high_s16( m1[13] ) );
+  m4[28] = vabsq_s32( vaddl_s16( vget_low_s16( m1[14] ), vget_low_s16( m1[15] ) ) );
+  m4[29] = vabsq_s32( vaddl_s16( vget_high_s16( m1[14] ), vget_high_s16( m1[15] ) ) );
+  m4[30] = vabdl_s16( vget_low_s16( m1[14] ), vget_low_s16( m1[15] ) );
+  m4[31] = vabdl_s16( vget_high_s16( m1[14] ), vget_high_s16( m1[15] ) );
 
-  m3[0] = vaddq_s32( m3[0], m3[1] );
-  m3[2] = vaddq_s32( m3[2], m3[3] );
-  m3[4] = vaddq_s32( m3[4], m3[5] );
-  m3[6] = vaddq_s32( m3[6], m3[7] );
-  m3[8] = vaddq_s32( m3[8], m3[9] );
-  m3[10] = vaddq_s32( m3[10], m3[11] );
-  m3[12] = vaddq_s32( m3[12], m3[13] );
-  m3[14] = vaddq_s32( m3[14], m3[15] );
-  m3[16] = vaddq_s32( m3[16], m3[17] );
-  m3[18] = vaddq_s32( m3[18], m3[19] );
-  m3[20] = vaddq_s32( m3[20], m3[21] );
-  m3[22] = vaddq_s32( m3[22], m3[23] );
-  m3[24] = vaddq_s32( m3[24], m3[25] );
-  m3[26] = vaddq_s32( m3[26], m3[27] );
-  m3[28] = vaddq_s32( m3[28], m3[29] );
-  m3[30] = vaddq_s32( m3[30], m3[31] );
+  const int32x4_t max0 = vmaxq_s32( m4[0], m4[1] );
+  const int32x4_t max1 = vmaxq_s32( m4[2], m4[3] );
+  const int32x4_t max2 = vmaxq_s32( m4[4], m4[5] );
+  const int32x4_t max3 = vmaxq_s32( m4[6], m4[7] );
+  const int32x4_t max4 = vmaxq_s32( m4[8], m4[9] );
+  const int32x4_t max5 = vmaxq_s32( m4[10], m4[11] );
+  const int32x4_t max6 = vmaxq_s32( m4[12], m4[13] );
+  const int32x4_t max7 = vmaxq_s32( m4[14], m4[15] );
+  const int32x4_t max8 = vmaxq_s32( m4[16], m4[17] );
+  const int32x4_t max9 = vmaxq_s32( m4[18], m4[19] );
+  const int32x4_t max10 = vmaxq_s32( m4[20], m4[21] );
+  const int32x4_t max11 = vmaxq_s32( m4[22], m4[23] );
+  const int32x4_t max12 = vmaxq_s32( m4[24], m4[25] );
+  const int32x4_t max13 = vmaxq_s32( m4[26], m4[27] );
+  const int32x4_t max14 = vmaxq_s32( m4[28], m4[29] );
+  const int32x4_t max15 = vmaxq_s32( m4[30], m4[31] );
 
-  m3[0] = vaddq_s32( m3[0], m3[2] );
-  m3[4] = vaddq_s32( m3[4], m3[6] );
-  m3[8] = vaddq_s32( m3[8], m3[10] );
-  m3[12] = vaddq_s32( m3[12], m3[14] );
-  m3[16] = vaddq_s32( m3[16], m3[18] );
-  m3[20] = vaddq_s32( m3[20], m3[22] );
-  m3[24] = vaddq_s32( m3[24], m3[26] );
-  m3[28] = vaddq_s32( m3[28], m3[30] );
+  const int32x4_t sum0 = horizontal_add_4d_s32x4( max0, max1, max2, max3 );
+  const int32x4_t sum1 = horizontal_add_4d_s32x4( max4, max5, max6, max7 );
+  const int32x4_t sum2 = horizontal_add_4d_s32x4( max8, max9, max10, max11 );
+  const int32x4_t sum3 = horizontal_add_4d_s32x4( max12, max13, max14, max15 );
 
-  m3[0] = vaddq_s32( m3[0], m3[4] );
-  m3[8] = vaddq_s32( m3[8], m3[12] );
-  m3[16] = vaddq_s32( m3[16], m3[20] );
-  m3[24] = vaddq_s32( m3[24], m3[28] );
+  int32x4_t sum0123 = horizontal_add_4d_s32x4( sum0, sum1, sum2, sum3 );
 
-  m3[0] = vaddq_s32( m3[0], m3[8] );
-  m3[16] = vaddq_s32( m3[16], m3[24] );
-
-  m3[0] = vaddq_s32( m3[0], m3[16] );
-
-  int sad = horizontal_add_s32x4( m3[0] );
-
+  uint32_t sad = ( uint32_t )horizontal_add_s32x4( sum0123 );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
   sad -= absDC;
   sad += absDC >> 2;
   sad = ( int )( sad / sqrt( 16.0 * 8 ) * 2 );
@@ -1089,8 +1009,8 @@ Distortion xGetHADs_neon( const DistParam& rcDtParam )
       {
         uiSum += xCalcHAD16x8_neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur );
       }
-      piOrg += 8*iStrideOrg;
-      piCur += 8*iStrideCur;
+      piOrg += 8 * iStrideOrg;
+      piCur += 8 * iStrideCur;
     }
   }
   else if( iCols < iRows && ( iRows & 15 ) == 0 && ( iCols & 7 ) == 0 )

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -191,22 +191,18 @@ Distortion xCalcHAD16x16_fast_neon( const Pel* piOrg, const Pel* piCur, const in
   return sad << 2;
 }
 
-static uint32_t xCalcHAD8x8_Neon( const Pel *piOrg, const Pel *piCur, const int iStrideOrg, const int iStrideCur, const int iBitDepth )
+Distortion xCalcHAD8x8_neon( const Pel* piOrg, const Pel* piCur, const int iStrideOrg, const int iStrideCur )
 {
-  CHECK( iBitDepth > 10, "Only bit-depths of up to 10 bits supported!" );
-
   int16x8_t m1[8], m2[8];
-  int32x4x2_t m3[8], m4[8];
-
+  int32x4_t m3[8];
   for( int i = 0; i < 8; i++ )
   {
-    int16x8_t r0 = vld1q_s16( piOrg + i * iStrideOrg );
-    int16x8_t r1 = vld1q_s16( piCur + i * iStrideCur );
-
-    m2[i] = vsubq_s16( r0, r1 ); // 11-bit
+    const int16x8_t org = vld1q_s16( piOrg + iStrideOrg * i );
+    const int16x8_t cur = vld1q_s16( piCur + iStrideCur * i );
+    m2[i] = vsubq_s16( org, cur ); // 11-bit
   }
 
-  // Vertical.
+  // Vertical Hadamard.
   m1[0] = vaddq_s16( m2[0], m2[4] );
   m1[1] = vaddq_s16( m2[1], m2[5] );
   m1[2] = vaddq_s16( m2[2], m2[6] );
@@ -234,6 +230,8 @@ static uint32_t xCalcHAD8x8_Neon( const Pel *piOrg, const Pel *piCur, const int 
   m1[6] = vaddq_s16( m2[6], m2[7] );
   m1[7] = vsubq_s16( m2[6], m2[7] ); // 14-bit
 
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x8( m1[0] ) );
+
   // Partial transpose to do the first horizontal step.
   m2[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
   m2[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
@@ -244,87 +242,57 @@ static uint32_t xCalcHAD8x8_Neon( const Pel *piOrg, const Pel *piCur, const int 
   m2[6] = vtrnq_s16( m1[6], m1[7] ).val[0];
   m2[7] = vtrnq_s16( m1[6], m1[7] ).val[1];
 
-  m1[0] = vaddq_s16( m2[0], m2[1] );
-  m1[1] = vaddq_s16( m2[2], m2[3] );
-  m1[2] = vaddq_s16( m2[4], m2[5] );
-  m1[3] = vaddq_s16( m2[6], m2[7] );
-  m1[4] = vsubq_s16( m2[0], m2[1] );
-  m1[5] = vsubq_s16( m2[2], m2[3] );
-  m1[6] = vsubq_s16( m2[4], m2[5] );
-  m1[7] = vsubq_s16( m2[6], m2[7] ); // 15-bit
+  // First horizontal butterfly.
+  m3[0] = vreinterpretq_s32_s16( vaddq_s16( m2[0], m2[1] ) );
+  m3[1] = vreinterpretq_s32_s16( vsubq_s16( m2[0], m2[1] ) );
+  m3[2] = vreinterpretq_s32_s16( vaddq_s16( m2[2], m2[3] ) );
+  m3[3] = vreinterpretq_s32_s16( vsubq_s16( m2[2], m2[3] ) );
+  m3[4] = vreinterpretq_s32_s16( vaddq_s16( m2[4], m2[5] ) );
+  m3[5] = vreinterpretq_s32_s16( vsubq_s16( m2[4], m2[5] ) );
+  m3[6] = vreinterpretq_s32_s16( vaddq_s16( m2[6], m2[7] ) );
+  m3[7] = vreinterpretq_s32_s16( vsubq_s16( m2[6], m2[7] ) ); // 15-bit
 
-  // Finish the transpose.
-  m2[0] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[0] ), vreinterpretq_s32_s16( m1[1] ) ).val[0] );
-  m2[1] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[0] ), vreinterpretq_s32_s16( m1[1] ) ).val[1] );
-  m2[2] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[2] ), vreinterpretq_s32_s16( m1[3] ) ).val[0] );
-  m2[3] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[2] ), vreinterpretq_s32_s16( m1[3] ) ).val[1] );
-  m2[4] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[4] ), vreinterpretq_s32_s16( m1[5] ) ).val[0] );
-  m2[5] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[4] ), vreinterpretq_s32_s16( m1[5] ) ).val[1] );
-  m2[6] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[6] ), vreinterpretq_s32_s16( m1[7] ) ).val[0] );
-  m2[7] = vreinterpretq_s16_s32( vzipq_s32( vreinterpretq_s32_s16( m1[6] ), vreinterpretq_s32_s16( m1[7] ) ).val[1] );
+  m1[0] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[0] );
+  m1[1] = vreinterpretq_s16_s32( vzipq_s32( m3[0], m3[1] ).val[1] );
+  m1[2] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[0] );
+  m1[3] = vreinterpretq_s16_s32( vzipq_s32( m3[2], m3[3] ).val[1] );
+  m1[4] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[0] );
+  m1[5] = vreinterpretq_s16_s32( vzipq_s32( m3[4], m3[5] ).val[1] );
+  m1[6] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[0] );
+  m1[7] = vreinterpretq_s16_s32( vzipq_s32( m3[6], m3[7] ).val[1] );
 
-  m4[0].val[0] = vaddl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[1] ) );
-  m4[1].val[0] = vaddl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[1] ) );
-  m4[2].val[0] = vsubl_s16( vget_low_s16( m2[0] ), vget_low_s16( m2[1] ) );
-  m4[3].val[0] = vsubl_s16( vget_high_s16( m2[0] ), vget_high_s16( m2[1] ) );
-  m4[4].val[0] = vaddl_s16( vget_low_s16( m2[4] ), vget_low_s16( m2[5] ) );
-  m4[5].val[0] = vaddl_s16( vget_high_s16( m2[4] ), vget_high_s16( m2[5] ) );
-  m4[6].val[0] = vsubl_s16( vget_low_s16( m2[4] ), vget_low_s16( m2[5] ) );
-  m4[7].val[0] = vsubl_s16( vget_high_s16( m2[4] ), vget_high_s16( m2[5] ) );
+  // vabs_s16 of -2^15 returns -2^15, which later gets reinterpreted to 2^15.
+  m2[0] = vabsq_s16( vaddq_s16( m1[0], m1[1] ) );
+  m2[1] = vabdq_s16( m1[0], m1[1] );
+  m2[2] = vabsq_s16( vaddq_s16( m1[2], m1[3] ) );
+  m2[3] = vabdq_s16( m1[2], m1[3] );
+  m2[4] = vabsq_s16( vaddq_s16( m1[4], m1[5] ) );
+  m2[5] = vabdq_s16( m1[4], m1[5] );
+  m2[6] = vabsq_s16( vaddq_s16( m1[6], m1[7] ) );
+  m2[7] = vabdq_s16( m1[6], m1[7] ); // 16-bit
 
-  m3[0].val[0] = vabsq_s32( vaddq_s32( m4[0].val[0], m4[1].val[0] ) );
-  m3[1].val[0] = vabdq_s32(m4[0].val[0], m4[1].val[0]);
-  m3[2].val[0] = vabsq_s32( vaddq_s32( m4[2].val[0], m4[3].val[0] ) );
-  m3[3].val[0] = vabdq_s32(m4[2].val[0], m4[3].val[0]);
-  m3[4].val[0] = vabsq_s32( vaddq_s32( m4[4].val[0], m4[5].val[0] ) );
-  m3[5].val[0] = vabdq_s32(m4[4].val[0], m4[5].val[0]);
-  m3[6].val[0] = vabsq_s32( vaddq_s32( m4[6].val[0], m4[7].val[0] ) );
-  m3[7].val[0] = vabdq_s32(m4[6].val[0], m4[7].val[0]);
+  const uint16x8_t r0 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[0] );
+  const uint16x8_t r1 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[0], m2[1] ).val[1] );
+  const uint16x8_t r2 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[2], m2[3] ).val[0] );
+  const uint16x8_t r3 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[2], m2[3] ).val[1] );
+  const uint16x8_t r4 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[4], m2[5] ).val[0] );
+  const uint16x8_t r5 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[4], m2[5] ).val[1] );
+  const uint16x8_t r6 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[6], m2[7] ).val[0] );
+  const uint16x8_t r7 = vreinterpretq_u16_s16( vvenc_vtrnq_s64_to_s16( m2[6], m2[7] ).val[1] );
 
-  // --------------------------------------------------------------------------------------------
-  m4[0].val[1] = vaddl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[3] ) );
-  m4[1].val[1] = vaddl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[3] ) );
-  m4[2].val[1] = vsubl_s16( vget_low_s16( m2[2] ), vget_low_s16( m2[3] ) );
-  m4[3].val[1] = vsubl_s16( vget_high_s16( m2[2] ), vget_high_s16( m2[3] ) );
-  m4[4].val[1] = vaddl_s16( vget_low_s16( m2[6] ), vget_low_s16( m2[7] ) );
-  m4[5].val[1] = vaddl_s16( vget_high_s16( m2[6] ), vget_high_s16( m2[7] ) );
-  m4[6].val[1] = vsubl_s16( vget_low_s16( m2[6] ), vget_low_s16( m2[7] ) );
-  m4[7].val[1] = vsubl_s16( vget_high_s16( m2[6] ), vget_high_s16( m2[7] ) );
+  // The last butterfly uses |x+y|+|x-y| = 2*max(|x|,|y|); we delay the "*2".
+  const uint16x8_t max0 = vmaxq_u16( r0, r1 );
+  const uint16x8_t max1 = vmaxq_u16( r2, r3 );
+  const uint16x8_t max2 = vmaxq_u16( r4, r5 );
+  const uint16x8_t max3 = vmaxq_u16( r6, r7 );
 
-  m3[0].val[1] = vabsq_s32( vaddq_s32( m4[0].val[1], m4[1].val[1] ) );
-  m3[1].val[1] = vabdq_s32(m4[0].val[1], m4[1].val[1]);
-  m3[2].val[1] = vabsq_s32( vaddq_s32( m4[2].val[1], m4[3].val[1] ) );
-  m3[3].val[1] = vabdq_s32(m4[2].val[1], m4[3].val[1]);
-  m3[4].val[1] = vabsq_s32( vaddq_s32( m4[4].val[1], m4[5].val[1] ) );
-  m3[5].val[1] = vabdq_s32(m4[4].val[1], m4[5].val[1]);
-  m3[6].val[1] = vabsq_s32( vaddq_s32( m4[6].val[1], m4[7].val[1] ) );
-  m3[7].val[1] = vabdq_s32(m4[6].val[1], m4[7].val[1]);
+  const uint32x4_t sum = horizontal_add_long_4d_u16x8( max0, max1, max2, max3 );
 
-  m4[0].val[0] = m3[0].val[0];
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[0].val[1] );
-  m3[1].val[0] = vaddq_s32( m3[1].val[0], m3[1].val[1] );
-  m3[2].val[0] = vaddq_s32( m3[2].val[0], m3[2].val[1] );
-  m3[3].val[0] = vaddq_s32( m3[3].val[0], m3[3].val[1] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[4].val[1] );
-  m3[5].val[0] = vaddq_s32( m3[5].val[0], m3[5].val[1] );
-  m3[6].val[0] = vaddq_s32( m3[6].val[0], m3[6].val[1] );
-  m3[7].val[0] = vaddq_s32( m3[7].val[0], m3[7].val[1] );
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[1].val[0] );
-  m3[2].val[0] = vaddq_s32( m3[2].val[0], m3[3].val[0] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[5].val[0] );
-  m3[6].val[0] = vaddq_s32( m3[6].val[0], m3[7].val[0] );
-
-  m3[0].val[0] = vaddq_s32( m3[0].val[0], m3[2].val[0] );
-  m3[4].val[0] = vaddq_s32( m3[4].val[0], m3[6].val[0] );
-  int32x4_t iSum = vaddq_s32( m3[0].val[0], m3[4].val[0] );
-
-  uint32_t sad = ( uint32_t ) horizontal_add_s32x4(iSum);
-  uint32_t absDC = vgetq_lane_s32( m4[0].val[0], 0 );
+  uint32_t sad = horizontal_add_u32x4( sum );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
   sad -= absDC;
   sad += absDC >> 2;
-  sad = ( ( sad + 2 ) >> 2 );
+  sad = ( sad + 2 ) >> 2;
 
   return sad;
 }
@@ -1232,16 +1200,14 @@ Distortion xGetHADs_neon( const DistParam& rcDtParam )
   }
   else if( ( ( ( iRows | iCols ) & 7 ) == 0 ) && ( iRows == iCols ) )
   {
-    for( y = 0; y<iRows; y += 8 )
+    for( y = 0; y < iRows; y += 8 )
     {
+      for( x = 0; x < iCols; x += 8 )
       {
-        for( x = 0; x < iCols; x += 8 )
-        {
-          uiSum += xCalcHAD8x8_Neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur, iBitDepth );
-        }
+        uiSum += xCalcHAD8x8_neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur );
       }
-      piOrg += 8*iStrideOrg;
-      piCur += 8*iStrideCur;
+      piOrg += 8 * iStrideOrg;
+      piCur += 8 * iStrideCur;
     }
   }
   else if( ( iRows % 4 == 0 ) && ( iCols % 4 == 0 ) )

--- a/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/RdCost_neon.cpp
@@ -869,7 +869,7 @@ static Distortion xCalcHAD8x16_neon( const Pel* piOrg, const Pel* piCur, int iSt
   return sad;
 }
 
-static Distortion xCalcHAD8x4_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
+Distortion xCalcHAD8x4_neon( const Pel* piOrg, const Pel* piCur, int iStrideOrg, int iStrideCur )
 {
   int16x8_t diff[4];
 
@@ -885,6 +885,7 @@ static Distortion xCalcHAD8x4_neon( const Pel* piOrg, const Pel* piCur, int iStr
   }
 
   int16x8_t m0[4], m1[4];
+  int32x4_t m2[8];
 
   // Vertical.
   m0[0] = vaddq_s16( diff[0], diff[2] );
@@ -897,53 +898,41 @@ static Distortion xCalcHAD8x4_neon( const Pel* piOrg, const Pel* piCur, int iStr
   m1[2] = vaddq_s16( m0[2], m0[3] );
   m1[3] = vsubq_s16( m0[2], m0[3] ); // 13-bit
 
-  // Transpose.
-  int16x8x2_t zip02 = vzipq_s16( m1[0], m1[2] );
-  int16x8x2_t zip13 = vzipq_s16( m1[1], m1[3] );
+  const uint32_t absDC = std::abs( horizontal_add_long_s16x8( m1[0] ) );
 
-  int16x8x2_t zip0123 = vzipq_s16( zip02.val[0], zip13.val[0] );
-  int16x8x2_t zip4567 = vzipq_s16( zip02.val[1], zip13.val[1] );
+  // Partial transpose to do the first horizontal step.
+  m0[0] = vtrnq_s16( m1[0], m1[1] ).val[0];
+  m0[1] = vtrnq_s16( m1[0], m1[1] ).val[1];
+  m0[2] = vtrnq_s16( m1[2], m1[3] ).val[0];
+  m0[3] = vtrnq_s16( m1[2], m1[3] ).val[1];
 
-  m0[0] = zip0123.val[0];
-  m0[1] = zip0123.val[1];
-  m0[2] = zip4567.val[0];
-  m0[3] = zip4567.val[1];
+  // First horizontal butterfly.
+  m2[0] = vreinterpretq_s32_s16( vaddq_s16( m0[0], m0[1] ) );
+  m2[1] = vreinterpretq_s32_s16( vsubq_s16( m0[0], m0[1] ) );
+  m2[2] = vreinterpretq_s32_s16( vaddq_s16( m0[2], m0[3] ) );
+  m2[3] = vreinterpretq_s32_s16( vsubq_s16( m0[2], m0[3] ) ); // 14-bit
 
-  // Horizontal.
-  m1[0] = vaddq_s16( m0[0], m0[2] );
-  m1[1] = vaddq_s16( m0[1], m0[3] );
-  m1[2] = vsubq_s16( m0[0], m0[2] );
-  m1[3] = vsubq_s16( m0[1], m0[3] ); // 14-bit
+  m1[0] = vreinterpretq_s16_s32( vzipq_s32( m2[0], m2[1] ).val[0] );
+  m1[1] = vreinterpretq_s16_s32( vzipq_s32( m2[0], m2[1] ).val[1] );
+  m1[2] = vreinterpretq_s16_s32( vzipq_s32( m2[2], m2[3] ).val[0] );
+  m1[3] = vreinterpretq_s16_s32( vzipq_s32( m2[2], m2[3] ).val[1] );
 
-  m0[0] = vaddq_s16( m1[0], m1[1] );
-  m0[1] = vsubq_s16( m1[0], m1[1] );
-  m0[2] = vaddq_s16( m1[2], m1[3] );
-  m0[3] = vsubq_s16( m1[2], m1[3] ); // 15-bit
+  m0[0] = vabsq_s16( vaddq_s16( m1[0], m1[1] ) );
+  m0[1] = vabdq_s16( m1[0], m1[1] );
+  m0[2] = vabsq_s16( vaddq_s16( m1[2], m1[3] ) );
+  m0[3] = vabdq_s16( m1[2], m1[3] ); // 15-bit
 
-  int16x8x2_t a = vvenc_vtrnq_s64_to_s16( m0[0], m0[1] );
-  int16x8x2_t b = vvenc_vtrnq_s64_to_s16( m0[2], m0[3] );
+  // The last butterfly uses |x+y|+|x-y| = 2*max(|x|,|y|); we delay the "*2".
+  m1[0] = vvenc_vtrnq_s64_to_s16( m0[0], m0[1] ).val[0];
+  m1[1] = vvenc_vtrnq_s64_to_s16( m0[0], m0[1] ).val[1];
+  m1[2] = vvenc_vtrnq_s64_to_s16( m0[2], m0[3] ).val[0];
+  m1[3] = vvenc_vtrnq_s64_to_s16( m0[2], m0[3] ).val[1];
 
-  m1[0] = a.val[0];
-  m1[1] = a.val[1];
-  m1[2] = b.val[0];
-  m1[3] = b.val[1];
+  const uint16x8_t max0 = vreinterpretq_u16_s16( vmaxq_s16( m1[0], m1[1] ) );
+  const uint16x8_t max1 = vreinterpretq_u16_s16( vmaxq_s16( m1[2], m1[3] ) );
 
-  int32x4_t sum0 = vabsq_s32( vaddl_s16( vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) ) );
-  uint32_t absDC = ( uint32_t )vgetq_lane_s32( sum0, 0 );
-  sum0 = vabal_s16( sum0, vget_low_s16( m1[0] ), vget_low_s16( m1[1] ) );
-
-  int32x4_t sum1 = vabsq_s32( vaddl_s16( vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) ) );
-  sum1 = vabal_s16( sum1, vget_high_s16( m1[0] ), vget_high_s16( m1[1] ) );
-
-  int32x4_t sum2 = vabsq_s32( vaddl_s16( vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) ) );
-  sum2 = vabal_s16( sum2, vget_low_s16( m1[2] ), vget_low_s16( m1[3] ) );
-
-  int32x4_t sum3 = vabsq_s32( vaddl_s16( vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) ) );
-  sum3 = vabal_s16( sum3, vget_high_s16( m1[2] ), vget_high_s16( m1[3] ) );
-
-  int32x4_t total = horizontal_add_4d_s32x4( sum0, sum1, sum2, sum3 );
-
-  uint32_t sad = ( uint32_t )horizontal_add_s32x4( total );
+  uint32_t sad = ( uint32_t )horizontal_add_long_u16x8( vaddq_u16( max0, max1 ) );
+  sad <<= 1; // Apply the deferred doubling from the last butterfly.
   sad -= absDC;
   sad += absDC >> 2;
   sad = ( uint32_t )( ( double )sad / sqrt( 4.0 * 8.0 ) * 2.0 );
@@ -1170,8 +1159,8 @@ Distortion xGetHADs_neon( const DistParam& rcDtParam )
       {
         uiSum += xCalcHAD8x4_neon( &piOrg[x], &piCur[x], iStrideOrg, iStrideCur );
       }
-      piOrg += 4*iStrideOrg;
-      piCur += 4*iStrideCur;
+      piOrg += 4 * iStrideOrg;
+      piCur += 4 * iStrideCur;
     }
   }
   else if( iCols < iRows && ( iRows & 7 ) == 0 && ( iCols & 3 ) == 0 )

--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -122,6 +122,15 @@ static inline int horizontal_add_long_s16x8( const int16x8_t a )
 #endif
 }
 
+static inline uint32_t horizontal_add_long_u16x8( const uint16x8_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddlvq_u16( a );
+#else
+  return horizontal_add_u32x4( vpaddlq_u16( a ) );
+#endif
+}
+
 static inline int64_t horizontal_add_long_s32x4( const int32x4_t a )
 {
 #if REAL_TARGET_AARCH64

--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -142,6 +142,23 @@ static inline uint64_t horizontal_add_long_u32x4( const uint32x4_t a )
 #endif
 }
 
+static inline uint32x4_t horizontal_add_4d_u32x4( const uint32x4_t v0, const uint32x4_t v1, const uint32x4_t v2,
+                           const uint32x4_t v3 )
+{
+#if REAL_TARGET_AARCH64
+  uint32x4_t v01 = vpaddq_u32( v0, v1 );
+  uint32x4_t v23 = vpaddq_u32( v2, v3 );
+  return vpaddq_u32( v01, v23 );
+#else
+  uint32x4_t res = vdupq_n_u32( 0 );
+  res            = vsetq_lane_u32( horizontal_add_u32x4( v0 ), res, 0 );
+  res            = vsetq_lane_u32( horizontal_add_u32x4( v1 ), res, 1 );
+  res            = vsetq_lane_u32( horizontal_add_u32x4( v2 ), res, 2 );
+  res            = vsetq_lane_u32( horizontal_add_u32x4( v3 ), res, 3 );
+  return res;
+#endif
+}
+
 static inline int32x4_t horizontal_add_4d_s32x4( const int32x4_t v0, const int32x4_t v1, const int32x4_t v2,
                                                  const int32x4_t v3 )
 {
@@ -157,6 +174,12 @@ static inline int32x4_t horizontal_add_4d_s32x4( const int32x4_t v0, const int32
   res           = vsetq_lane_s32( horizontal_add_s32x4( v3 ), res, 3 );
   return res;
 #endif
+}
+
+static inline uint32x4_t horizontal_add_long_4d_u16x8( const uint16x8_t v0, const uint16x8_t v1, const uint16x8_t v2,
+                                                      const uint16x8_t v3 )
+{
+  return horizontal_add_4d_u32x4( vpaddlq_u16( v0 ), vpaddlq_u16( v1 ), vpaddlq_u16( v2 ), vpaddlq_u16( v3 ) );
 }
 
 static inline int32x4_t horizontal_add_long_4d_s16x8( const int16x8_t v0, const int16x8_t v1, const int16x8_t v2,

--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -113,6 +113,15 @@ static inline uint64_t horizontal_add_u64x2( const uint64x2_t a )
 #endif
 }
 
+static inline int horizontal_add_long_s16x4( const int16x4_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddlv_s16( a );
+#else
+  return horizontal_add_s32x4( vmovl_s16( a ) );
+#endif
+}
+
 static inline int horizontal_add_long_s16x8( const int16x8_t a )
 {
 #if REAL_TARGET_AARCH64


### PR DESCRIPTION
Optimize Neon xCalcHAD* by using `|x+y|+|x-y| = 2*max(|x|,|y|)` identity to fuse last stage of horizontal Hadamard with absolute value summation. Changes to the following kernels provide up to the following uplifts when measured on a Neoverse V2 machine with LLVM-21:
 
- xCalcHAD16x16_fast_Neon: 27%
- xCalcHAD8x8_Neon: 44%
- xCalcHAD8x4_Neon: 16%
- xCalcHAD4x8_neon: 14%
- xCalcHAD4x4_neon: 9%
- xCalcHAD16x8_neon: 43%
- xCalcHAD16x8_neon: 36%