### PR TITLE
fix undefined behavior: call through pointer to incorrect function type

### DIFF
--- a/source/Lib/CommonLib/MCTF.cpp
+++ b/source/Lib/CommonLib/MCTF.cpp
@@ -1356,10 +1356,11 @@ void MCTF::motionEstimationLuma(Array2D<MotionVector> &mvs, const PelStorage &or
 
     for( int n = 0, blockY = 0; blockY + 8 <= origHeight; blockY += stepSize, n++ )
     {
-      static auto task = []( int tId, EstParams* params)
+      static auto task = []( int, void* task_param )
       {
         ITT_TASKSTART( itt_domain_MCTF_est, itt_handle_est );
 
+        EstParams* params = static_cast<EstParams*>( task_param );
         bool ret = params->mctf->estimateLumaLn( params->blockX, params->prevLineX, *params->mvs, *params->orig, *params->buffer, params->blockSize, params->previous, params->factor, params->doubleRes, params->blockY, params->bitDepth );
 
         ITT_TASKEND( itt_domain_MCTF_est, itt_handle_est );
@@ -1380,7 +1381,7 @@ void MCTF::motionEstimationLuma(Array2D<MotionVector> &mvs, const PelStorage &or
       cEstParams.blockY = blockY;
       cEstParams.bitDepth = bitDepth;
 
-      m_threadPool->addBarrierTask<EstParams>( task, &cEstParams, &taskCounter);
+      m_threadPool->addBarrierTask( task, &cEstParams, &taskCounter);
     }
     taskCounter.wait();
   }
@@ -1512,32 +1513,32 @@ void MCTF::bilateralFilter(const PelStorage& orgPic, std::deque<TemporalFilterSo
       int yStart; 
     };
 
-    std::vector<FltParams> FltParamsArray( orgPic.Y().height/ m_mctfUnitSize + 1 );
+    std::vector<FltParams> FltParamsArray( orgPic.Y().height / m_mctfUnitSize + 1 );
 
     WaitCounter taskCounter;
-
-    for (int n = 0, yStart = 0; yStart < orgPic.Y().height; yStart += m_mctfUnitSize, n++)
+    for( int n = 0, yStart = 0; yStart < orgPic.Y().height; yStart += m_mctfUnitSize, n++ )
     {
-      static auto task = []( int tId, FltParams* params)
+      static auto task = []( int, void* task_param )
       {
         ITT_TASKSTART( itt_domain_MCTF_flt, itt_handle_flt );
 
+        FltParams* params = static_cast<FltParams*>( task_param );
         params->mctf->xFinalizeBlkLine( *params->orgPic, *params->srcFrameInfo, *params->newOrgPic, params->yStart, params->sigmaSqCh, params->overallStrength );
 
         ITT_TASKEND( itt_domain_MCTF_flt, itt_handle_flt );
         return true;
       };
 
-      FltParams& cFltParams = FltParamsArray[n];
-      cFltParams.orgPic = &orgPic; 
-      cFltParams.srcFrameInfo = &srcFrameInfo; 
-      cFltParams.newOrgPic = &newOrgPic;
-      cFltParams.sigmaSqCh = sigmaSqCh;
+      FltParams& cFltParams      = FltParamsArray[n];
+      cFltParams.orgPic          = &orgPic;
+      cFltParams.srcFrameInfo    = &srcFrameInfo;
+      cFltParams.newOrgPic       = &newOrgPic;
+      cFltParams.sigmaSqCh       = sigmaSqCh;
       cFltParams.overallStrength = overallStrength;
-      cFltParams.mctf = this;
-      cFltParams.yStart = yStart;
+      cFltParams.mctf            = this;
+      cFltParams.yStart          = yStart;
 
-      m_threadPool->addBarrierTask<FltParams>( task, &cFltParams, &taskCounter);
+      m_threadPool->addBarrierTask( task, &cFltParams, &taskCounter );
     }
     taskCounter.wait();
   }

--- a/source/Lib/EncoderLib/EncGOP.cpp
+++ b/source/Lib/EncoderLib/EncGOP.cpp
@@ -649,12 +649,15 @@ void EncGOP::xEncodePicture( Picture* pic, EncPicture* picEncoder )
   // finish picture encoding and cleanup
   if( m_pcEncCfg->m_numThreads > 0 )
   {
-    static auto finishTask = []( int, FinishTaskParam* param ) {
+    static auto finishTask = []( int, void* task_param )
+    {
+      FinishTaskParam* param = static_cast<FinishTaskParam*>( task_param );
       param->picEncoder->finalizePicture( *param->pic );
       {
         std::lock_guard<std::mutex> lock( param->gopEncoder->m_gopEncMutex );
         param->pic->isReconstructed = true;
-        if( param->pic->picApsGlobal ) param->pic->picApsGlobal->initalized = true;
+        if( param->pic->picApsGlobal )
+          param->pic->picApsGlobal->initalized = true;
         param->gopEncoder->m_freePicEncoderList.push_back( param->picEncoder );
         param->gopEncoder->m_gopEncCond.notify_one();
       }
@@ -662,7 +665,7 @@ void EncGOP::xEncodePicture( Picture* pic, EncPicture* picEncoder )
       return true;
     };
     FinishTaskParam* param = new FinishTaskParam( this, picEncoder, pic );
-    m_threadPool->addBarrierTask<FinishTaskParam>( finishTask, param, nullptr, nullptr, { &picEncoder->m_ctuTasksDoneCounter.done } );
+    m_threadPool->addBarrierTask( finishTask, param, nullptr, nullptr, { &picEncoder->m_ctuTasksDoneCounter.done } );
   }
   else
   {

--- a/source/Lib/EncoderLib/EncSlice.cpp
+++ b/source/Lib/EncoderLib/EncSlice.cpp
@@ -825,12 +825,12 @@ void EncSlice::xProcessCtus( Picture* pic, const unsigned startCtuTsAddr, const 
   {
     for( auto& ctuEncParam : ctuEncParams )
     {
-      m_threadPool->addBarrierTask<CtuEncParam>( EncSlice::xProcessCtuTask<false>,
-                                                 &ctuEncParam,
-                                                 m_ctuTasksDoneCounter,
-                                                 nullptr,
-                                                 {},
-                                                 EncSlice::xProcessCtuTask<true> );
+      m_threadPool->addBarrierTask( EncSlice::xProcessCtuTask<false>,
+                                    &ctuEncParam,
+                                    m_ctuTasksDoneCounter,
+                                    nullptr,
+                                    {},
+                                    EncSlice::xProcessCtuTask<true> );
     }
   }
   else
@@ -879,8 +879,9 @@ inline bool checkCtuTaskNbBotRgt( const PPS& pps, const int& ctuPosX, const int&
 }
 
 template<bool checkReadyState>
-bool EncSlice::xProcessCtuTask( int threadIdx, CtuEncParam* ctuEncParam )
+bool EncSlice::xProcessCtuTask( int threadIdx, void* taskParam )
 {
+  CtuEncParam* ctuEncParam       = static_cast<CtuEncParam*>( taskParam );
   Picture* pic                   = ctuEncParam->pic;
   EncSlice* encSlice             = ctuEncParam->encSlice;
   CodingStructure& cs            = *pic->cs;

--- a/source/Lib/EncoderLib/EncSlice.h
+++ b/source/Lib/EncoderLib/EncSlice.h
@@ -150,7 +150,7 @@ private:
   double  xCalculateLambda    ( const Slice* slice, const int depth, const double refQP, const double dQP, int& iQP );
   void    xProcessCtus        ( Picture* pic, const unsigned startCtuTsAddr, const unsigned boundingCtuTsAddr );
   template<bool checkReadyState=false>
-  static bool xProcessCtuTask ( int taskIdx, CtuEncParam* ctuEncParam );
+  static bool xProcessCtuTask ( int taskIdx, void* taskParam );
 
   int     xGetQPForPicture    ( const Slice* slice );
 };

--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -391,13 +391,12 @@ public:
   NoMallocThreadPool( int numThreads = 1, const char *threadPoolName = nullptr, const VVEncCfg* encCfg = nullptr );
   ~NoMallocThreadPool();
 
-  template<class TParam>
-  bool addBarrierTask( bool             ( *func )( int, TParam* ),
-                       TParam*             param,
-                       WaitCounter*        counter                      = nullptr,
-                       Barrier*            done                         = nullptr,
-                       const CBarrierVec&& barriers                     = {},
-                       bool             ( *readyCheck )( int, TParam* ) = nullptr )
+  bool addBarrierTask( bool             ( *func )( int, void* ),
+                       void*               param,
+                       WaitCounter*        counter                    = nullptr,
+                       Barrier*            done                       = nullptr,
+                       const CBarrierVec&& barriers                   = {},
+                       bool             ( *readyCheck )( int, void* ) = nullptr )
   {
     if( m_threads.empty() )
     {
@@ -452,8 +451,8 @@ public:
             counter->operator++();
           }
 
-          t.func       = (TaskFunc)func;
-          t.readyCheck = (TaskFunc)readyCheck;
+          t.func       = func;
+          t.readyCheck = readyCheck;
           t.param      = param;
           t.done       = done;
           t.counter    = counter;


### PR DESCRIPTION
Functions called through a fuction pointer need to exactly match the type of the function pointer. So passing a typed pointer as an argument of type void* and implicitly interpreting it as the original type is undefined behavior.

The thread pool task functions now all take a void* parameter, which is then explicitly casted to the actually used struct inside the task function.

fixes: #688