### PR TITLE
test: initialize interface test input samples without memset

### DIFF
--- a/test/vvencinterfacetest/vvencinterfacetest.c
+++ b/test/vvencinterfacetest/vvencinterfacetest.c
@@ -110,7 +110,11 @@ int run( vvenc_config* vvencCfg, int maxFrames, bool runTillFlushed )
   // inititialize yuv input buffer
   for( int comp = 0; comp < 3; comp++ )
   {
-    memset( cYUVInputBuffer.planes[ comp ].ptr, 512, cYUVInputBuffer.planes[comp].width*cYUVInputBuffer.planes[comp].height*sizeof(int16_t));
+    const int size = cYUVInputBuffer.planes[comp].stride * cYUVInputBuffer.planes[comp].height;
+    for( int i = 0; i < size; i++ )
+    {
+      cYUVInputBuffer.planes[comp].ptr[i] = 512;
+    }
   }
 
   // --- allocate memory for output packets


### PR DESCRIPTION
`memset` fills bytes, and the value argument is converted to unsigned char.
Passing 512 therefore does not initialize int16_t samples to 512.
Initialize the interface test input buffer sample-by-sample instead.

Refs #354

Tested:
- cmake --build build/static -j 8
- ctest --test-dir build/static --output-on-failure