### PR TITLE
Arm: fix cap even checks

### DIFF
--- a/source/Lib/CommonLib/arm/neon/DepQuant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/DepQuant_neon.cpp
@@ -93,7 +93,7 @@ static inline void shuffleStateBuf_neon( uint8_t* buf, const uint8x16_t stateShu
 
 static inline uint8x8_t capWithParity_u8x8_neon( const uint8x8_t value, int capEven )
 {
-  CHECKD( capEven % 2 == 0, "Cap value must be even" );
+  CHECKD( capEven % 2 != 0, "Cap value must be even" );
   uint8x8_t cappedValue = vmin_u8( value, vdup_n_u8( uint8_t( capEven ) ) );
   cappedValue = vbsl_u8( vdup_n_u8( 1 ), value, cappedValue ); // Preserve parity bit.
   return cappedValue;
@@ -101,7 +101,7 @@ static inline uint8x8_t capWithParity_u8x8_neon( const uint8x8_t value, int capE
 
 static inline int16x4_t capWithParity_s16x4_neon( const int16x4_t value, int capEven )
 {
-  CHECKD( capEven % 2 == 0, "Cap value must be even" );
+  CHECKD( capEven % 2 != 0, "Cap value must be even" );
   int16x4_t cappedValue = vmin_s16( value, vdup_n_s16( int16_t( capEven ) ) );
   cappedValue = vbsl_s16( vdup_n_u16( 1 ), value, cappedValue ); // Preserve parity bit.
   return cappedValue;


### PR DESCRIPTION
Some tests are failing with AArch64 Neon intrinsics enabled after https://github.com/fraunhoferhhi/vvenc/pull/691:

```
[main] Building folder: /Users/andoni/git/vvenc/build
[build] Starting build
[proc] Executing command: /opt/homebrew/bin/cmake --build /Users/andoni/git/vvenc/build --config Debug --target all --
[build] [1/2   0% :: 0.011] Re-checking globbed directories...
[build] -- GLOB mismatch!
[build] [2/2  50% :: 0.027] Re-running CMake...
[build] CMake Warning at /opt/homebrew/Cellar/cmake/3.25.1/share/cmake/Modules/Platform/Darwin-Initialize.cmake:303 (message):
[build]   Ignoring CMAKE_OSX_SYSROOT value:
[build]
[build]    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk
[build]
[build]   because the directory does not exist.
[build] Call Stack (most recent call first):
[build]   /opt/homebrew/Cellar/cmake/3.25.1/share/cmake/Modules/CMakeSystemSpecificInitialize.cmake:21 (include)
[build]   CMakeLists.txt:13 (project)
[build]
[build]
[build] -- CMAKE_MODULE_PATH: updating module path to: /Users/andoni/git/vvenc/cmake/modules
[build] -- normalized target architecture: AARCH64
[build] -- Performing Test SUPPORTED_march=armv8_2_a+sve
[build] -- Performing Test SUPPORTED_march=armv8_2_a+sve - Success
[build] -- Performing Test SUPPORTED_march=armv9_a+sve2
[build] -- Performing Test SUPPORTED_march=armv9_a+sve2 - Success
[build] -- x86 SIMD intrinsics enabled (using SIMDE for non-x86 targets)
[build] -- AArch64 Neon intrinsics enabled
[build] -- AArch64 SVE intrinsics enabled
[build] -- VVENC_ENABLE_THIRDPARTY_JSON: ON
[build] -- Configuring done
[build] -- Generating done
[build] -- Build files have been written to: /Users/andoni/git/vvenc/build
[build] [1/2   0% :: 0.004] Re-checking globbed directories...
[build] [6/12   8% :: 0.956] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc_arm_simd.dir/__/CommonLib/arm/neon/DepQuant_neon.cpp.o
[build] [6/12  16% :: 1.065] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc.dir/__/CommonLib/arm/InitARM.cpp.o
[build] [6/12  25% :: 1.115] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc_arm_simd.dir/__/CommonLib/arm/sve/RdCost_sve.cpp.o
[build] [6/12  33% :: 1.160] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc_arm_simd.dir/__/CommonLib/arm/neon/RdCost_neon.cpp.o
[build] [6/12  41% :: 1.176] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc_arm_simd.dir/__/CommonLib/arm/sve/InterpolationFilter_sve.cpp.o
[build] [6/12  50% :: 1.343] Building CXX object source/Lib/vvenc/CMakeFiles/vvenc_arm_simd.dir/__/CommonLib/arm/sve/MCTF_sve.cpp.o
[build] [7/12  58% :: 1.941] Linking CXX static library /Users/andoni/git/vvenc/lib/debug-static/libvvenc.a
[build] ranlib: warning: 'libvvenc.a(SearchSpaceCounter.cpp.o)' has no symbols
[build] ranlib: warning: 'libvvenc.a(TimeProfiler.cpp.o)' has no symbols
[build] ranlib: warning: 'libvvenc.a(SearchSpaceCounter.cpp.o)' has no symbols
[build] ranlib: warning: 'libvvenc.a(TimeProfiler.cpp.o)' has no symbols
[build] [12/12  66% :: 2.089] Linking CXX executable /Users/andoni/git/vvenc/bin/debug-static/vvenclibtest
[build] [12/12  75% :: 2.103] Linking CXX executable /Users/andoni/git/vvenc/bin/debug-static/vvencapp
[build] [12/12  83% :: 2.104] Linking CXX executable /Users/andoni/git/vvenc/bin/debug-static/vvenc_unit_test
[build] [12/12  91% :: 2.107] Linking CXX executable /Users/andoni/git/vvenc/bin/debug-static/vvencFFapp
[build] [12/12 100% :: 2.117] Linking CXX executable /Users/andoni/git/vvenc/bin/debug-static/vvencinterfacetest
[driver] Build completed: 00:00:03.082
[build] Build finished with exit code 0
[proc] Executing command: /opt/homebrew/bin/ctest -j10 -C Debug -T test --output-on-failure -R ^Test_vvencapp-fast$
[ctest] Cannot find file: /Users/andoni/git/vvenc/build/DartConfiguration.tcl
[ctest]    Site:
[ctest]    Build name: (empty)
[ctest] Cannot find file: /Users/andoni/git/vvenc/build/DartConfiguration.tcl
[ctest] Test project /Users/andoni/git/vvenc/build
[ctest]     Start 17: Test_vvencapp-fast
[ctest] 1/2 Test #17: Test_vvencapp-fast ...............Subprocess aborted***Exception:   3.35 sec
[ctest] libc++abi: terminating due to uncaught exception of type vvenc::Exception: ERROR: In function "capWithParity_s16x4_neon" in /Users/andoni/git/vvenc/source/Lib/CommonLib/arm/neon/DepQuant_neon.cpp:104: Cap value must be even
[ctest] vvencapp: VVenC, the Fraunhofer H.266/VVC Encoder, version 1.15.0-dev [Mac OS X][clang 21.0.0][64 bit][SIMD=NEON]
```

This fixes the check that validates the cap value is even.

Given the CI didn't catch this issue, this might indicate there are no neon-enabled builds.  The `os: macos-latest osx_arch: arm64` should have caught that problem.