### PR TITLE
Fix PVS-Studio V519: remove double-assignment in xInitConstraintInfo

### DIFF
--- a/source/Lib/EncoderLib/EncGOP.cpp
+++ b/source/Lib/EncoderLib/EncGOP.cpp
@@ -875,16 +875,6 @@ void EncGOP::xInitConstraintInfo(ConstraintInfo &ci) const
   ci.onePictureOnlyConstraintFlag                 = false;
   ci.lowerBitRateConstraintFlag                   = false;
   ci.allLayersIndependentConstraintFlag           = false;
-  ci.noMrlConstraintFlag                          = false;
-  ci.noIspConstraintFlag                          = false;
-  ci.noMipConstraintFlag                          = false;
-  ci.noLfnstConstraintFlag                        = false;
-  ci.noMmvdConstraintFlag                         = false;
-  ci.noSmvdConstraintFlag                         = false;
-  ci.noProfConstraintFlag                         = false;
-  ci.noPaletteConstraintFlag                      = false;
-  ci.noActConstraintFlag                          = false;
-  ci.noLmcsConstraintFlag                         = false;
   ci.noQtbttDualTreeIntraConstraintFlag           = ! m_pcEncCfg->m_dualITree;
   ci.noPartitionConstraintsOverrideConstraintFlag = false;
   ci.noSaoConstraintFlag                          = ! m_pcEncCfg->m_bUseSAO;


### PR DESCRIPTION
## Summary

PVS-Studio V519 flagged ten fields in `EncGOP::xInitConstraintInfo()` that
were assigned `false` at the top of the function and then unconditionally
overwritten a few lines later — the initial assignment is never read.

Fields removed:
- `noMrlConstraintFlag`
- `noIspConstraintFlag`
- `noMipConstraintFlag`
- `noLfnstConstraintFlag`
- `noMmvdConstraintFlag`
- `noSmvdConstraintFlag`
- `noProfConstraintFlag`
- `noPaletteConstraintFlag`
- `noActConstraintFlag`
- `noLmcsConstraintFlag`

No behaviour change — the final assigned values are identical.

Addresses issue #354.

## Tested

- `cmake --build build --parallel 8` — success
- `ctest --test-dir build -j8` — all tests pass