### PR TITLE
arm/neon: add Neon long deblocking filter

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@
 * Micro Daryl Robles, @micro-arm, Arm
 * Alex Davicenko, @alex-davicenko-arm, Arm
 * Li Zhang, @lizhang-arm, Arm
+* Jeongkeun Kim, @kjg0724

--- a/source/Lib/CommonLib/LoopFilter.cpp
+++ b/source/Lib/CommonLib/LoopFilter.cpp
@@ -355,6 +355,9 @@ LoopFilter::LoopFilter()
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_DBLF
   initLoopFilterX86();
 #endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+  initLoopFilterARM();
+#endif
 }
 
 LoopFilter::~LoopFilter()

--- a/source/Lib/CommonLib/LoopFilter.h
+++ b/source/Lib/CommonLib/LoopFilter.h
@@ -85,6 +85,12 @@ private:
   void _initLoopFilterX86();
 #endif
 
+#if defined(TARGET_SIMD_ARM) && ENABLE_SIMD_DBLF
+  void initLoopFilterARM();
+  template <ARM_VEXT vext>
+  void _initLoopFilterARM();
+#endif
+
 public:
 
   LoopFilter();

--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -217,6 +217,17 @@ void IntraPrediction::initIntraPredictionARM()
 }
 #endif
 
+#if ENABLE_SIMD_DBLF
+void LoopFilter::initLoopFilterARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initLoopFilterARM<NEON>();
+  }
+}
+#endif  // ENABLE_SIMD_DBLF
+
 #endif  // TARGET_SIMD_ARM
 
 }   // namespace

--- a/source/Lib/CommonLib/arm/neon/LoopFilter_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/LoopFilter_neon.cpp
@@ -1,0 +1,259 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/** \file     LoopFilter_neon.cpp
+    \brief    deblocking filter, Neon version
+*/
+
+#include <arm_neon.h>
+
+#include "CommonDefARM.h"
+#include "CommonLib/LoopFilter.h"
+#include "CommonLib/Rom.h"
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+
+namespace vvenc
+{
+
+// ====================================================================================================================
+// Tables (mirror x86 side)
+// ====================================================================================================================
+
+static const int dbCoeffs7[7] = { 59, 50, 41, 32, 23, 14,  5 };
+static const int dbCoeffs5[5] = { 58, 45, 32, 19,  6 };
+static const int dbCoeffs3[3] = { 53, 32, 11 };
+static const int tcCoeffs7[7] = { 6, 5, 4, 3, 2, 1, 1 };
+static const int tcCoeffs3[3] = { 6, 4, 2 };
+
+// ====================================================================================================================
+// Long (bilinear) filter — horizontal edge (step == 1)
+// ====================================================================================================================
+
+static inline void xFilteringPandQHor_neon( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
+                                            int numberPSide, int numberQSide, int tc )
+{
+  CHECKD( step != 1, "step must be 1 for horizontal edge" );
+
+  const int* dbCoeffsP = numberPSide == 7 ? dbCoeffs7 : ( numberPSide == 5 ? dbCoeffs5 : dbCoeffs3 );
+  const int* dbCoeffsQ = numberQSide == 7 ? dbCoeffs7 : ( numberQSide == 5 ? dbCoeffs5 : dbCoeffs3 );
+  const int* tcP       = numberPSide == 3 ? tcCoeffs3 : tcCoeffs7;
+  const int* tcQ       = numberQSide == 3 ? tcCoeffs3 : tcCoeffs7;
+
+  // Scalar reference computation per row (4 rows = DEBLOCK_SMALLEST_BLOCK/2)
+  uint64_t refPx4 = 0, refQx4 = 0, refMiddlex4 = 0;
+
+  for( int i = 0; i < DEBLOCK_SMALLEST_BLOCK / 2; i++ )
+  {
+    const Pel* srcP = src + step * i - offset;
+    const Pel* srcQ = src + step * i;
+
+    const Pel refP = ( srcP[-numberPSide * offset] + srcP[-( numberPSide - 1 ) * offset] + 1 ) >> 1;
+    const Pel refQ = ( srcQ[ numberQSide * offset] + srcQ[  ( numberQSide - 1 ) * offset] + 1 ) >> 1;
+
+    Pel refMiddle = 0;
+    if( numberPSide == numberQSide )
+    {
+      if( numberPSide == 5 )
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset] + srcP[-2*offset] + srcQ[2*offset] )
+                      + srcP[-3*offset] + srcQ[3*offset] + srcP[-4*offset] + srcQ[4*offset] + 8 ) >> 4;
+      else
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] ) + srcP[-offset] + srcQ[offset] + srcP[-2*offset] + srcQ[2*offset]
+                      + srcP[-3*offset] + srcQ[3*offset] + srcP[-4*offset] + srcQ[4*offset]
+                      + srcP[-5*offset] + srcQ[5*offset] + srcP[-6*offset] + srcQ[6*offset] + 8 ) >> 4;
+    }
+    else
+    {
+      const Pel* srcPt = srcP, *srcQt = srcQ;
+      ptrdiff_t  offP  = -offset, offQ = offset;
+      int        nP    = numberPSide, nQ = numberQSide;
+      if( nQ > nP ) { std::swap( srcPt, srcQt ); std::swap( offP, offQ ); std::swap( nP, nQ ); }
+
+      if( nP == 7 && nQ == 5 )
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset] )
+                      + srcP[-2*offset] + srcQ[2*offset] + srcP[-3*offset] + srcQ[3*offset]
+                      + srcP[-4*offset] + srcQ[4*offset] + srcP[-5*offset] + srcQ[5*offset] + 8 ) >> 4;
+      else if( nP == 7 && nQ == 3 )
+        refMiddle = ( 2 * ( srcPt[0] + srcQt[0] ) + srcQt[0]
+                      + 2 * ( srcQt[offQ] + srcQt[2*offQ] ) + srcPt[offP] + srcQt[offQ]
+                      + srcPt[2*offP] + srcPt[3*offP] + srcPt[4*offP] + srcPt[5*offP] + srcPt[6*offP] + 8 ) >> 4;
+      else
+        refMiddle = ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset]
+                      + srcP[-2*offset] + srcQ[2*offset] + srcP[-3*offset] + srcQ[3*offset] + 4 ) >> 3;
+    }
+
+    refPx4      |= ( (uint64_t)(uint16_t)refP      << ( i * 16 ) );
+    refQx4      |= ( (uint64_t)(uint16_t)refQ      << ( i * 16 ) );
+    refMiddlex4 |= ( (uint64_t)(uint16_t)refMiddle << ( i * 16 ) );
+  }
+
+  // NEON weighted blend for P side
+  int16x4_t vref_mid = vreinterpret_s16_u64( vcreate_u64( refMiddlex4 ) );
+  int16x4_t vref_p   = vreinterpret_s16_u64( vcreate_u64( refPx4 ) );
+  int16x4_t vref_q   = vreinterpret_s16_u64( vcreate_u64( refQx4 ) );
+
+  Pel* srcP = src - offset;
+  Pel* srcQ = src;
+
+  for( int pos = 0; pos < numberPSide; pos++ )
+  {
+    int16x4_t vsrc   = vld1_s16( srcP - offset * pos );
+    int16x4_t cval   = vdup_n_s16( (int16_t)( ( tc * tcP[pos] ) >> 1 ) );
+    int16x4_t vlo    = vsub_s16( vsrc, cval );
+    int16x4_t vhi    = vadd_s16( vsrc, cval );
+    int32x4_t vacc   = vmull_s16( vref_mid, vdup_n_s16( (int16_t)dbCoeffsP[pos] ) );
+    vacc              = vmlal_s16( vacc, vref_p, vdup_n_s16( (int16_t)( 64 - dbCoeffsP[pos] ) ) );
+    vacc              = vaddq_s32( vacc, vdupq_n_s32( 32 ) );
+    int16x4_t vresult = vqmovn_s32( vshrq_n_s32( vacc, 6 ) );
+    vresult            = vmin_s16( vmax_s16( vresult, vlo ), vhi );
+    vst1_s16( srcP - offset * pos, vresult );
+  }
+
+  for( int pos = 0; pos < numberQSide; pos++ )
+  {
+    int16x4_t vsrc   = vld1_s16( srcQ + offset * pos );
+    int16x4_t cval   = vdup_n_s16( (int16_t)( ( tc * tcQ[pos] ) >> 1 ) );
+    int16x4_t vlo    = vsub_s16( vsrc, cval );
+    int16x4_t vhi    = vadd_s16( vsrc, cval );
+    int32x4_t vacc   = vmull_s16( vref_mid, vdup_n_s16( (int16_t)dbCoeffsQ[pos] ) );
+    vacc              = vmlal_s16( vacc, vref_q, vdup_n_s16( (int16_t)( 64 - dbCoeffsQ[pos] ) ) );
+    vacc              = vaddq_s32( vacc, vdupq_n_s32( 32 ) );
+    int16x4_t vresult = vqmovn_s32( vshrq_n_s32( vacc, 6 ) );
+    vresult            = vmin_s16( vmax_s16( vresult, vlo ), vhi );
+    vst1_s16( srcQ + offset * pos, vresult );
+  }
+}
+
+// Vertical edge long filter: scalar fallback (matches x86 non-AVX2 path)
+static inline void xFilteringPandQVer_scalar( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
+                                              int numberPSide, int numberQSide, int tc )
+{
+  CHECKD( offset != 1, "offset must be 1 for vertical edge" );
+
+  const int* dbCoeffsP = numberPSide == 7 ? dbCoeffs7 : ( numberPSide == 5 ? dbCoeffs5 : dbCoeffs3 );
+  const int* dbCoeffsQ = numberQSide == 7 ? dbCoeffs7 : ( numberQSide == 5 ? dbCoeffs5 : dbCoeffs3 );
+  const int* tcP       = numberPSide == 3 ? tcCoeffs3 : tcCoeffs7;
+  const int* tcQ       = numberQSide == 3 ? tcCoeffs3 : tcCoeffs7;
+
+  for( int i = 0; i < DEBLOCK_SMALLEST_BLOCK / 2; i++ )
+  {
+    Pel* srcP = src + step * i - offset;
+    Pel* srcQ = src + step * i;
+
+    const Pel refP = ( srcP[-numberPSide * offset] + srcP[-( numberPSide - 1 ) * offset] + 1 ) >> 1;
+    const Pel refQ = ( srcQ[ numberQSide * offset] + srcQ[  ( numberQSide - 1 ) * offset] + 1 ) >> 1;
+
+    Pel refMiddle = 0;
+    if( numberPSide == numberQSide )
+    {
+      if( numberPSide == 5 )
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset] + srcP[-2*offset] + srcQ[2*offset] )
+                      + srcP[-3*offset] + srcQ[3*offset] + srcP[-4*offset] + srcQ[4*offset] + 8 ) >> 4;
+      else
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] ) + srcP[-offset] + srcQ[offset] + srcP[-2*offset] + srcQ[2*offset]
+                      + srcP[-3*offset] + srcQ[3*offset] + srcP[-4*offset] + srcQ[4*offset]
+                      + srcP[-5*offset] + srcQ[5*offset] + srcP[-6*offset] + srcQ[6*offset] + 8 ) >> 4;
+    }
+    else
+    {
+      const Pel* srcPt = srcP, *srcQt = srcQ;
+      ptrdiff_t  offP  = -offset, offQ = offset;
+      int        nP    = numberPSide, nQ = numberQSide;
+      if( nQ > nP ) { std::swap( srcPt, srcQt ); std::swap( offP, offQ ); std::swap( nP, nQ ); }
+
+      if( nP == 7 && nQ == 5 )
+        refMiddle = ( 2 * ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset] )
+                      + srcP[-2*offset] + srcQ[2*offset] + srcP[-3*offset] + srcQ[3*offset]
+                      + srcP[-4*offset] + srcQ[4*offset] + srcP[-5*offset] + srcQ[5*offset] + 8 ) >> 4;
+      else if( nP == 7 && nQ == 3 )
+        refMiddle = ( 2 * ( srcPt[0] + srcQt[0] ) + srcQt[0]
+                      + 2 * ( srcQt[offQ] + srcQt[2*offQ] ) + srcPt[offP] + srcQt[offQ]
+                      + srcPt[2*offP] + srcPt[3*offP] + srcPt[4*offP] + srcPt[5*offP] + srcPt[6*offP] + 8 ) >> 4;
+      else
+        refMiddle = ( srcP[0] + srcQ[0] + srcP[-offset] + srcQ[offset]
+                      + srcP[-2*offset] + srcQ[2*offset] + srcP[-3*offset] + srcQ[3*offset] + 4 ) >> 3;
+    }
+
+    for( int pos = 0; pos < numberPSide; pos++ )
+    {
+      int src_val = srcP[-offset * pos];
+      int cvalue  = ( tc * tcP[pos] ) >> 1;
+      srcP[-offset * pos] = Clip3( src_val - cvalue, src_val + cvalue,
+                                   ( refMiddle * dbCoeffsP[pos] + refP * ( 64 - dbCoeffsP[pos] ) + 32 ) >> 6 );
+    }
+
+    for( int pos = 0; pos < numberQSide; pos++ )
+    {
+      int src_val = srcQ[offset * pos];
+      int cvalue  = ( tc * tcQ[pos] ) >> 1;
+      srcQ[offset * pos] = Clip3( src_val - cvalue, src_val + cvalue,
+                                  ( refMiddle * dbCoeffsQ[pos] + refQ * ( 64 - dbCoeffsQ[pos] ) + 32 ) >> 6 );
+    }
+  }
+}
+
+static void xFilteringPandQNeon( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
+                                 int numberPSide, int numberQSide, int tc )
+{
+  CHECKD( numberPSide <= 3 && numberQSide <= 3, "Short filtering in long filtering function" );
+
+  if( step == 1 )
+    xFilteringPandQHor_neon( src, step, offset, numberPSide, numberQSide, tc );
+  else
+    xFilteringPandQVer_scalar( src, step, offset, numberPSide, numberQSide, tc );
+}
+
+// ====================================================================================================================
+// Init
+// ====================================================================================================================
+
+template <ARM_VEXT vext>
+void LoopFilter::_initLoopFilterARM()
+{
+  xFilteringPandQ = xFilteringPandQNeon;
+}
+
+template void LoopFilter::_initLoopFilterARM<NEON>();
+
+}  // namespace vvenc
+
+#endif  // TARGET_SIMD_ARM && ENABLE_SIMD_DBLF

--- a/source/Lib/CommonLib/arm/neon/LoopFilter_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/LoopFilter_neon.cpp
@@ -66,7 +66,7 @@ static const int tcCoeffs7[7] = { 6, 5, 4, 3, 2, 1, 1 };
 static const int tcCoeffs3[3] = { 6, 4, 2 };
 
 // ====================================================================================================================
-// Long (bilinear) filter — horizontal edge (step == 1)
+// Long (bilinear) filter -- horizontal edge (step == 1)
 // ====================================================================================================================
 
 static inline void xFilteringPandQHor_neon( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
@@ -163,9 +163,9 @@ static inline void xFilteringPandQHor_neon( Pel* src, ptrdiff_t step, const ptrd
   }
 }
 
-// Vertical edge long filter: scalar fallback (matches x86 non-AVX2 path)
-static inline void xFilteringPandQVer_scalar( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
-                                              int numberPSide, int numberQSide, int tc )
+// Vertical edge long filter -- lane loads/stores across 4 rows
+static inline void xFilteringPandQVer_neon( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
+                                            int numberPSide, int numberQSide, int tc )
 {
   CHECKD( offset != 1, "offset must be 1 for vertical edge" );
 
@@ -174,10 +174,12 @@ static inline void xFilteringPandQVer_scalar( Pel* src, ptrdiff_t step, const pt
   const int* tcP       = numberPSide == 3 ? tcCoeffs3 : tcCoeffs7;
   const int* tcQ       = numberQSide == 3 ? tcCoeffs3 : tcCoeffs7;
 
+  uint64_t refPx4 = 0, refQx4 = 0, refMiddlex4 = 0;
+
   for( int i = 0; i < DEBLOCK_SMALLEST_BLOCK / 2; i++ )
   {
-    Pel* srcP = src + step * i - offset;
-    Pel* srcQ = src + step * i;
+    const Pel* srcP = src + step * i - offset;
+    const Pel* srcQ = src + step * i;
 
     const Pel refP = ( srcP[-numberPSide * offset] + srcP[-( numberPSide - 1 ) * offset] + 1 ) >> 1;
     const Pel refQ = ( srcQ[ numberQSide * offset] + srcQ[  ( numberQSide - 1 ) * offset] + 1 ) >> 1;
@@ -213,21 +215,58 @@ static inline void xFilteringPandQVer_scalar( Pel* src, ptrdiff_t step, const pt
                       + srcP[-2*offset] + srcQ[2*offset] + srcP[-3*offset] + srcQ[3*offset] + 4 ) >> 3;
     }
 
-    for( int pos = 0; pos < numberPSide; pos++ )
-    {
-      int src_val = srcP[-offset * pos];
-      int cvalue  = ( tc * tcP[pos] ) >> 1;
-      srcP[-offset * pos] = Clip3( src_val - cvalue, src_val + cvalue,
-                                   ( refMiddle * dbCoeffsP[pos] + refP * ( 64 - dbCoeffsP[pos] ) + 32 ) >> 6 );
-    }
+    refPx4      |= ( (uint64_t)(uint16_t)refP      << ( i * 16 ) );
+    refQx4      |= ( (uint64_t)(uint16_t)refQ      << ( i * 16 ) );
+    refMiddlex4 |= ( (uint64_t)(uint16_t)refMiddle << ( i * 16 ) );
+  }
 
-    for( int pos = 0; pos < numberQSide; pos++ )
-    {
-      int src_val = srcQ[offset * pos];
-      int cvalue  = ( tc * tcQ[pos] ) >> 1;
-      srcQ[offset * pos] = Clip3( src_val - cvalue, src_val + cvalue,
-                                  ( refMiddle * dbCoeffsQ[pos] + refQ * ( 64 - dbCoeffsQ[pos] ) + 32 ) >> 6 );
-    }
+  int16x4_t vref_mid = vreinterpret_s16_u64( vcreate_u64( refMiddlex4 ) );
+  int16x4_t vref_p   = vreinterpret_s16_u64( vcreate_u64( refPx4 ) );
+  int16x4_t vref_q   = vreinterpret_s16_u64( vcreate_u64( refQx4 ) );
+
+  Pel* srcP = src - offset;
+  Pel* srcQ = src;
+
+  for( int pos = 0; pos < numberPSide; pos++ )
+  {
+    Pel* base      = srcP - offset * pos;
+    int16x4_t vsrc = vld1_lane_s16( base,          vdup_n_s16( 0 ), 0 );
+    vsrc            = vld1_lane_s16( base + step,   vsrc,            1 );
+    vsrc            = vld1_lane_s16( base + step*2, vsrc,            2 );
+    vsrc            = vld1_lane_s16( base + step*3, vsrc,            3 );
+    int16x4_t cval   = vdup_n_s16( (int16_t)( ( tc * tcP[pos] ) >> 1 ) );
+    int16x4_t vlo    = vsub_s16( vsrc, cval );
+    int16x4_t vhi    = vadd_s16( vsrc, cval );
+    int32x4_t vacc   = vmull_s16( vref_mid, vdup_n_s16( (int16_t)dbCoeffsP[pos] ) );
+    vacc              = vmlal_s16( vacc, vref_p, vdup_n_s16( (int16_t)( 64 - dbCoeffsP[pos] ) ) );
+    vacc              = vaddq_s32( vacc, vdupq_n_s32( 32 ) );
+    int16x4_t vresult = vqmovn_s32( vshrq_n_s32( vacc, 6 ) );
+    vresult            = vmin_s16( vmax_s16( vresult, vlo ), vhi );
+    vst1_lane_s16( base,          vresult, 0 );
+    vst1_lane_s16( base + step,   vresult, 1 );
+    vst1_lane_s16( base + step*2, vresult, 2 );
+    vst1_lane_s16( base + step*3, vresult, 3 );
+  }
+
+  for( int pos = 0; pos < numberQSide; pos++ )
+  {
+    Pel* base      = srcQ + offset * pos;
+    int16x4_t vsrc = vld1_lane_s16( base,          vdup_n_s16( 0 ), 0 );
+    vsrc            = vld1_lane_s16( base + step,   vsrc,            1 );
+    vsrc            = vld1_lane_s16( base + step*2, vsrc,            2 );
+    vsrc            = vld1_lane_s16( base + step*3, vsrc,            3 );
+    int16x4_t cval   = vdup_n_s16( (int16_t)( ( tc * tcQ[pos] ) >> 1 ) );
+    int16x4_t vlo    = vsub_s16( vsrc, cval );
+    int16x4_t vhi    = vadd_s16( vsrc, cval );
+    int32x4_t vacc   = vmull_s16( vref_mid, vdup_n_s16( (int16_t)dbCoeffsQ[pos] ) );
+    vacc              = vmlal_s16( vacc, vref_q, vdup_n_s16( (int16_t)( 64 - dbCoeffsQ[pos] ) ) );
+    vacc              = vaddq_s32( vacc, vdupq_n_s32( 32 ) );
+    int16x4_t vresult = vqmovn_s32( vshrq_n_s32( vacc, 6 ) );
+    vresult            = vmin_s16( vmax_s16( vresult, vlo ), vhi );
+    vst1_lane_s16( base,          vresult, 0 );
+    vst1_lane_s16( base + step,   vresult, 1 );
+    vst1_lane_s16( base + step*2, vresult, 2 );
+    vst1_lane_s16( base + step*3, vresult, 3 );
   }
 }
 
@@ -239,7 +278,7 @@ static void xFilteringPandQNeon( Pel* src, ptrdiff_t step, const ptrdiff_t offse
   if( step == 1 )
     xFilteringPandQHor_neon( src, step, offset, numberPSide, numberQSide, tc );
   else
-    xFilteringPandQVer_scalar( src, step, offset, numberPSide, numberQSide, tc );
+    xFilteringPandQVer_neon( src, step, offset, numberPSide, numberQSide, tc );
 }
 
 // ====================================================================================================================
@@ -253,6 +292,12 @@ void LoopFilter::_initLoopFilterARM()
 }
 
 template void LoopFilter::_initLoopFilterARM<NEON>();
+
+void xFilteringPandQNeonEntry( Pel* src, ptrdiff_t step, const ptrdiff_t offset,
+                               int numberPSide, int numberQSide, int tc )
+{
+  xFilteringPandQNeon( src, step, offset, numberPSide, numberQSide, tc );
+}
 
 }  // namespace vvenc
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -57,6 +57,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 
 #include "CommonLib/AdaptiveLoopFilter.h"
+#include "CommonLib/LoopFilter.h"
 #include "CommonLib/AffineGradientSearch.h"
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/DepQuant.h"
@@ -3164,6 +3165,94 @@ static bool test_SampleAdaptiveOffset()
 
 #endif // ENABLE_SIMD_OPT_SAO
 
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+
+namespace vvenc {
+  void xFilteringPandQCore( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int );
+  void xFilteringPandQNeonEntry( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int );
+}
+
+static bool check_xFilteringPandQ( void ( *neon )( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int ),
+                                    const std::vector<Pel>& input,
+                                    ptrdiff_t step, ptrdiff_t offset, int nP, int nQ, int tc )
+{
+  const ptrdiff_t stride = 32;
+  std::vector<Pel> buf_ref  = input;
+  std::vector<Pel> buf_neon = input;
+
+  // Horizontal (step==1): boundary at row 8, col 0  — needs rows [0..15]
+  // Vertical   (step==stride): boundary at row 0, col 8 — needs cols [0..16]
+  ptrdiff_t src_idx = ( step == 1 ) ? 8 * stride : 8;
+
+  vvenc::xFilteringPandQCore( buf_ref.data()  + src_idx, step, offset, nP, nQ, tc );
+  neon(                        buf_neon.data() + src_idx, step, offset, nP, nQ, tc );
+
+  std::ostringstream ctx;
+  ctx << "xFilteringPandQ step=" << step << " offset=" << offset
+      << " nP=" << nP << " nQ=" << nQ << " tc=" << tc;
+  return compare_values_1d( ctx.str(), buf_ref.data(), buf_neon.data(), (unsigned)input.size() );
+}
+
+static bool test_LoopFilterPandQ()
+{
+  printf( "Testing LoopFilter::xFilteringPandQ\n" );
+
+  auto neon = vvenc::xFilteringPandQNeonEntry;
+
+  const ptrdiff_t stride   = 32;
+  const int       buf_rows = 20;
+  const int       buf_size = buf_rows * stride;
+  bool            passed   = true;
+
+  const int nP_vals[] = { 3, 3, 5, 5, 5, 7, 7, 7 };
+  const int nQ_vals[] = { 5, 7, 3, 5, 7, 3, 5, 7 };
+
+  // --- Deterministic edge vectors (always run, even in fast mode) ---
+  std::vector<Pel> buf_zero( buf_size, 0 );
+  std::vector<Pel> buf_max ( buf_size, 1023 );
+  std::vector<Pel> buf_alt ( buf_size );
+  for( int i = 0; i < buf_size; i++ ) buf_alt[i] = ( i & 1 ) ? 1023 : 0;
+
+  struct { const std::vector<Pel>* buf; int tc; } fixed[] = {
+    { &buf_zero, 16 },  // all-zero, mid tc
+    { &buf_max,  16 },  // all-max, mid tc
+    { &buf_alt,  16 },  // alternating, mid tc
+    { &buf_alt,   1 },  // alternating, tc=1 (minimum)
+    { &buf_zero, 32 },  // all-zero,    tc=32 (maximum)
+  };
+
+  for( auto& f : fixed )
+  {
+    for( int k = 0; k < 8; ++k )
+    {
+      int nP = nP_vals[k], nQ = nQ_vals[k];
+      passed = check_xFilteringPandQ( neon, *f.buf, 1,      stride, nP, nQ, f.tc ) && passed;
+      passed = check_xFilteringPandQ( neon, *f.buf, stride, 1,      nP, nQ, f.tc ) && passed;
+    }
+  }
+
+  // --- Random cases ---
+  InputGenerator<Pel> gen{ 10, /*is_signed=*/false };
+  unsigned num_cases = g_fastUnitTest ? 10 : NUM_CASES;
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    int tc = 1 + ( rand() & 0x1f );
+    std::vector<Pel> buf_rand( buf_size );
+    std::generate( buf_rand.begin(), buf_rand.end(), gen );
+
+    for( int k = 0; k < 8; ++k )
+    {
+      int nP = nP_vals[k], nQ = nQ_vals[k];
+      passed = check_xFilteringPandQ( neon, buf_rand, 1,      stride, nP, nQ, tc ) && passed;
+      passed = check_xFilteringPandQ( neon, buf_rand, stride, 1,      nP, nQ, tc ) && passed;
+    }
+  }
+  return passed;
+}
+
+#endif // TARGET_SIMD_ARM && ENABLE_SIMD_DBLF
+
 struct UnitTestEntry
 {
   std::string name;
@@ -3203,6 +3292,9 @@ static const UnitTestEntry test_suites[] = {
 #endif
 #if ENABLE_SIMD_OPT_SAO
     { "SAO", test_SampleAdaptiveOffset },
+#endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+    { "LoopFilterPandQ", test_LoopFilterPandQ },
 #endif
 };
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3180,8 +3180,8 @@ static bool check_xFilteringPandQ( void ( *neon )( Pel*, ptrdiff_t, const ptrdif
   std::vector<Pel> buf_ref  = input;
   std::vector<Pel> buf_neon = input;
 
-  // Horizontal (step==1): boundary at row 8, col 0  — needs rows [0..15]
-  // Vertical   (step==stride): boundary at row 0, col 8 — needs cols [0..16]
+  // Horizontal (step==1): boundary at row 8, col 0  -- needs rows [0..15]
+  // Vertical   (step==stride): boundary at row 0, col 8 -- needs cols [0..16]
   ptrdiff_t src_idx = ( step == 1 ) ? 8 * stride : 8;
 
   vvenc::xFilteringPandQCore( buf_ref.data()  + src_idx, step, offset, nP, nQ, tc );


### PR DESCRIPTION
Adds an ARM Neon path for the long (bilinear) deblocking filter
(xFilteringPandQ), registered via initLoopFilterARM() alongside the
existing x86 path.

Horizontal edges (step == 1):
Uses contiguous vld1_s16 loads and processes four rows in parallel.
Reference values are prepared per row, then the weighted blend and
tc-clip are applied with Neon.

Vertical edges (step == stride):
Uses the same vmull/vmlal int16x4_t arithmetic as the horizontal path.
Lane loads/stores (vld1_lane_s16 / vst1_lane_s16) handle the
non-contiguous vertical access pattern.

Performance (Neoverse N1, clang 15, N=2,000,000, 7-round median):
hor 7+7: scalar 206.3ns -> neon 90.6ns, 2.28x
hor 5+5: 163.6 -> 68.5, 2.39x
hor 7+5: 188.9 -> 82.6, 2.29x
hor 7+3: 170.0 -> 75.3, 2.26x
hor 3+5: 133.6 -> 60.2, 2.22x
ver 7+7: 206.2 -> 130.3, 1.58x
ver 5+5: 161.6 -> 98.4, 1.64x
ver 7+5: 182.6 -> 117.4, 1.56x
ver 7+3: 171.9 -> 105.7, 1.63x
ver 3+5: 138.0 -> 84.5, 1.63x

Tested:
- aarch64 build
- ctest
- LoopFilterPandQ unit test in vvenc_unit_test.cpp, covering all nP/nQ
  combinations for horizontal and vertical filters with deterministic
  and random inputs