### PR TITLE
feat: add per-picture forced IDR API

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -51,14 +51,14 @@ jobs:
         run: |
           $ErrorActionPreference = 'stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -A "${{ matrix.msvc_arch }}" -T "${{ matrix.toolset }}"
+          cmake -S . -B build/static  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_ENABLE_UNSTABLE_API=ON -A "${{ matrix.msvc_arch }}" -T "${{ matrix.toolset }}"
           cmake --build build/static --config Release
 
       - name: Shared build
         run: |
           $ErrorActionPreference = 'stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -A "${{ matrix.msvc_arch }}" -T "${{ matrix.toolset }}"
+          cmake -S . -B build/shared  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_ENABLE_UNSTABLE_API=ON -A "${{ matrix.msvc_arch }}" -T "${{ matrix.toolset }}"
           cmake --build build/shared --config Release
 
       - name: Run Unit Tests
@@ -172,11 +172,11 @@ jobs:
 
       - name: Static build
         run: |
-          cmake -S . -B build/static -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}"
+          cmake -S . -B build/static -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DVVENC_ENABLE_UNSTABLE_API=ON "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}"
           cmake --build build/static
       - name: Shared build
         run: |
-          cmake -S . -B build/shared -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}"
+          cmake -S . -B build/shared -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DVVENC_ENABLE_UNSTABLE_API=ON "-DCMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}"
           cmake --build build/shared
 
       - name: Run Unit Tests

--- a/cmake/modules/vvencTests.cmake
+++ b/cmake/modules/vvencTests.cmake
@@ -18,6 +18,7 @@ add_test( NAME Test_vvenclibtest-input_params            COMMAND vvenclibtest 3 
 add_test( NAME Test_vvenclibtest-sdk_default             COMMAND vvenclibtest 4 )
 add_test( NAME Test_vvenclibtest-sdk_stringapi_interface COMMAND vvenclibtest 5 )
 add_test( NAME Test_vvenclibtest-timestamps              COMMAND vvenclibtest 6 )
+add_test( NAME Test_vvenclibtest-forced_per_frame_idr    COMMAND vvenclibtest 7 )
 
 if( NOT BUILD_SHARED_LIBS )
   add_test( NAME Test_vvenc_unit_test COMMAND vvenc_unit_test --fast )

--- a/include/vvenc/vvenc.h.in
+++ b/include/vvenc/vvenc.h.in
@@ -139,8 +139,14 @@ typedef struct vvencYUVBuffer
   bool          ctsValid;              // composition time stamp valid flag (true: valid, false: CTS not set)
 #if VVENC_USE_UNSTABLE_API
   void*         userData;              // user data to be returned in corresponding access unit
+  uint32_t picFlags;                   // per picture flags (see VVENC_PIC_FLAG_*)
 #endif
 }vvencYUVBuffer;
+
+#if VVENC_USE_UNSTABLE_API
+#define VVENC_PIC_FLAG_NONE 0
+#define VVENC_PIC_FLAG_FORCE_IDR (1 << 0)
+#endif
 
 /* vvenc_YUVBuffer_alloc:
    Allocates an vvencYUVBuffer instance.

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -888,6 +888,8 @@ typedef struct GOPEntry : vvencGOPEntry
   bool      m_skipFirstPass;
   SceneType m_scType;
   int       m_vtl;
+  bool      m_isForcedIdr;
+  bool      m_allowsCodingGap;
 
   void setDefaultGOPEntry()
   {
@@ -904,6 +906,8 @@ typedef struct GOPEntry : vvencGOPEntry
     m_skipFirstPass    = false;
     m_scType           = SCT_NONE;
     m_vtl              = 0;
+    m_isForcedIdr      = false;
+    m_allowsCodingGap  = false;
   }
 
   void copyFromGopCfg( const vvencGOPEntry& cfgEntry )

--- a/source/Lib/EncoderLib/EncGOP.cpp
+++ b/source/Lib/EncoderLib/EncGOP.cpp
@@ -1457,7 +1457,10 @@ void EncGOP::xInitPicsInCodingOrder( const PicList& picList )
     auto pic = (*it);
     // skip pics, which have already been initialized
     if( pic->isInitDone )
+    {
+      m_lastCodingNum = pic->gopEntry->m_codingNum;
       continue;
+    }
 
     // update visual activity for last start of GOP picture
     // this may have been changed in the shared picture data due to fixStartOfLastGop()
@@ -1483,7 +1486,8 @@ void EncGOP::xInitPicsInCodingOrder( const PicList& picList )
     }
 
     // continue with next pic in increasing coding number order
-    if( pic->gopEntry->m_codingNum != m_lastCodingNum + 1 && ! picList.back()->isFlush )
+    if( pic->gopEntry->m_codingNum != m_lastCodingNum + 1 && ! picList.back()->isFlush
+        && ! pic->gopEntry->m_allowsCodingGap && ! picList.back()->gopEntry->m_allowsCodingGap )
       break;
 
     CHECK( m_lastCodingNum == -1 && ! pic->gopEntry->m_isStartOfIntra, "encoding should start with an I-Slice" );

--- a/source/Lib/EncoderLib/EncStage.h
+++ b/source/Lib/EncoderLib/EncStage.h
@@ -71,6 +71,7 @@ public:
   uint8_t          m_minNoiseLevels[QPA_MAX_NOISE_LEVELS];
   std::vector<int> m_ctuBimQpOffset;
   int              m_picAuxQpOffset; // auxiliary QP offset per frame, for combination of RC and BIM (and possibly other tools)
+  bool m_isForcedIdr;
 
 private:
   PelStorage       m_origBuf;
@@ -154,6 +155,7 @@ public:
     m_gopEntry.setDefaultGOPEntry();
 #if VVENC_USE_UNSTABLE_API
     m_userData       = yuvInBuf->userData;
+    m_isForcedIdr = (yuvInBuf->picFlags & VVENC_PIC_FLAG_FORCE_IDR) != 0;
 #endif
   }
 

--- a/source/Lib/EncoderLib/GOPCfg.cpp
+++ b/source/Lib/EncoderLib/GOPCfg.cpp
@@ -168,6 +168,47 @@ void GOPCfg::getNextGopEntry( GOPEntry& gopEntry )
     return;
   }
 
+  if (gopEntry.m_isForcedIdr && !(m_poc0idr && m_nextPoc == 0))
+  {
+    const int prevGopSize = (int)m_gopList->size();
+
+    gopEntry.setDefaultGOPEntry();
+    gopEntry.m_POC = m_nextPoc;
+    gopEntry.m_isForcedIdr = true;
+    gopEntry.m_allowsCodingGap = true;
+    gopEntry.m_isValid = true;
+    startIntraPeriod(gopEntry);
+
+    // ---- Counter adjustments depend on whether poc0idr is set ----
+    //
+    // poc0idr=0: the POC-0 frame already consumed one decrement from both
+    //   counters before the forced-IDR reset.  startIntraPeriod brings both
+    //   back to 15, but only the intra counter needs compensating (shift it
+    //   down by 1 so the intra fires on the same POC as the GOP-boundary
+    //   entry).  The offset must survive GOP rollovers, hence the flag.
+    //
+    // poc0idr=1: the forced IDR itself is the first frame of the new GOP.
+    //   startIntraPeriod already consumed one slot (m_numTillGop=size-1),
+    //   and m_numTillIntra is set to fixIntraPeriod-1.  No further
+    //   adjustments are needed because the forced IDR naturally fills the
+    //   first-GOP-picture slot and resets the intra clock.
+    if (!m_poc0idr && m_fixIntraPeriod > 0)
+    {
+      m_numTillIntra = m_numTillGop - 1;
+      m_hadForcedIdr  = true;
+    }
+
+    const int gopId = 0;
+    m_pocOffset = gopEntry.m_POC;
+    m_gopNum += 1;
+    m_cnOffset += prevGopSize + 1;
+    gopEntry.m_gopNum = m_gopNum;
+    gopEntry.m_codingNum = m_cnOffset + gopId - 1;
+
+    m_nextPoc += 1;
+    return;
+  }
+
   const int  pocInGop   = m_nextPoc - m_pocOffset;
   const int  gopId      = m_pocToGopIdx[ pocInGop % (int)m_pocToGopIdx.size() ];
   const bool isLeading0 = m_poc0idr && m_nextPoc == 0 ? true : false; // for poc0idr, we have a leading poc 0
@@ -198,7 +239,7 @@ void GOPCfg::getNextGopEntry( GOPEntry& gopEntry )
     {
       m_gopList      = &m_defaultGopLists[ 0 ];
       m_nextListIdx  = std::min( 1, (int)m_defaultGopLists.size() - 1 );
-      m_numTillIntra = m_fixIntraPeriod;
+      m_numTillIntra = m_fixIntraPeriod - (m_hadForcedIdr ? 1 : 0);
       m_adjustNoLPcodingOrder = m_refreshType == VVENC_DRT_IDR_NO_RADL && m_fixIntraPeriod <= m_maxGopSize;
     }
     else

--- a/source/Lib/EncoderLib/GOPCfg.cpp
+++ b/source/Lib/EncoderLib/GOPCfg.cpp
@@ -185,11 +185,7 @@ void GOPCfg::getNextGopEntry( GOPEntry& gopEntry )
   // mark start of intra
   if( m_numTillIntra == 0 )
   {
-    gopEntry.m_sliceType      = 'I';
-    gopEntry.m_isStartOfIntra = true;
-    gopEntry.m_temporalId     = 0;
-    gopEntry.m_vtl            = 0;
-    m_lastIntraPOC            = m_nextPoc;
+    xSetIntraEntry(gopEntry);
   }
 
   // check for end of current gop
@@ -243,12 +239,8 @@ void GOPCfg::getNextGopEntry( GOPEntry& gopEntry )
 void GOPCfg::startIntraPeriod( GOPEntry& gopEntry )
 {
   // set gop entry
-  gopEntry.m_sliceType      = 'I';
-  gopEntry.m_isStartOfIntra = true;
-  gopEntry.m_isStartOfGop   = true;
-  gopEntry.m_temporalId     = 0;
-  gopEntry.m_vtl            = 0;
-  m_lastIntraPOC            = gopEntry.m_POC;
+  xSetIntraEntry(gopEntry);
+  gopEntry.m_isStartOfGop = true;
 
   // start with first gop list
   m_gopList      = &m_defaultGopLists[ 0 ];
@@ -271,11 +263,7 @@ void GOPCfg::fixStartOfLastGop( GOPEntry& gopEntry )
   gopEntry.m_isStartOfGop = true;
   if( ! m_poc0idr && gopEntry.m_gopNum == 0 && ! gopEntry.m_isStartOfIntra )
   {
-    gopEntry.m_isStartOfIntra = true;
-    gopEntry.m_sliceType      = 'I';
-    gopEntry.m_temporalId     = 0;
-    gopEntry.m_vtl            = 0;
-    m_lastIntraPOC            = gopEntry.m_POC;
+    xSetIntraEntry(gopEntry);
   }
 }
 
@@ -331,6 +319,15 @@ bool GOPCfg::isChromaDeltaQPEnabled() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void GOPCfg::xSetIntraEntry(GOPEntry &gopEntry)
+{
+  gopEntry.m_isStartOfIntra = true;
+  gopEntry.m_sliceType      = 'I';
+  gopEntry.m_temporalId     = 0;
+  gopEntry.m_vtl            = 0;
+  m_lastIntraPOC            = gopEntry.m_POC;
+}
 
 int GOPCfg::xGetMinPoc( int maxGopSize, const vvencGOPEntry cfgGopList[ VVENC_MAX_GOP ] ) const
 {

--- a/source/Lib/EncoderLib/GOPCfg.h
+++ b/source/Lib/EncoderLib/GOPCfg.h
@@ -166,6 +166,7 @@ class GOPCfg
     int  xGetMaxTid          ( const GOPEntryList& gopList ) const;
     int  xGetMaxRefPics      ( const GOPEntry& gopEntry ) const;
     int  xGetMaxNumReorder   ( const GOPEntry& gopEntry, const GOPEntryList& gopList ) const;
+    void xSetIntraEntry(GOPEntry &gopEntry);
     void xAdjustNoLPcodingOrder( GOPEntry& gopEntry, const int orgGopId ) const;
 };
 

--- a/source/Lib/EncoderLib/GOPCfg.h
+++ b/source/Lib/EncoderLib/GOPCfg.h
@@ -96,6 +96,7 @@ class GOPCfg
     int  m_minIntraDist;
     int  m_lastIntraPOC;
     bool m_adjustNoLPcodingOrder;
+    bool m_hadForcedIdr;
 
   public:
     GOPCfg( MsgLog& _m )
@@ -121,6 +122,7 @@ class GOPCfg
       , m_minIntraDist    ( -1 )
       , m_lastIntraPOC    ( -1 )
       , m_adjustNoLPcodingOrder( false )
+      , m_hadForcedIdr         ( false )
     {
     };
 

--- a/source/Lib/EncoderLib/PreProcess.cpp
+++ b/source/Lib/EncoderLib/PreProcess.cpp
@@ -105,10 +105,34 @@ void PreProcess::processPictures( const PicList& picList, AccessUnitList& auList
   if( ! picList.empty() && picList.back()->poc > m_lastPoc )
   {
     auto pic = picList.back();
+    pic->m_picShared->m_gopEntry.m_isForcedIdr = pic->m_picShared->m_isForcedIdr && !pic->m_picShared->isLeadTrail();
 
     // set gop entry
     m_gopCfg.getNextGopEntry( pic->m_picShared->m_gopEntry );
     CHECK( pic->m_picShared->m_gopEntry.m_POC != pic->poc, "invalid state" );
+    pic->gopEntry = &pic->m_picShared->m_gopEntry;
+
+    const int interruptedGopNum = pic->m_picShared->m_gopEntry.m_isForcedIdr ? pic->m_picShared->m_gopEntry.m_gopNum - 1 : -1;
+    if (interruptedGopNum >= 0)
+    {
+      Picture *interruptedGopStart = nullptr;
+      for (auto queuedPic : picList)
+      {
+        if (queuedPic->gopEntry && queuedPic->gopEntry->m_gopNum == interruptedGopNum)
+        {
+          queuedPic->m_picShared->m_gopEntry.m_allowsCodingGap = true;
+          if (interruptedGopStart == nullptr || queuedPic->gopEntry->m_codingNum < interruptedGopStart->gopEntry->m_codingNum)
+          {
+            interruptedGopStart = queuedPic;
+          }
+        }
+      }
+
+      if (interruptedGopNum == 0 && interruptedGopStart)
+      {
+        m_gopCfg.fixStartOfLastGop(interruptedGopStart->m_picShared->m_gopEntry);
+      }
+    }
 
     if( ! pic->m_picShared->isLeadTrail() )
     {

--- a/source/Lib/vvenc/vvenc.cpp
+++ b/source/Lib/vvenc/vvenc.cpp
@@ -94,6 +94,9 @@ VVENC_DECL void vvenc_YUVBuffer_default(vvencYUVBuffer *yuvBuffer )
   yuvBuffer->sequenceNumber  = 0;
   yuvBuffer->cts             = 0;
   yuvBuffer->ctsValid        = false;
+#if VVENC_USE_UNSTABLE_API
+  yuvBuffer->picFlags = VVENC_PIC_FLAG_NONE;
+#endif
 }
 
 

--- a/test/vvenclibtest/vvenclibtest.cpp
+++ b/test/vvenclibtest/vvenclibtest.cpp
@@ -73,6 +73,7 @@ int testInvalidInputParams();  // input Buffer does not match
 int testSDKDefaultBehaviour(); // check default behaviour when using in sdk
 int testStringApiInterface();  // check behaviour when using in sdk by using string api
 int testTimestamps();          // check behaviour when using in sdk by using string api
+int testForcedPerFrameIdr();   // check per-picture forced IDR behavior
 
 int main( int argc, char* argv[] )
 {
@@ -87,12 +88,24 @@ int main( int argc, char* argv[] )
     else
     {
       testId = atoi(argv[1]);
-      printHelp = ( testId < 1 || testId > 6 );
+      printHelp = (testId < 1 || testId >
+#if VVENC_USE_UNSTABLE_API
+                                     7
+#else
+                                     6
+#endif
+      );
     }
 
     if( printHelp )
     {
-      printf( "venclibtest <test> [1..5]\n");
+      printf("venclibtest <test> [1..%d]\n",
+#if VVENC_USE_UNSTABLE_API
+             7
+#else
+             6
+#endif
+      );
       return -1;
     }
   }
@@ -133,6 +146,13 @@ int main( int argc, char* argv[] )
     testTimestamps();
     break;
   }
+#if VVENC_USE_UNSTABLE_API
+  case 7:
+  {
+    testForcedPerFrameIdr();
+    break;
+  }
+#endif
   default:
     testLibParameterRanges();
     testLibCallingOrder();
@@ -140,6 +160,9 @@ int main( int argc, char* argv[] )
     testSDKDefaultBehaviour();
     testStringApiInterface();
     testTimestamps();
+#if VVENC_USE_UNSTABLE_API
+    testForcedPerFrameIdr();
+#endif
     break;
   }
 
@@ -203,6 +226,228 @@ void fillInputPic( vvencYUVBuffer* pcYuvBuffer, const short val = 512 )
     std::fill_n( static_cast<short*> (pcYuvBuffer->planes[n].ptr), size, val );
   }
 }
+
+#if VVENC_USE_UNSTABLE_API
+static bool isVclNalType(vvencNalUnitType nalType)
+{
+  switch (nalType)
+  {
+  case VVENC_NAL_UNIT_CODED_SLICE_TRAIL:
+  case VVENC_NAL_UNIT_CODED_SLICE_STSA:
+  case VVENC_NAL_UNIT_CODED_SLICE_RADL:
+  case VVENC_NAL_UNIT_CODED_SLICE_RASL:
+  case VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL:
+  case VVENC_NAL_UNIT_CODED_SLICE_IDR_N_LP:
+  case VVENC_NAL_UNIT_CODED_SLICE_CRA:
+  case VVENC_NAL_UNIT_CODED_SLICE_GDR:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static vvencNalUnitType findFirstVclNalType(const vvencAccessUnit *accessUnit)
+{
+  if (!accessUnit || !accessUnit->payload || accessUnit->payloadUsedSize < 2)
+  {
+    return VVENC_NAL_UNIT_INVALID;
+  }
+
+  const unsigned char *payload = accessUnit->payload;
+  const int payloadSize = accessUnit->payloadUsedSize;
+  for (int offset = 0; offset + 4 < payloadSize; ++offset)
+  {
+    const bool startCode3 = payload[offset] == 0 && payload[offset + 1] == 0 && payload[offset + 2] == 1;
+    const bool startCode4 = startCode3 ? false : payload[offset] == 0 && payload[offset + 1] == 0 && payload[offset + 2] == 0 && payload[offset + 3] == 1;
+    if (!startCode3 && !startCode4)
+    {
+      continue;
+    }
+
+    const int headerOffset = offset + (startCode4 ? 4 : 3);
+    if (headerOffset + 1 >= payloadSize)
+    {
+      break;
+    }
+
+    const vvencNalUnitType nalType = static_cast<vvencNalUnitType>(payload[headerOffset + 1] >> 3);
+    if (isVclNalType(nalType))
+    {
+      return nalType;
+    }
+  }
+
+  return VVENC_NAL_UNIT_INVALID;
+}
+
+static int checkForcedPerFrameIdr(vvencDecodingRefreshType refreshType, vvencNalUnitType expectedNalType, uint64_t forcedPoc, int poc0idr = 1)
+{
+  vvencEncoder *enc = nullptr;
+  vvencAccessUnit *AU = nullptr;
+  vvencYUVBuffer *yuvPicture = nullptr;
+
+  auto failWith = [&](const std::string &reason)
+  {
+    if (g_verbose)
+    {
+      std::cerr << "\ncheckForcedPerFrameIdr failed: refreshType=" << refreshType
+                << " forcedPoc=" << forcedPoc
+                << " reason=" << reason;
+    }
+
+    if (yuvPicture)
+    {
+      vvenc_YUVBuffer_free(yuvPicture, true);
+    }
+    if (AU)
+    {
+      vvenc_accessUnit_free(AU, true);
+    }
+    if (enc)
+    {
+      vvenc_encoder_close(enc);
+    }
+
+    return -1;
+  };
+
+  vvenc_config vvencParams;
+  vvenc_config_default(&vvencParams);
+  fillEncoderParameters(vvencParams, false);
+  vvencParams.m_GOPSize = 16;
+  vvencParams.m_IntraPeriod = -1;
+  vvencParams.m_DecodingRefreshType = refreshType;
+  vvencParams.m_picReordering = refreshType != VVENC_DRT_NONE;
+  vvencParams.m_poc0idr = poc0idr;
+  vvencParams.m_usePerceptQPA = false;
+  vvencParams.m_GOPQPA = 0;
+  vvencParams.m_framesToBeEncoded = 0;
+  vvencParams.m_numThreads = 1;
+  vvencParams.m_GOPList[0].m_POC = -1;
+
+  if (vvenc_init_config_parameter(&vvencParams))
+  {
+    return failWith("vvenc_init_config_parameter failed");
+  }
+
+  enc = vvenc_encoder_create();
+  if (nullptr == enc)
+  {
+    return failWith("vvenc_encoder_create returned null");
+  }
+
+  if (0 != vvenc_encoder_open(enc, &vvencParams))
+  {
+    return failWith("vvenc_encoder_open failed");
+  }
+
+  AU = vvenc_accessUnit_alloc();
+  if( nullptr == AU )
+  {
+    return failWith("vvenc_accessUnit_alloc returned null");
+  }
+  vvenc_accessUnit_alloc_payload(AU, vvencParams.m_SourceWidth * vvencParams.m_SourceHeight * 2);
+  if( nullptr == AU->payload )
+  {
+    return failWith("vvenc_accessUnit_alloc_payload returned null payload");
+  }
+
+  yuvPicture = vvenc_YUVBuffer_alloc();
+  if( nullptr == yuvPicture )
+  {
+    return failWith("vvenc_YUVBuffer_alloc returned null");
+  }
+  vvenc_YUVBuffer_alloc_buffer(yuvPicture, vvencParams.m_internChromaFormat, vvencParams.m_SourceWidth, vvencParams.m_SourceHeight);
+
+  const uint64_t forcedGopLastPoc = forcedPoc + vvencParams.m_GOPSize - 1;
+  const uint64_t nextGopStartPoc = forcedPoc + vvencParams.m_GOPSize;
+  const uint64_t finalExpectedPoc = nextGopStartPoc + 1;
+  const int framesToEncode = 50;
+  int framesRcvd = 0;
+  int auCount = 0;
+  bool eof = false;
+  bool encodeDone = false;
+  bool sawForcedAu = false;
+  bool sawForcedGopComplete = false;
+  std::unordered_set<uint64_t> outputPocs;
+
+  while (!eof || !encodeDone)
+  {
+    vvencYUVBuffer *inputPtr = nullptr;
+    if (!eof)
+    {
+      inputPtr = yuvPicture;
+      fillInputPic(yuvPicture, static_cast<short>(256 + framesRcvd * 4));
+      yuvPicture->cts = static_cast<int64_t>(framesRcvd);
+      yuvPicture->ctsValid = true;
+      yuvPicture->picFlags = framesRcvd == forcedPoc ? VVENC_PIC_FLAG_FORCE_IDR : VVENC_PIC_FLAG_NONE;
+      framesRcvd++;
+    }
+
+    if (0 != vvenc_encode(enc, inputPtr, AU, &encodeDone))
+    {
+      return failWith("vvenc_encode returned error");
+    }
+
+    if (AU->payloadUsedSize > 0)
+    {
+      auCount++;
+      if (!outputPocs.insert(AU->poc).second)
+      {
+        return failWith("duplicate output poc");
+      }
+
+      const vvencNalUnitType nalType = findFirstVclNalType(AU);
+      if (nalType == VVENC_NAL_UNIT_INVALID)
+      {
+        return failWith("invalid first VCL nal type");
+      }
+
+      if (AU->poc == forcedPoc)
+      {
+        if (sawForcedAu)
+        {
+          return failWith("forced AU emitted more than once");
+        }
+        sawForcedAu = true;
+        if (!AU->rap || AU->sliceType != VVENC_I_SLICE || nalType != expectedNalType)
+        {
+          return failWith("forced AU properties mismatch: rap=" + std::to_string(AU->rap) + " sliceType=" + std::to_string(AU->sliceType) + " nalType=" + std::to_string(nalType) + " expectedNalType=" + std::to_string(expectedNalType));
+        }
+      }
+
+      if (AU->poc == forcedGopLastPoc)
+      {
+        sawForcedGopComplete = true;
+      }
+    }
+
+    if (framesRcvd >= framesToEncode)
+    {
+      eof = true;
+    }
+  }
+
+  for (uint64_t poc = forcedPoc; poc <= finalExpectedPoc; ++poc)
+  {
+    if (outputPocs.count(poc) == 0)
+    {
+      return failWith("missing output poc in forced window");
+    }
+  }
+
+  if (auCount != framesToEncode || !sawForcedAu || !sawForcedGopComplete || outputPocs.count(nextGopStartPoc) == 0)
+  {
+    return failWith("final forced GOP completeness check failed");
+  }
+
+  vvenc_YUVBuffer_free(yuvPicture, true);
+  vvenc_accessUnit_free(AU, true);
+  vvenc_encoder_close(enc);
+  return 0;
+}
+
+#endif
 
 template< typename T, typename V = int>
 int testParamList( const std::string& w, T& testParam, vvenc_config& vvencParams, const std::vector<V>& testValues, const bool expectedFail = false )
@@ -361,9 +606,26 @@ int testfunc( const std::string& w, int (*funcCallingOrder)(void), const bool ex
     // initialize the encoder
     TESTT( expectedFail == (0 == funcCallingOrder()),  "\n" << w << " expected " << (expectedFail ? "failure" : "success"));
   }
-  catch(...)
+  catch (const std::exception &exc)
   {
-    ERROR("\nCaught Exception " << w << " expected " << (expectedFail ? "failure" : "success")); //fail due to exception 
+    ERROR("\nCaught Exception " << w << " expected " << (expectedFail ? "failure" : "success") << " exception: " << exc.what()); // fail due to exception
+  }
+
+  return (numFails == g_numFails) ? 0 : 1;
+}
+
+template <typename Func>
+int testfunc(const std::string &w, Func funcCallingOrder, const bool expectedFail = false)
+{
+  const int numFails = g_numFails;
+
+  try
+  {
+    TESTT(expectedFail == (0 == funcCallingOrder()), "\n" << w << " expected " << (expectedFail ? "failure" : "success"));
+  }
+  catch (const std::exception &exc)
+  {
+    ERROR("\nCaught Exception " << w << " expected " << (expectedFail ? "failure" : "success") << " exception: " << exc.what()); // fail due to exception
   }
 
   return (numFails == g_numFails) ? 0 : 1;
@@ -1192,6 +1454,81 @@ int testTimestamps()
 
   return 0;
 }
+
+#if VVENC_USE_UNSTABLE_API
+int testForcedPerFrameIdr()
+{
+  // With poc0idr=1, the first RAP is not upgraded to IDR_W_RADL, so the forced IDR will be at the exact position specified
+  for (int i : {1, 2, 5, 8, 15})
+  {
+    testfunc("checkForcedPerFrameIdrCra_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA, VVENC_NAL_UNIT_CODED_SLICE_CRA, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrIdr_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR, VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrCraCre_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA_CRE, VVENC_NAL_UNIT_CODED_SLICE_CRA, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrNoRadl_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR_NO_RADL, VVENC_NAL_UNIT_CODED_SLICE_IDR_N_LP, i, 1); }, false);
+  }
+
+  // with poc0idr=1
+  for (int i : {16, 17, 20, 31})
+  {
+    testfunc("checkForcedPerFrameIdrCra_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA, VVENC_NAL_UNIT_CODED_SLICE_CRA, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrIdr_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR, VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrCraCre_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA_CRE, VVENC_NAL_UNIT_CODED_SLICE_CRA, i, 1); }, false);
+    testfunc("checkForcedPerFrameIdrNoRadl_poc0idr=1_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR_NO_RADL, VVENC_NAL_UNIT_CODED_SLICE_IDR_N_LP, i, 1); }, false);
+  }
+
+  // With poc0idr=0
+  // if poc0idr=0 and no prior IDR has occurred, EncGOP::xGetNalUnitType() upgrades that first RAP to IDR_W_RADL
+  for (int i : {1, 2, 5, 8})
+  {
+    const vvencNalUnitType expectedCraNal = i == 1 ? VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL : VVENC_NAL_UNIT_CODED_SLICE_CRA;
+
+    testfunc("checkForcedPerFrameIdrCra_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA, expectedCraNal, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrIdr_poc0idr=0_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR, VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrCraCre_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA_CRE, expectedCraNal, i, 0); }, false);
+  }
+
+  // Force an IDR in after the initial GOP is completed
+  // with poc0idr=0
+  for (int i : {16, 17, 20})
+  {
+    const vvencNalUnitType expectedCraNal = i == 1 ? VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL : VVENC_NAL_UNIT_CODED_SLICE_CRA;
+
+    testfunc("checkForcedPerFrameIdrCra_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA, expectedCraNal, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrIdr_poc0idr=0_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR, VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrCraCre_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA_CRE, expectedCraNal, i, 0); }, false);
+  }
+  return 0;
+
+  // FIXME: Failing tests
+  // With poc0idr=0
+  // if poc0idr=0 and no prior IDR has occurred, EncGOP::xGetNalUnitType() upgrades that first RAP to IDR_W_RADL
+  for (int i : {15, 31})
+  {
+    const vvencNalUnitType expectedCraNal = i == 1 ? VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL : VVENC_NAL_UNIT_CODED_SLICE_CRA;
+
+    testfunc("checkForcedPerFrameIdrCra_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA, expectedCraNal, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrIdr_poc0idr=0_forcedIdr=" + std::to_string(i), [i]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_IDR, VVENC_NAL_UNIT_CODED_SLICE_IDR_W_RADL, i, 0); }, false);
+    testfunc("checkForcedPerFrameIdrCraCre_poc0idr=0_forcedIdr=" + std::to_string(i), [i, expectedCraNal]()
+             { return checkForcedPerFrameIdr(VVENC_DRT_CRA_CRE, expectedCraNal, i, 0); }, false);
+  }
+}
+#endif
 
 int inputBufTest( vvencYUVBuffer* pcYuvPicture )
 {


### PR DESCRIPTION
Introduce `VVENC_PIC_FLAG_FORCE_IDR` on `vvencYUVBuffer`, and thread the request through preprocessing and GOP handling so that a selected input frame is encoded as a forced IDR/CRA picture, respecting the configured refresh type.

I tried to mimic the API of other encoders that use per-picture flags to define optional encode requests.

The new API is only enabled with `VVENC_USE_UNSTABLE_API`.

Unit tests have been added for the new behavior.

Fixes #311