### PR TITLE
Arm: Add Neon implementation for gnsSolveByChol

### DIFF
--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -60,6 +60,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/AffineGradientSearch.h"
 #include "CommonLib/AdaptiveLoopFilter.h"
 #include "CommonLib/SampleAdaptiveOffset.h"
+#include "EncoderLib/EncAdaptiveLoopFilter.h"
 
 namespace vvenc
 {
@@ -73,6 +74,15 @@ void AdaptiveLoopFilter::initAdaptiveLoopFilterARM()
   if( vext >= NEON )
   {
     _initAdaptiveLoopFilterARM<NEON>();
+  }
+}
+
+void AlfCovariance::initAlfCovarianceARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initAlfCovarianceARM<NEON>();
   }
 }
 #endif

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
@@ -147,7 +147,7 @@ alf_float_t AlfCovariance::optimizeFilter(const AlfFilterShape& alfShape, int* c
 
   setEyFromClip( clip, kE, ky, size );
 
-  gnsSolveByChol( kE, ky, f, size );
+  m_gnsSolveByChol( kE, ky, f, size );
   err_best = calculateError( clip, f, size );
 
   int step = optimize_clip ? (numBins+1)/2 : 0;
@@ -170,7 +170,7 @@ alf_float_t AlfCovariance::optimizeFilter(const AlfFilterShape& alfShape, int* c
           kE[l][k] = E[clip[l]][clip[k]][l][k];
         }
 
-        gnsSolveByChol( kE, ky, f, size );
+        m_gnsSolveByChol( kE, ky, f, size );
         err_last = calculateError( clip, f, size );
 
         if( err_last < err_min )
@@ -191,7 +191,7 @@ alf_float_t AlfCovariance::optimizeFilter(const AlfFilterShape& alfShape, int* c
           kE[l][k] = E[clip[l]][clip[k]][l][k];
         }
 
-        gnsSolveByChol( kE, ky, f, size );
+        m_gnsSolveByChol( kE, ky, f, size );
         err_last = calculateError( clip, f, size );
 
         if( err_last < err_min )
@@ -238,7 +238,7 @@ alf_float_t AlfCovariance::optimizeFilter(const AlfFilterShape& alfShape, int* c
     Ty ky_max;
     setEyFromClip( clip_max, kE_max, ky_max, size );
 
-    gnsSolveByChol( kE_max, ky_max, f, size );
+    m_gnsSolveByChol( kE_max, ky_max, f, size );
     err_last = calculateError( clip_max, f, size );
     if( err_last < err_best )
     {
@@ -254,7 +254,7 @@ alf_float_t AlfCovariance::optimizeFilter(const AlfFilterShape& alfShape, int* c
       reduceClipCost(alfShape, clip);
 
       // update f with best solution
-      gnsSolveByChol( kE, ky, f, size );
+      m_gnsSolveByChol( kE, ky, f, size );
     }
   }
 
@@ -982,7 +982,7 @@ int AlfCovariance::gnsSolveByChol( const int *clip, alf_float_t*x, int numEq ) c
   Ty rhs;
 
   setEyFromClip( clip, LHS, rhs, numEq );
-  return gnsSolveByChol( LHS, rhs, x, numEq );
+  return m_gnsSolveByChol( LHS, rhs, x, numEq );
 }
 
 template<int NumEq>
@@ -1037,7 +1037,7 @@ static int solveByChol( AlfCovariance::TE LHS, alf_float_t* rhs, alf_float_t*x )
   return res;
 }
 
-int AlfCovariance::gnsSolveByChol( TE LHS, alf_float_t* rhs, alf_float_t*x, int numEq ) const
+int AlfCovariance::gnsSolveByChol( TE LHS, alf_float_t* rhs, alf_float_t*x, int numEq )
 {
   if( numEq == 7 )
   {
@@ -5421,7 +5421,7 @@ void EncAdaptiveLoopFilter::deriveCcAlfFilterCoeff( ComponentID compID, short fi
     }
   }
 
-  m_alfCovarianceFrameCcAlf[compID - 1][filterIdx].gnsSolveByChol(kE, ky, filterCoeffDbl, size);
+  m_alfCovarianceFrameCcAlf[compID - 1][filterIdx].m_gnsSolveByChol( kE, ky, filterCoeffDbl, size );
   roundFiltCoeffCCALF(filterCoeffInt, filterCoeffDbl, size, (1 << m_scaleBits));
 
   for (int k = 0; k < size; k++)

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
@@ -81,15 +81,18 @@ public:
 
   int ( *m_gnsSolveByChol )( AlfCovariance::TE LHS, alf_float_t* rhs, alf_float_t* x, int numEq );
 
-  AlfCovariance() : numBins( -1 ), _numBinsAlloc( -1 ), y( nullptr ), E( nullptr ), all0( true )
+  AlfCovariance( bool enableOpt = true ) : numBins( -1 ), _numBinsAlloc( -1 ), y( nullptr ), E( nullptr ), all0( true )
   {
     m_gnsSolveByChol = &AlfCovariance::gnsSolveByChol;
 
+    if( enableOpt )
+    {
 #if ENABLE_SIMD_OPT_ALF
 #ifdef TARGET_SIMD_ARM
-    initAlfCovarianceARM();
+      initAlfCovarianceARM();
 #endif
 #endif
+    }
   }
   ~AlfCovariance() { }
 

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
@@ -79,8 +79,25 @@ public:
   alf_float_t pixAcc;
   bool all0;
 
-  AlfCovariance() : numBins( -1 ), _numBinsAlloc( -1 ), y( nullptr ), E( nullptr ), all0( true ) {}
+  int ( *m_gnsSolveByChol )( AlfCovariance::TE LHS, alf_float_t* rhs, alf_float_t* x, int numEq );
+
+  AlfCovariance() : numBins( -1 ), _numBinsAlloc( -1 ), y( nullptr ), E( nullptr ), all0( true )
+  {
+    m_gnsSolveByChol = &AlfCovariance::gnsSolveByChol;
+
+#if ENABLE_SIMD_OPT_ALF
+#ifdef TARGET_SIMD_ARM
+    initAlfCovarianceARM();
+#endif
+#endif
+  }
   ~AlfCovariance() { }
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
+  void initAlfCovarianceARM();
+  template<ARM_VEXT vext>
+  void _initAlfCovarianceARM();
+#endif
 
   void create( int size, int num_bins )
   {
@@ -303,7 +320,7 @@ public:
 
   void getClipMax          ( const AlfFilterShape& alfShape, int *clip_max) const;
   void reduceClipCost      ( const AlfFilterShape& alfShape, int *clip) const;
-  int  gnsSolveByChol              ( TE LHS, alf_float_t* rhs, alf_float_t*x, int numEq ) const;
+  static int gnsSolveByChol( TE LHS, alf_float_t* rhs, alf_float_t* x, int numEq );
 
 private:
   // Cholesky decomposition

--- a/source/Lib/EncoderLib/arm/neon/EncAdaptiveLoopFilter_neon.cpp
+++ b/source/Lib/EncoderLib/arm/neon/EncAdaptiveLoopFilter_neon.cpp
@@ -1,0 +1,486 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/**
+ * \file EncAdaptiveLoopFilter_neon.cpp
+ * \brief Neon helpers for encoder-side adaptive loop filter code.
+ */
+
+#include "EncoderLib/EncAdaptiveLoopFilter.h"
+#include <arm_neon.h>
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
+
+namespace vvenc
+{
+
+#define REG alf_float_t( 0.0001 )
+#define REG_SQR alf_float_t( 0.0000001 )
+
+template<int NumEq>
+static bool checkForZero( const AlfCovariance::TE lhs, const alf_float_t* rhs )
+{
+  for( int i = 0; i < NumEq; i++ )
+  {
+    if( rhs[i] != 0.0f )
+    {
+      return false;
+    }
+    for( int j = 0; j < NumEq; j++ )
+    {
+      if( lhs[i][j] != 0.0f )
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+template<int NumEq>
+static int gnsCholeskyDec_neon( const AlfCovariance::TE inpMatr, AlfCovariance::TE outMatr );
+
+template<>
+int gnsCholeskyDec_neon<7>( const AlfCovariance::TE inpMatr, AlfCovariance::TE outMatr )
+{
+  static constexpr int NumEq = 7;
+  for( int i = 0; i < NumEq; i++ )
+  {
+    alf_float_t invDiag = 0.0f;
+
+    for( int j = i; j < NumEq; j++ )
+    {
+      // Compute the scaling factor.
+      alf_float_t scale = inpMatr[i][j];
+      if( i > 0 )
+      {
+        for( int k = i - 1; k >= 0; k-- )
+        {
+          scale -= outMatr[k][j] * outMatr[k][i];
+        }
+      }
+
+      // Compute i'th row of outMatr.
+      if( i == j )
+      {
+        if( scale <= REG_SQR ) // If inpMatr is singular.
+        {
+          return 0;
+        }
+        else
+        {
+          // Normal operation.
+          invDiag = alf_float_t( 1.0 ) / ( outMatr[i][i] = sqrtf( scale ) );
+        }
+      }
+      else
+      {
+        outMatr[i][j] = scale * invDiag;    // Upper triangular part.
+        outMatr[j][i] = alf_float_t( 0.0 ); // Lower triangular part set to 0.
+      }
+    }
+  }
+  return 1; // Signal that Cholesky factorization is successfully performed.
+}
+
+template<int Row>
+static inline bool choleskyStep13( const AlfCovariance::TE inpMatr, AlfCovariance::TE outMatr )
+{
+  static constexpr int NumEq = 13;
+
+  // Computes scale from inpMatr[Row][Row] and outMatr[0..Row-1][Row].
+  alf_float_t scale = inpMatr[Row][Row];
+
+  for( int k = Row - 1; k >= 0; --k )
+  {
+    scale -= outMatr[k][Row] * outMatr[k][Row];
+  }
+
+  if( scale <= REG_SQR )
+  {
+    return false;
+  }
+
+  // Updates outMatr[Row][Row] and outMatr[Row][Row+1..12].
+  outMatr[Row][Row] = sqrtf( scale );
+  const alf_float_t invDiag = alf_float_t( 1.0 ) / outMatr[Row][Row];
+
+  if( Row % 4 == 0 )
+  {
+    for( int j = Row + 1; j < NumEq; j += 4 )
+    {
+      float32x4_t scale = vld1q_f32( &inpMatr[Row][j] );
+
+      for( int k = Row - 1; k >= 0; k -= 4 )
+      {
+        const float32x4_t v1 = vld1q_f32( &outMatr[k][j] );
+        const float32x4_t v2 = vld1q_f32( &outMatr[k - 1][j] );
+        const float32x4_t v3 = vld1q_f32( &outMatr[k - 2][j] );
+        const float32x4_t v4 = vld1q_f32( &outMatr[k - 3][j] );
+
+        scale = vmlsq_n_f32( scale, v1, outMatr[k][Row] );
+        scale = vmlsq_n_f32( scale, v2, outMatr[k - 1][Row] );
+        scale = vmlsq_n_f32( scale, v3, outMatr[k - 2][Row] );
+        scale = vmlsq_n_f32( scale, v4, outMatr[k - 3][Row] );
+      }
+
+      const float32x4_t out = vmulq_n_f32( scale, invDiag );
+      vst1q_f32( &outMatr[Row][j], out );
+    }
+  }
+  else if( Row % 2 == 0 )
+  {
+    for( int j = Row + 1; j < NumEq; j += 2 )
+    {
+      float32x2_t scale = vld1_f32( &inpMatr[Row][j] );
+
+      for( int k = Row - 1; k >= 0; k -= 2 )
+      {
+        const float32x2_t v1 = vld1_f32( &outMatr[k][j] );
+        const float32x2_t v2 = vld1_f32( &outMatr[k - 1][j] );
+
+        scale = vmls_n_f32( scale, v1, outMatr[k][Row] );
+        scale = vmls_n_f32( scale, v2, outMatr[k - 1][Row] );
+      }
+
+      const float32x2_t out = vmul_n_f32( scale, invDiag );
+      vst1_f32( &outMatr[Row][j], out );
+    }
+  }
+  else
+  {
+    for( int j = Row + 1; j < NumEq; j++ )
+    {
+      alf_float_t scale = inpMatr[Row][j];
+      for( int k = Row - 1; k >= 0; k-- )
+      {
+        scale -= outMatr[k][j] * outMatr[k][Row];
+      }
+      outMatr[Row][j] = scale * invDiag;
+    }
+  }
+  return true;
+}
+
+template<>
+int gnsCholeskyDec_neon<13>( const AlfCovariance::TE inpMatr, AlfCovariance::TE outMatr )
+{
+  static constexpr int NumEq = 13;
+
+  if( !choleskyStep13<0>( inpMatr, outMatr ) || !choleskyStep13<1>( inpMatr, outMatr ) ||
+      !choleskyStep13<2>( inpMatr, outMatr ) || !choleskyStep13<3>( inpMatr, outMatr ) ||
+      !choleskyStep13<4>( inpMatr, outMatr ) || !choleskyStep13<5>( inpMatr, outMatr ) ||
+      !choleskyStep13<6>( inpMatr, outMatr ) || !choleskyStep13<7>( inpMatr, outMatr ) ||
+      !choleskyStep13<8>( inpMatr, outMatr ) || !choleskyStep13<9>( inpMatr, outMatr ) ||
+      !choleskyStep13<10>( inpMatr, outMatr ) || !choleskyStep13<11>( inpMatr, outMatr ) ||
+      !choleskyStep13<12>( inpMatr, outMatr ) )
+  {
+    return 0;
+  }
+
+  // Lower triangular part set to 0.
+  for( int i = 1; i < NumEq; ++i )
+  {
+    for( int j = 0; j < i; ++j )
+    {
+      outMatr[i][j] = alf_float_t( 0.0 );
+    }
+  }
+
+  return 1; // Signal that Cholesky factorization is successfully performed.
+}
+
+template<int order>
+static void gnsTransposeBacksubstitution_neon( const AlfCovariance::TE U, const alf_float_t* rhs, alf_float_t* x );
+
+template<>
+void gnsTransposeBacksubstitution_neon<7>( const AlfCovariance::TE U, const alf_float_t* rhs, alf_float_t* x )
+{
+  x[0] = rhs[0] / U[0][0];
+  alf_float_t s1 = x[0] * U[0][1];
+  alf_float_t s2 = x[0] * U[0][2];
+  alf_float_t s3 = x[0] * U[0][3];
+  alf_float_t s4 = x[0] * U[0][4];
+  alf_float_t s5 = x[0] * U[0][5];
+  alf_float_t s6 = x[0] * U[0][6];
+
+  // sum = x[0] * U[0][1];
+  x[1] = ( rhs[1] - s1 ) / U[1][1];
+  s2 += x[1] * U[1][2];
+  s3 += x[1] * U[1][3];
+  s4 += x[1] * U[1][4];
+  s5 += x[1] * U[1][5];
+  s6 += x[1] * U[1][6];
+
+  // sum = x[0] * U[0][2] + x[1] * U[1][2];
+  x[2] = ( rhs[2] - s2 ) / U[2][2];
+  s3 += x[2] * U[2][3];
+  s4 += x[2] * U[2][4];
+  s5 += x[2] * U[2][5];
+  s6 += x[2] * U[2][6];
+
+  // sum = x[0] * U[0][3] + x[1] * U[1][3] + x[2] * U[2][3];
+  x[3] = ( rhs[3] - s3 ) / U[3][3];
+  s4 += x[3] * U[3][4];
+  s5 += x[3] * U[3][5];
+  s6 += x[3] * U[3][6];
+
+  // sum = x[0] * U[0][4] + x[1] * U[1][4] + x[2] * U[2][4] + x[3] * U[3][4];
+  x[4] = ( rhs[4] - s4 ) / U[4][4];
+  s5 += x[4] * U[4][5];
+  s6 += x[4] * U[4][6];
+
+  // sum = x[0] * U[0][5] + x[1] * U[1][5] + x[2] * U[2][5] + x[3] * U[3][5] + x[4] * U[4][5];
+  x[5] = ( rhs[5] - s5 ) / U[5][5];
+  s6 += x[5] * U[5][6];
+
+  // sum = x[0] * U[0][6] + x[1] * U[1][6] + x[2] * U[2][6] + x[3] * U[3][6] + x[4] * U[4][6] + x[5] * U[5][6];
+  x[6] = ( rhs[6] - s6 ) / U[6][6];
+}
+
+static inline void accum4( float32x4_t& acc, const alf_float_t* u, const alf_float_t x )
+{
+  const float32x4_t uv = vld1q_f32( u );
+  acc = vmlaq_n_f32( acc, uv, x );
+}
+
+template<>
+void gnsTransposeBacksubstitution_neon<13>( const AlfCovariance::TE U, const alf_float_t* rhs, alf_float_t* x )
+{
+  float32x4_t sum1 = vdupq_n_f32( 0.0f );
+  float32x4_t sum2 = vdupq_n_f32( 0.0f );
+  float32x4_t sum3 = vdupq_n_f32( 0.0f );
+
+  x[0] = rhs[0] / U[0][0];
+  accum4( sum1, &U[0][1], x[0] );
+  accum4( sum2, &U[0][5], x[0] );
+  accum4( sum3, &U[0][9], x[0] );
+
+  alf_float_t s1 = vgetq_lane_f32( sum1, 0 );
+  alf_float_t s2 = vgetq_lane_f32( sum1, 1 );
+  alf_float_t s3 = vgetq_lane_f32( sum1, 2 );
+  alf_float_t s4 = vgetq_lane_f32( sum1, 3 );
+
+  // sum = x[0] * U[0][1];
+  x[1] = ( rhs[1] - s1 ) / U[1][1];
+  s2 += x[1] * U[1][2];
+  s3 += x[1] * U[1][3];
+  s4 += x[1] * U[1][4];
+  accum4( sum2, &U[1][5], x[1] );
+  accum4( sum3, &U[1][9], x[1] );
+
+  // sum = x[0] * U[0][2] + x[1] * U[1][2];
+  x[2] = ( rhs[2] - s2 ) / U[2][2];
+  s3 += x[2] * U[2][3];
+  s4 += x[2] * U[2][4];
+  accum4( sum2, &U[2][5], x[2] );
+  accum4( sum3, &U[2][9], x[2] );
+
+  // sum = x[0] * U[0][3] + x[1] * U[1][3] + x[2] * U[2][3];
+  x[3] = ( rhs[3] - s3 ) / U[3][3];
+  s4 += x[3] * U[3][4];
+  accum4( sum2, &U[3][5], x[3] );
+  accum4( sum3, &U[3][9], x[3] );
+
+  // sum = x[0] * U[0][4] + x[1] * U[1][4] + x[2] * U[2][4] + x[3] * U[3][4];
+  x[4] = ( rhs[4] - s4 ) / U[4][4];
+  accum4( sum2, &U[4][5], x[4] );
+  accum4( sum3, &U[4][9], x[4] );
+
+  alf_float_t s5 = vgetq_lane_f32( sum2, 0 );
+  alf_float_t s6 = vgetq_lane_f32( sum2, 1 );
+  alf_float_t s7 = vgetq_lane_f32( sum2, 2 );
+  alf_float_t s8 = vgetq_lane_f32( sum2, 3 );
+
+  // sum = x[0] * U[0][5] + x[1] * U[1][5] + x[2] * U[2][5] + x[3] * U[3][5] + x[4] * U[4][5];
+  x[5] = ( rhs[5] - s5 ) / U[5][5];
+  s6 += x[5] * U[5][6];
+  s7 += x[5] * U[5][7];
+  s8 += x[5] * U[5][8];
+  accum4( sum3, &U[5][9], x[5] );
+
+  // sum = x[0] * U[0][6] + x[1] * U[1][6] + x[2] * U[2][6] + x[3] * U[3][6] + x[4] * U[4][6] + x[5] * U[5][6];
+  x[6] = ( rhs[6] - s6 ) / U[6][6];
+  s7 += x[6] * U[6][7];
+  s8 += x[6] * U[6][8];
+  accum4( sum3, &U[6][9], x[6] );
+
+  // sum = x[0] * U[0][7] + x[1] * U[1][7] + x[2] * U[2][7] + x[3] * U[3][7] + x[4] * U[4][7] + x[5] * U[5][7] +
+  //             x[6] * U[6][7];
+  x[7] = ( rhs[7] - s7 ) / U[7][7];
+  s8 += x[7] * U[7][8];
+  accum4( sum3, &U[7][9], x[7] );
+
+  // sum = x[0] * U[0][8] + x[1] * U[1][8] + x[2] * U[2][8] + x[3] * U[3][8] + x[4] * U[4][8] + x[5] * U[5][8] +
+  //             x[6] * U[6][8] + x[7] * U[7][8];
+  x[8] = ( rhs[8] - s8 ) / U[8][8];
+  accum4( sum3, &U[8][9], x[8] );
+
+  alf_float_t s9 = vgetq_lane_f32( sum3, 0 );
+  alf_float_t s10 = vgetq_lane_f32( sum3, 1 );
+  alf_float_t s11 = vgetq_lane_f32( sum3, 2 );
+  alf_float_t s12 = vgetq_lane_f32( sum3, 3 );
+
+  // sum = x[0] * U[0][9] + x[1] * U[1][9] + x[2] * U[2][9] + x[3] * U[3][9] + x[4] * U[4][9] + x[5] * U[5][9] +
+  //             x[6] * U[6][9] + x[7] * U[7][9] + x[8] * U[8][9];
+  x[9] = ( rhs[9] - s9 ) / U[9][9];
+  s10 += x[9] * U[9][10];
+  s11 += x[9] * U[9][11];
+  s12 += x[9] * U[9][12];
+
+  // sum = x[0] * U[0][10] + x[1] * U[1][10] + x[2] * U[2][10] + x[3] * U[3][10] + x[4] * U[4][10] +
+  //              x[5] * U[5][10] + x[6] * U[6][10] + x[7] * U[7][10] + x[8] * U[8][10] + x[9] * U[9][10];
+  x[10] = ( rhs[10] - s10 ) / U[10][10];
+  s11 += x[10] * U[10][11];
+  s12 += x[10] * U[10][12];
+
+  // sum = x[0] * U[0][11] + x[1] * U[1][11] + x[2] * U[2][11] + x[3] * U[3][11] + x[4] * U[4][11] +
+  //              x[5] * U[5][11] + x[6] * U[6][11] + x[7] * U[7][11] + x[8] * U[8][11] + x[9] * U[9][11] +
+  //              x[10] * U[10][11];
+  x[11] = ( rhs[11] - s11 ) / U[11][11];
+  s12 += x[11] * U[11][12];
+
+  // sum = x[0] * U[0][12] + x[1] * U[1][12] + x[2] * U[2][12] + x[3] * U[3][12] + x[4] * U[4][12] +
+  //              x[5] * U[5][12] + x[6] * U[6][12] + x[7] * U[7][12] + x[8] * U[8][12] + x[9] * U[9][12] +
+  //              x[10] * U[10][12] + x[11] * U[11][12];
+  x[12] = ( rhs[12] - s12 ) / U[12][12];
+}
+
+template<int NumEq>
+static void gnsBacksubstitution( const AlfCovariance::TE R, const alf_float_t* z, alf_float_t* A )
+{
+  const int size = NumEq - 1;
+
+  A[size] = z[size] / R[size][size];
+
+  for( int i = size - 1; i >= 0; i-- )
+  {
+    alf_float_t sum = 0;
+
+    for( int j = i + 1; j <= size; j++ )
+    {
+      sum += R[i][j] * A[j];
+    }
+
+    A[i] = ( z[i] - sum ) / R[i][i];
+  }
+}
+
+template<int NumEq>
+static int solveByChol_neon( AlfCovariance::TE lhs, const alf_float_t* rhs, alf_float_t* x )
+{
+  static_assert( NumEq == 7 || NumEq == 13, "Unsupported ALF Cholesky order" );
+
+  AlfCovariance::Ty aux; // Auxiliary vector.
+  AlfCovariance::TE U;   // Upper triangular Cholesky factor of lhs.
+
+  int res = 1; // Signal that Cholesky factorization is successfully performed
+
+  // The equation to be solved is LHSx = rhs.
+
+  // Compute upper triangular U such that U'*U = LHS.
+  if( gnsCholeskyDec_neon<NumEq>( lhs, U ) ) // If Cholesky decomposition has been successful.
+  {
+    // Now, the equation is  U'*U*x = rhs, where U is upper triangular
+    // Solve U'*aux = rhs for aux.
+    gnsTransposeBacksubstitution_neon<NumEq>( U, rhs, aux );
+
+    // The equation is now U*x = aux, solve it for x (new motion coefficients).
+    gnsBacksubstitution<NumEq>( U, aux, x );
+  }
+  else // lhs was singular.
+  {
+    // Check if lhs and rhs are all zero, in which the solution is also all zero.
+    if( checkForZero<NumEq>( lhs, rhs ) )
+    {
+      std::memset( x, 0, sizeof( alf_float_t ) * NumEq );
+      return 1;
+    }
+
+    // Regularize lhs.
+    for( int i = 0; i < NumEq; i++ )
+    {
+      lhs[i][i] += REG;
+    }
+
+    // Compute upper triangular U such that U'*U = regularized lhs.
+    res = gnsCholeskyDec_neon<NumEq>( lhs, U );
+
+    if( !res )
+    {
+      std::memset( x, 0, sizeof( alf_float_t ) * NumEq );
+      return 0;
+    }
+
+    // Solve  U'*aux = rhs for aux.
+    gnsTransposeBacksubstitution_neon<NumEq>( U, rhs, aux );
+
+    // Solve U*x = aux for x.
+    gnsBacksubstitution<NumEq>( U, aux, x );
+  }
+  return res;
+}
+
+int gnsSolveByChol_neon( AlfCovariance::TE lhs, alf_float_t* rhs, alf_float_t* x, int numEq )
+{
+  if( numEq == 7 )
+  {
+    return solveByChol_neon<7>( lhs, rhs, x );
+  }
+  else if( numEq == 13 )
+  {
+    return solveByChol_neon<13>( lhs, rhs, x );
+  }
+  CHECK( true, "Unsupported ALF Cholesky order" );
+  return 0;
+}
+
+template<>
+void AlfCovariance::_initAlfCovarianceARM<NEON>()
+{
+  m_gnsSolveByChol = gnsSolveByChol_neon;
+}
+
+} // namespace vvenc
+
+#endif

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -48,7 +48,7 @@ if( VVENC_ENABLE_ARM_SIMD )
   file( GLOB ARM_SRC_FILES CONFIGURE_DEPENDS      "../CommonLib/arm/*.cpp"      )
   file( GLOB ARM_INC_FILES CONFIGURE_DEPENDS      "../CommonLib/arm/*.h"        )
 
-  file( GLOB ARM_NEON_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/neon/*.cpp" )
+  file( GLOB ARM_NEON_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/neon/*.cpp" "../EncoderLib/arm/neon/*.cpp" )
   file( GLOB ARM_SVE_SRC_FILES  CONFIGURE_DEPENDS "../CommonLib/arm/sve/*.cpp" )
   file( GLOB ARM_SVE2_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/sve2/*.cpp" )
 endif()

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -70,6 +70,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/TypeDef.h"
 #include "CommonLib/Unit.h"
 
+#include "EncoderLib/EncAdaptiveLoopFilter.h"
+
 #include "apputils/ParseArg.h"
 #include "vvenc/vvenc.h"
 
@@ -91,12 +93,15 @@ static inline bool compare_value( const std::string& context, const T ref, const
   return opt == ref;
 }
 
-template<typename T>
-static inline bool compare_values_1d( const std::string& context, const T* ref, const T* opt, unsigned length )
+template<typename T, typename U = T>
+static inline bool compare_values_1d( const std::string& context, const T* ref, const T* opt, unsigned length,
+                                      U tolerance = U( 0 ) )
 {
+  auto abs_diff = []( T value1, T value2 ) -> U { return static_cast<U>( std::abs( value1 - value2 ) ); };
+
   for( unsigned idx = 0; idx < length; ++idx )
   {
-    if( ref[idx] != opt[idx] )
+    if( abs_diff( ref[idx], opt[idx] ) > tolerance )
     {
       std::cout << "failed: " << context << "\n"
                 << "  mismatch:  ref[" << idx << "]=" << +ref[idx] << "  opt[" << idx << "]=" << +opt[idx] << "\n";
@@ -253,6 +258,24 @@ public:
     CHECK( values.empty(), "getOneOf: values vector must not be empty" );
     return values[rand() % values.size()];
   }
+};
+
+class FloatGenerator
+{
+public:
+  FloatGenerator( float min_val, float max_val ) : m_min( min_val ), m_max( max_val )
+  {
+  }
+
+  float operator()() const
+  {
+    const float scale = float( rand() ) / float( RAND_MAX );
+    return m_min + ( m_max - m_min ) * scale;
+  }
+
+private:
+  float m_min;
+  float m_max;
 };
 
 #if ENABLE_SIMD_OPT_QUANT
@@ -3061,6 +3084,170 @@ static bool check_filterBlk( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* opt, u
   return true;
 }
 
+template<typename G>
+static void generate_symmetric_positive_definite_matrix( AlfCovariance::TE lhs, AlfCovariance::Ty rhs, int size, G gen )
+{
+  // Builds a random linear system that is guaranteed to be solvable by Cholesky.
+  // The matrix is symmetric positive definite, i.e. A = A^T and x^T A x > 0 for every nonzero x.
+  // It is constructed as A = U^T * U with a strictly positive diagonal in U.
+  AlfCovariance::TE upper;
+  AlfCovariance::Ty x;
+
+  // Generate a random solution vector x and a random upper-triangular matrix U.
+  std::generate_n( x, size, gen );
+
+  for( int row = 0; row < size; ++row )
+  {
+    // Fill the lower triangle part with zeros.
+    std::fill_n( upper[row], row, 0.0f );
+    // Diagonal entries are never zero (kept far away from zero) and strictly positive.
+    upper[row][row] = 50000.0f + std::abs( gen() );
+    // Upper triangular entries can be zero or any value, but smaller in magnitude than the diagonal.
+    std::generate_n( upper[row] + row + 1, size - row - 1, [&]() { return gen() * 0.25f; } );
+  }
+
+  // Form the symmetric positive-definite matrix A = U^T * U.
+  // A is lhs and U is upper.
+  for( int row = 0; row < size; ++row )
+  {
+    for( int col = 0; col < size; ++col )
+    {
+      alf_float_t sum = 0.0f;
+      for( int k = 0; k < size; ++k )
+      {
+        sum += upper[k][row] * upper[k][col];
+      }
+      lhs[row][col] = sum;
+    }
+  }
+
+  // Generate rhs = A * x so that the system A * x = rhs has a consistent solution.
+  for( int row = 0; row < size; ++row )
+  {
+    alf_float_t sum = 0.0f;
+    for( int col = 0; col < size; ++col )
+    {
+      sum += lhs[row][col] * x[col];
+    }
+    rhs[row] = sum;
+  }
+}
+
+template<typename GDiag, typename GRhs>
+static void generate_non_positive_definite_matrix( AlfCovariance::TE lhs, AlfCovariance::Ty rhs, int size,
+                                                   GDiag genDiag, GRhs genRhs )
+{
+  // Builds a diagonal matrix with strictly negative diagonal entries.
+  // Such a matrix is symmetric but not positive definite, so the initial Cholesky check fails.
+  // Depending on the chosen value range, regularization may or may not recover it.
+  for( int i = 0; i < size; ++i )
+  {
+    lhs[i][i] = genDiag();
+    CHECK( lhs[i][i] >= 0.0f, "Diagonal entries must be negative to ensure non-positive definiteness." );
+    rhs[i] = genRhs();
+  }
+}
+
+static bool check_one_gnsSolveByChol( const std::string& context, AlfCovariance* ref, AlfCovariance* opt,
+                                      AlfCovariance::TE lhsRef, AlfCovariance::Ty rhsRef, AlfCovariance::TE lhsOpt,
+                                      AlfCovariance::Ty rhsOpt, int size )
+{
+  AlfCovariance::Ty xRef;
+  AlfCovariance::Ty xOpt;
+
+  // gnsSolveByChol returns non-zero on successful Cholesky factorization and zero on failure.
+  const bool refOk = ref->m_gnsSolveByChol( lhsRef, rhsRef, xRef, size );
+  const bool optOk = opt->m_gnsSolveByChol( lhsOpt, rhsOpt, xOpt, size );
+
+  bool passed = true;
+  passed = compare_value( context + " Cholesky status", refOk, optOk ) && passed;
+  passed = compare_values_1d( context + " x", xRef, xOpt, size, 0.1f ) && passed;
+  return passed;
+}
+
+enum class CholeskyTestCase
+{
+  PositiveDefinite,
+  RegularizedRecovery,
+  NonPositiveDefinite,
+  AllZero,
+};
+
+template<CholeskyTestCase TestCase>
+static bool check_gnsSolveByChol( AlfCovariance* ref, AlfCovariance* opt, int size, unsigned num_cases )
+{
+  std::ostringstream sstm;
+  bool passed = true;
+
+  const char* caseStr = TestCase == CholeskyTestCase::PositiveDefinite      ? "Positive Definite"
+                        : TestCase == CholeskyTestCase::RegularizedRecovery ? "Regularized Recovery"
+                        : TestCase == CholeskyTestCase::NonPositiveDefinite ? "Non-Positive Definite"
+                                                                            : "All Zero";
+  sstm << "AlfCovariance::gnsSolveByChol " << caseStr << " Size=" << size;
+  std::cout << "Testing " << sstm.str() << '\n';
+
+  AlfCovariance::TE lhsRef;
+  AlfCovariance::Ty rhsRef;
+  AlfCovariance::TE lhsOpt;
+  AlfCovariance::Ty rhsOpt;
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    if( TestCase == CholeskyTestCase::PositiveDefinite )
+    {
+      FloatGenerator gen( -100000.0f, 100000.0f );
+      generate_symmetric_positive_definite_matrix( lhsRef, rhsRef, size, gen );
+    }
+    else if( TestCase == CholeskyTestCase::RegularizedRecovery )
+    {
+      // Negative before regularization, positive after adding REG=0.0001f.
+      FloatGenerator genDiag( -0.00009f, -0.00001f );
+      FloatGenerator genRhs( -1000.0f, 1000.0f );
+      generate_non_positive_definite_matrix( lhsRef, rhsRef, size, genDiag, genRhs );
+    }
+    else if( TestCase == CholeskyTestCase::NonPositiveDefinite )
+    {
+      FloatGenerator genDiag( -2.0f, -0.1f ); // Every diagonal entry is negative.
+      FloatGenerator genRhs( 0.0f, 0.0f );
+      generate_non_positive_definite_matrix( lhsRef, rhsRef, size, genDiag, genRhs );
+    }
+    else // TestCase == CholeskyTestCase::AllZero.
+    {
+      std::memset( lhsRef, 0, sizeof( lhsRef ) );
+      std::memset( rhsRef, 0, sizeof( rhsRef ) );
+    }
+
+    std::memcpy( lhsOpt, lhsRef, sizeof( lhsRef ) );
+    std::memcpy( rhsOpt, rhsRef, sizeof( rhsRef ) );
+
+    passed = check_one_gnsSolveByChol( sstm.str(), ref, opt, lhsRef, rhsRef, lhsOpt, rhsOpt, size ) && passed;
+  }
+
+  return passed;
+}
+
+static bool test_AlfCovariance( unsigned num_cases )
+{
+  AlfCovariance ref( /*enableOpt=*/false );
+  AlfCovariance opt( /*enableOpt=*/true );
+  bool passed = true;
+
+  // 13 for luma and 7 for chroma.
+  for( int size : { 7, 13 } )
+  {
+    // Uses a valid positive-definite matrix.
+    passed = check_gnsSolveByChol<CholeskyTestCase::PositiveDefinite>( &ref, &opt, size, num_cases ) && passed;
+    // First Cholesky fails, but regularization makes the matrix solvable.
+    passed = check_gnsSolveByChol<CholeskyTestCase::RegularizedRecovery>( &ref, &opt, size, num_cases ) && passed;
+    // Failure handling - uses an invalid/singular matrix.
+    passed = check_gnsSolveByChol<CholeskyTestCase::NonPositiveDefinite>( &ref, &opt, size, num_cases ) && passed;
+    // All-zero LHS and RHS.
+    passed = check_gnsSolveByChol<CholeskyTestCase::AllZero>( &ref, &opt, size, 1 ) && passed;
+  }
+
+  return passed;
+}
+
 static bool test_AdaptiveLoopFilter()
 {
   AdaptiveLoopFilter ref{ /*enableOpt=*/false };
@@ -3068,6 +3255,8 @@ static bool test_AdaptiveLoopFilter()
 
   unsigned num_cases = NUM_CASES;
   bool passed = true;
+
+  passed = test_AlfCovariance( num_cases ) && passed;
 
   for( unsigned w : { 8, 16, 32, 48, 64, 128 } )
   {


### PR DESCRIPTION
- Add Neon implementation for `AlfCovariance::gnsSolveByChol`, with the optimization work mainly focused on ALF order 13. The output `md5sum` values may differ from the existing implementation because of floating-point accuracy differences.

Add Arm initialization and function-pointer dispatch for `AlfCovariance::gnsSolveByChol`. Update CMakeLists to include Arm Neon sources from new EncoderLib location.
Make `gnsSolveByChol` static so they can be used through plain function-pointer dispatch and called without an `AlfCovariance` instance; the previous const qualifier on the function are no longer needed as it is static member function now.

This new implementation improves performance by approximately ~20% for order 13 compared to the generic version when benchmarked on a Neoverse V2 with LLVM 21.

- Add unit tests for `AlfCovariance::gnsSolveByChol`.

Add `FloatGenerator` for floating point inputs and tolerance in `compare_values_1d` for comparing results.
Modify the AlfCovariance constructor to include a new `enableOpt` parameter to create a reference object and an optimized object for testing.