### PR TITLE
Refactor EncAdaptiveLoopFilter::getPreBlkStats

### DIFF
--- a/source/Lib/CommonLib/x86/InitX86.cpp
+++ b/source/Lib/CommonLib/x86/InitX86.cpp
@@ -62,6 +62,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "TrQuant_EMT.h"
 #include "QuantRDOQ2.h"
 #include "SEIFilmGrainAnalyzer.h"
+#include "EncoderLib/EncAdaptiveLoopFilter.h"
 
 #ifdef TARGET_SIMD_X86
 
@@ -205,6 +206,22 @@ void AdaptiveLoopFilter::initAdaptiveLoopFilterX86()
     break;
   default:
     break;
+  }
+}
+
+void EncAdaptiveLoopFilter::initEncAdaptiveLoopFilter_X86()
+{
+  auto vext = read_x86_extension_flags();
+  switch (vext){
+    case AVX512:
+    case AVX2:
+    case AVX:
+    case SSE42:
+    case SSE41:
+      _initEncAdaptiveLoopFilter_X86<SSE41>();
+      break;
+    default:
+      break;
   }
 }
 #endif

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
@@ -1052,6 +1052,11 @@ int AlfCovariance::gnsSolveByChol( TE LHS, alf_float_t* rhs, alf_float_t*x, int 
 }
 //////////////////////////////////////////////////////////////////////////////////////////
 
+static void getPreBlkStatsAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                 const Pel yLocal[4][4], const int numBins );
+static void getPreBlkStatsWeightedAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                         const Pel yLocal[4][4], const alf_float_t weight[4][4], const int numBins );
+
 EncAdaptiveLoopFilter::EncAdaptiveLoopFilter()
   : m_encCfg         ( nullptr )
   , m_apsMap         ( nullptr )
@@ -1091,6 +1096,13 @@ EncAdaptiveLoopFilter::EncAdaptiveLoopFilter()
   {
     m_alfFilterStatEnabled[i] = false;
   }
+
+  m_getPreBlkStatsAccum = getPreBlkStatsAccum;
+  m_getPreBlkStatsWeightedAccum = getPreBlkStatsWeightedAccum;
+
+#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
+  initEncAdaptiveLoopFilter_X86();
+#endif
 }
 
 void EncAdaptiveLoopFilter::initASU( int alfUnitSize )
@@ -3247,6 +3259,116 @@ void EncAdaptiveLoopFilter::getFrameStat( AlfCovariance* frameCov, AlfCovariance
 #define GET_ALF_COVAR( elocal, b, k, x ) elocal[( b ) * NL_COVAR_bstride + ( k ) * NL_COVAR_kstride + ( x ) * NL_COVAR_xstride]
 #define SET_ALF_COVAR( elocal, b, k, x, v ) GET_ALF_COVAR( elocal, b, k, x ) = ( v )
 
+static void getPreBlkStatsAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                 const Pel yLocal[4][4], const int numBins )
+{
+  for( int b0 = 0; b0 < numBins; b0++ )
+  {
+    for( int k = 0; k < shape.numCoeff; k++ )
+    {
+      const Pel* Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
+
+      for( int b1 = 0; b1 < numBins; b1++ )
+      {
+        alf_float_t* cov = &alfCovariance.E[b0][b1][k][k];
+
+        for( int l = k; l < shape.numCoeff; l++ )
+        {
+          const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
+
+          int64_t sum = 0;
+          for( int ii = 0; ii < 4; ii++ )
+          {
+            for( int jj = 0; jj < 4; jj++ )
+            {
+              sum += int( Elocall[( ii << 2 ) + jj] ) * Elocalk[( ii << 2 ) + jj];
+            }
+          }
+
+          *cov++ += sum;
+        }
+      }
+
+      int64_t sum = 0;
+      for( int ii = 0; ii < 4; ii++ )
+      {
+        for( int jj = 0; jj < 4; jj++ )
+        {
+          sum += int( Elocalk[( ii << 2 ) + jj] ) * yLocal[ii][jj];
+        }
+      }
+
+      alfCovariance.y[b0][k] += sum;
+    }
+  }
+
+  int64_t sum = 0;
+  for( int ii = 0; ii < 4; ii++ )
+  {
+    for( int jj = 0; jj < 4; jj++ )
+    {
+      sum += int( yLocal[ii][jj] ) * yLocal[ii][jj];
+    }
+  }
+
+  alfCovariance.pixAcc += sum;
+}
+
+static void getPreBlkStatsWeightedAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                         const Pel yLocal[4][4], const alf_float_t weight[4][4], const int numBins )
+{
+  for( int b0 = 0; b0 < numBins; b0++ )
+  {
+    for( int k = 0; k < shape.numCoeff; k++ )
+    {
+      const Pel* Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
+
+      for( int b1 = 0; b1 < numBins; b1++ )
+      {
+        alf_float_t* cov = &alfCovariance.E[b0][b1][k][k];
+
+        for( int l = k; l < shape.numCoeff; l++ )
+        {
+          const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
+
+          alf_float_t sum = 0.0;
+          for( int ii = 0; ii < 4; ii++ )
+          {
+            for( int jj = 0; jj < 4; jj++ )
+            {
+              sum += weight[ii][jj] * Elocall[( ii << 2 ) + jj] * Elocalk[( ii << 2 ) + jj];
+            }
+          }
+
+          *cov++ += sum;
+        }
+      }
+
+      alf_float_t sum = 0.0;
+      for( int ii = 0; ii < 4; ii++ )
+      {
+        for( int jj = 0; jj < 4; jj++ )
+        {
+          sum += weight[ii][jj] * Elocalk[( ii << 2 ) + jj] * yLocal[ii][jj];
+        }
+      }
+
+      alfCovariance.y[b0][k] += sum;
+    }
+  }
+
+  alf_float_t sum = 0.0;
+  for( int ii = 0; ii < 4; ii++ )
+  {
+    for( int jj = 0; jj < 4; jj++ )
+    {
+      sum += weight[ii][jj] * yLocal[ii][jj] * yLocal[ii][jj];
+    }
+  }
+
+  alfCovariance.pixAcc += sum;
+}
+
 void EncAdaptiveLoopFilter::getPreBlkStats(AlfCovariance* alfCovariance, const AlfFilterShape& shape, AlfClassifier* classifier, Pel* org, const int orgStride, Pel* rec, const int recStride, const CompArea& areaDst, const ChannelType channel, int vbCTUHeight, int vbPos)
 {
   const int numBins = ( isLuma( channel ) ? m_encCfg->m_useNonLinearAlfLuma : m_encCfg->m_useNonLinearAlfChroma ) ? AlfNumClippingValues : 1;
@@ -3362,284 +3484,11 @@ void EncAdaptiveLoopFilter::getPreBlkStats(AlfCovariance* alfCovariance, const A
           weight[ii][jj] = m_lumaLevelToWeightPLUT[org[j + jj + ii * orgStride]];
         }
 
-#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
-        if( useSimd )
-        {
-          for( int b0 = 0; b0 < numBins; b0++ )
-          {
-            for( int k = 0; k < shape.numCoeff; k++ )
-            {
-              const Pel* Elocalk  = &GET_ALF_COVAR( ELocal, b0, k, 0 );
-
-              __m128 xprodwk[4];
-              for( int ii = 0; ii < 4; ii++ )
-              {
-                const __m128i xlockx32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* ) &Elocalk[(ii << 2)] ) );
-
-                __m128 xlocd  = _mm_cvtepi32_ps( xlockx32 );
-                __m128 xwght  = _mm_loadu_ps   ( &weight[ii][0] );
-                __m128 xprdct = _mm_mul_ps     ( xwght, xlocd );
-                xprodwk[ii] = xprdct;
-              }
-
-              for( int b1 = 0; b1 < numBins; b1++ )
-              {
-                alf_float_t* cov    = &alfCovariance[classIdx].E[b0][b1][k][k];
-
-                for( int l = k; l < shape.numCoeff; l++ )
-                {
-                  const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
-
-                  //double sum = 0.0;
-                  __m128 xacc = _mm_setzero_ps();
-
-                  for( int ii = 0; ii < 4; ii++ )
-                  {
-                    const __m128i xloclx32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* ) &Elocall[(ii << 2)] ) );
-                  
-                    __m128 xlockd = _mm_cvtepi32_ps( xloclx32 );
-                    xacc = _mm_add_ps( xacc, _mm_mul_ps( xprodwk[ii], xlockd ) );
-
-                    //for( int jj = 0; jj < 4; jj++ ) sum += weight[ii][jj] * Elocall[(ii << 2) + jj] * Elocalk[(ii << 2) + jj];
-                  }
-
-                  xacc = _mm_hadd_ps( xacc, xacc );
-                  xacc = _mm_hadd_ps( xacc, xacc );
-
-                  *cov++ += _mm_cvtss_f32( xacc );
-                  //*cov++ += sum;
-                }
-              }
-
-              //double sum = 0.0;
-              __m128 xacc = _mm_setzero_ps();
-
-              for( int ii = 0; ii < 4; ii++ )
-              {
-                const __m128i yloc32   = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* ) &yLocal [ii][0] ) );
-                
-                __m128 ylocd  = _mm_cvtepi32_ps( yloc32 );
-                __m128 xprdct = _mm_mul_ps( ylocd, xprodwk[ii] );
-                
-                xacc    = _mm_add_ps      ( xacc, xprdct );
-                //for( int jj = 0; jj < 4; jj++ ) sum += weight[ii][jj] * Elocalk[(ii << 2) + jj] * yLocal[ii][jj];
-              }
-
-              xacc = _mm_hadd_ps( xacc, xacc );
-              xacc = _mm_hadd_ps( xacc, xacc );
-
-              alfCovariance[classIdx].y[b0][k] += _mm_cvtss_f32( xacc );
-              //alfCovariance[classIdx].y[b0][k] += sum;
-            }
-          }
-
-          //double sum = 0.0;
-          __m128 xacc = _mm_setzero_ps();
-
-          for( int ii = 0; ii < 4; ii++ )
-          {
-            const __m128i yloc32   = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* ) &yLocal[ii][0] ) );
-              
-            __m128 ylocd  = _mm_cvtepi32_ps( yloc32 );
-            __m128 xwght  = _mm_loadu_ps   ( &weight[ii][0] );
-            __m128 xprdct = _mm_mul_ps     ( xwght, _mm_mul_ps( ylocd, ylocd ) );
-              
-            xacc    = _mm_add_ps      ( xacc, xprdct );
-            //for( int jj = 0; jj < 4; jj++ ) sum += weight[ii][jj] * yLocal[ii][jj] * yLocal[ii][jj];
-          }
-
-          xacc = _mm_hadd_ps( xacc, xacc );
-          xacc = _mm_hadd_ps( xacc, xacc );
-
-          alfCovariance[classIdx].pixAcc += _mm_cvtss_f32( xacc );
-          //alfCovariance[classIdx].pixAcc += sum;
-        }
-        else
-#endif
-        {
-          for( int b0 = 0; b0 < numBins; b0++ )
-          {
-            for( int k = 0; k < shape.numCoeff; k++ )
-            {
-              const Pel *Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
-
-              for( int b1 = 0; b1 < numBins; b1++ )
-              {
-                alf_float_t *cov = &alfCovariance[classIdx].E[b0][b1][k][k];
-
-                for( int l = k; l < shape.numCoeff; l++ )
-                {
-                  const Pel *Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
-
-                  alf_float_t sum = 0.0;
-                  for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-                  {
-                    sum += weight[ii][jj] * Elocall[( ii << 2 ) + jj] * Elocalk[( ii << 2 ) + jj];
-                  }
-
-                  *cov++ += sum;
-                }
-              }
-
-              alf_float_t sum = 0.0;
-              for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-              {
-                sum += weight[ii][jj] * Elocalk[(ii << 2) + jj] * yLocal[ii][jj];
-              }
-
-              alfCovariance[classIdx].y[b0][k] += sum;
-            }
-          }
-
-          alf_float_t sum = 0.0;
-          for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-          {
-            sum += weight[ii][jj] * yLocal[ii][jj] * yLocal[ii][jj];
-          }
-
-          alfCovariance[classIdx].pixAcc += sum;
-        }
+        m_getPreBlkStatsWeightedAccum( alfCovariance[classIdx], shape, ELocal, yLocal, weight, numBins );
       }
       else
       {
-#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
-        if( useSimd )
-        {
-          const __m128i mylocal0 = _mm_loadu_si128( ( const __m128i* ) &yLocal[0][0] );
-          const __m128i mylocal8 = _mm_loadu_si128( ( const __m128i* ) &yLocal[2][0] );
-
-          for( int b0 = 0; b0 < numBins; b0++ )
-          {
-            for( int k = 0; k < shape.numCoeff; k++ )
-            {
-              const Pel *Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
-
-              const __m128i melocalk0 = _mm_loadu_si128( ( const __m128i* ) &Elocalk[0] );
-              const __m128i melocalk8 = _mm_loadu_si128( ( const __m128i* ) &Elocalk[8] );
-
-              for( int b1 = 0; b1 < numBins; b1++ )
-              {
-                alf_float_t* cov = &alfCovariance[classIdx].E[b0][b1][k][k];
-
-                int l = k;
-              
-                for( ; l < ( shape.numCoeff - 3 ); l += 4 )
-                {
-                  __m128i vmacc[4];
-
-                  for( int ll = 0; ll < 4; ll++ )
-                  {
-                    const Pel *Elocall = &GET_ALF_COVAR( ELocal, b1, l + ll, 0 );
-
-                    __m128i melocall0 = _mm_loadu_si128( ( const __m128i * ) &Elocall[0] );
-                    __m128i melocall8 = _mm_loadu_si128( ( const __m128i * ) &Elocall[8] );
-
-                    __m128i mmacc0 = _mm_madd_epi16( melocalk0, melocall0 );
-                    __m128i mmacc8 = _mm_madd_epi16( melocalk8, melocall8 );
-
-                    __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
-
-                    vmacc[ll] = mmacc;
-                  }
-
-                  __m128i
-                  mmacc = _mm_hadd_epi32( _mm_hadd_epi32( vmacc[0], vmacc[1] ),
-                                          _mm_hadd_epi32( vmacc[2], vmacc[3] ) );
-                
-                  __m128 mmaccf = _mm_cvtepi32_ps( mmacc );
-
-                  __m128 mcov = _mm_loadu_ps( cov );
-                  mcov = _mm_add_ps( mcov, mmaccf );
-                  _mm_storeu_ps( cov, mcov );
-
-                  cov += 4;
-                }
-              
-                for( ; l < shape.numCoeff; l++ )
-                {
-                  const Pel *Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
-                
-                  __m128i melocall0 = _mm_loadu_si128( ( const __m128i* ) &Elocall[0] );
-                  __m128i melocall8 = _mm_loadu_si128( ( const __m128i* ) &Elocall[8] );
-
-                  __m128i mmacc0 = _mm_madd_epi16( melocalk0, melocall0 );
-                  __m128i mmacc8 = _mm_madd_epi16( melocalk8, melocall8 );
-                
-                  __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
-                  mmacc = _mm_hadd_epi32( mmacc, mmacc );
-                  mmacc = _mm_hadd_epi32( mmacc, mmacc );
-                
-                  __m128 mmaccf = _mm_cvtepi32_ps( mmacc );
-
-                  *cov++ += _mm_cvtss_f32( mmaccf );
-                }
-              }
-
-              const __m128i mmacc0 = _mm_madd_epi16( melocalk0, mylocal0 );
-              const __m128i mmacc8 = _mm_madd_epi16( melocalk8, mylocal8 );
-
-              __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
-              mmacc = _mm_hadd_epi32( mmacc, mmacc );
-              mmacc = _mm_hadd_epi32( mmacc, mmacc );
-
-              alfCovariance[classIdx].y[b0][k] += _mm_cvtsi128_si32( mmacc );
-            }
-          }
-
-          const __m128i mmacc0 = _mm_madd_epi16( mylocal0, mylocal0 );
-          const __m128i mmacc8 = _mm_madd_epi16( mylocal8, mylocal8 );
-
-          __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
-          mmacc = _mm_hadd_epi32( mmacc, mmacc );
-          mmacc = _mm_hadd_epi32( mmacc, mmacc );
-
-          alfCovariance[classIdx].pixAcc += _mm_cvtsi128_si32( mmacc );
-        }
-        else
-#endif
-        {
-          for( int b0 = 0; b0 < numBins; b0++ )
-          {
-            for( int k = 0; k < shape.numCoeff; k++ )
-            {
-              const Pel *Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
-
-              for( int b1 = 0; b1 < numBins; b1++ )
-              {
-                alf_float_t* cov    = &alfCovariance[classIdx].E[b0][b1][k][k];
-
-                for( int l = k; l < shape.numCoeff; l++ )
-                {
-                  const Pel *Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
-
-                  int64_t sum = 0;
-                  for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-                  {
-                    sum += int( Elocall[(ii << 2) + jj] ) * Elocalk[(ii << 2) + jj];
-                  }
-
-                  *cov++ += sum;
-                }
-              }
-
-              int64_t sum = 0;
-              for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-              {
-                sum += int( Elocalk[(ii << 2) + jj] ) * yLocal[ii][jj];
-              }
-
-              alfCovariance[classIdx].y[b0][k] += sum;
-            }
-          }
-
-          int64_t sum = 0;
-          for( int ii = 0; ii < 4; ii++ ) for( int jj = 0; jj < 4; jj++ )
-          {
-            sum += int( yLocal[ii][jj] ) * yLocal[ii][jj];
-          }
-
-          alfCovariance[classIdx].pixAcc += sum;
-        }
+        m_getPreBlkStatsAccum( alfCovariance[classIdx], shape, ELocal, yLocal, numBins );
       }
 
       alfCovariance[classIdx].all0 = false;

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
@@ -1057,7 +1057,7 @@ static void getPreBlkStatsAccum( AlfCovariance& alfCovariance, const AlfFilterSh
 static void getPreBlkStatsWeightedAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
                                          const Pel yLocal[4][4], const alf_float_t weight[4][4], const int numBins );
 
-EncAdaptiveLoopFilter::EncAdaptiveLoopFilter()
+EncAdaptiveLoopFilter::EncAdaptiveLoopFilter( bool enableOpt )
   : m_encCfg         ( nullptr )
   , m_apsMap         ( nullptr )
   , m_CABACEstimator ( nullptr )
@@ -1100,9 +1100,12 @@ EncAdaptiveLoopFilter::EncAdaptiveLoopFilter()
   m_getPreBlkStatsAccum = getPreBlkStatsAccum;
   m_getPreBlkStatsWeightedAccum = getPreBlkStatsWeightedAccum;
 
+  if( enableOpt )
+  {
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
-  initEncAdaptiveLoopFilter_X86();
+    initEncAdaptiveLoopFilter_X86();
 #endif
+  }
 }
 
 void EncAdaptiveLoopFilter::initASU( int alfUnitSize )

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
@@ -441,7 +441,19 @@ public:
   void resetFrameStats              ( bool ccAlfEnabled );
   bool isSkipAlfForFrame            ( const Picture& pic ) const;
   int  getAsuHeightInCtus           () { return m_numCtusInAsuHeight; }
-private:
+
+  void ( *m_getPreBlkStatsAccum )( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                   const Pel yLocal[4][4], const int numBins );
+  void ( *m_getPreBlkStatsWeightedAccum )( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                           const Pel yLocal[4][4], const alf_float_t weight[4][4], const int numBins );
+
+                                           private:
+#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
+  void initEncAdaptiveLoopFilter_X86();
+  template<X86_VEXT vext>
+  void _initEncAdaptiveLoopFilter_X86();
+#endif
+
   void   xStoreAlfAsuEnabledFlag    ( CodingStructure& cs, int ctuX, int ctuY, int ctuIdx, const int compIdx, bool flag );
   void   xStoreAlfAsuAlternative    ( CodingStructure& cs, int ctuX, int ctuY, int ctuIdx, const int compIdx, const uint8_t alt );
   void   xStoreAlfAsuFilterIdx      ( CodingStructure& cs, int ctuX, int ctuY, int ctuIdx, const short fltIdx, short* alfCtbFilterSetIndex );

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
@@ -413,7 +413,7 @@ private:
   bool                   m_alfFilterStatEnabled[MAX_NUM_COMP];
 
 public:
-  EncAdaptiveLoopFilter();
+  EncAdaptiveLoopFilter( bool enableOpt = true );
   virtual ~EncAdaptiveLoopFilter() { destroy(); }
   void init                         ( const VVEncCfg& encCfg, const PPS& pps, CABACWriter& cabacEstimator, CtxCache& ctxCache, NoMallocThreadPool* threadpool );
   void destroy                      ();

--- a/source/Lib/EncoderLib/x86/EncAdaptiveLoopFilterX86.h
+++ b/source/Lib/EncoderLib/x86/EncAdaptiveLoopFilterX86.h
@@ -1,0 +1,261 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/** \file     EncAdaptiveLoopFilterX86.h
+ \brief    x86 helpers for adaptive loop filter
+ */
+
+#include "CommonDefX86.h"
+
+#include "../EncAdaptiveLoopFilter.h"
+
+//! \ingroup EncoderLib
+//! \{
+
+#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
+
+namespace vvenc
+{
+
+#define NL_COVAR_bstride ( MAX_NUM_ALF_LUMA_COEFF << 4 )
+#define NL_COVAR_kstride ( 1 << 4 )
+#define NL_COVAR_xstride ( 1 )
+#define GET_ALF_COVAR( elocal, b, k, x )                                                                               \
+  elocal[( b ) * NL_COVAR_bstride + ( k ) * NL_COVAR_kstride + ( x ) * NL_COVAR_xstride]
+
+template<X86_VEXT vext>
+void simdGetPreBlkStatsWeightedAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                                      const Pel yLocal[4][4], const alf_float_t weight[4][4], const int numBins )
+{
+  for( int b0 = 0; b0 < numBins; b0++ )
+  {
+    for( int k = 0; k < shape.numCoeff; k++ )
+    {
+      const Pel* Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
+
+      __m128 xprodwk[4];
+      for( int ii = 0; ii < 4; ii++ )
+      {
+        const __m128i xlockx32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* )&Elocalk[( ii << 2 )] ) );
+
+        __m128 xlocd = _mm_cvtepi32_ps( xlockx32 );
+        __m128 xwght = _mm_loadu_ps( &weight[ii][0] );
+        __m128 xprdct = _mm_mul_ps( xwght, xlocd );
+        xprodwk[ii] = xprdct;
+      }
+
+      for( int b1 = 0; b1 < numBins; b1++ )
+      {
+        alf_float_t* cov = &alfCovariance.E[b0][b1][k][k];
+
+        for( int l = k; l < shape.numCoeff; l++ )
+        {
+          const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
+
+          __m128 xacc = _mm_setzero_ps();
+
+          for( int ii = 0; ii < 4; ii++ )
+          {
+            const __m128i xloclx32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* )&Elocall[( ii << 2 )] ) );
+
+            __m128 xlockd = _mm_cvtepi32_ps( xloclx32 );
+            xacc = _mm_add_ps( xacc, _mm_mul_ps( xprodwk[ii], xlockd ) );
+          }
+
+          xacc = _mm_hadd_ps( xacc, xacc );
+          xacc = _mm_hadd_ps( xacc, xacc );
+
+          *cov++ += _mm_cvtss_f32( xacc );
+        }
+      }
+
+      __m128 xacc = _mm_setzero_ps();
+
+      for( int ii = 0; ii < 4; ii++ )
+      {
+        const __m128i yloc32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* )&yLocal[ii][0] ) );
+
+        __m128 ylocd = _mm_cvtepi32_ps( yloc32 );
+        __m128 xprdct = _mm_mul_ps( ylocd, xprodwk[ii] );
+
+        xacc = _mm_add_ps( xacc, xprdct );
+      }
+
+      xacc = _mm_hadd_ps( xacc, xacc );
+      xacc = _mm_hadd_ps( xacc, xacc );
+
+      alfCovariance.y[b0][k] += _mm_cvtss_f32( xacc );
+    }
+  }
+
+  __m128 xacc = _mm_setzero_ps();
+
+  for( int ii = 0; ii < 4; ii++ )
+  {
+    const __m128i yloc32 = _mm_cvtepi16_epi32( _vv_loadl_epi64( ( const __m128i* )&yLocal[ii][0] ) );
+
+    __m128 ylocd = _mm_cvtepi32_ps( yloc32 );
+    __m128 xwght = _mm_loadu_ps( &weight[ii][0] );
+    __m128 xprdct = _mm_mul_ps( xwght, _mm_mul_ps( ylocd, ylocd ) );
+
+    xacc = _mm_add_ps( xacc, xprdct );
+  }
+
+  xacc = _mm_hadd_ps( xacc, xacc );
+  xacc = _mm_hadd_ps( xacc, xacc );
+
+  alfCovariance.pixAcc += _mm_cvtss_f32( xacc );
+}
+
+template<X86_VEXT vext>
+void simdGetPreBlkStatsAccum( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                              const Pel yLocal[4][4], const int numBins )
+{
+  const __m128i mylocal0 = _mm_loadu_si128( ( const __m128i* )&yLocal[0][0] );
+  const __m128i mylocal8 = _mm_loadu_si128( ( const __m128i* )&yLocal[2][0] );
+
+  for( int b0 = 0; b0 < numBins; b0++ )
+  {
+    for( int k = 0; k < shape.numCoeff; k++ )
+    {
+      const Pel* Elocalk = &GET_ALF_COVAR( ELocal, b0, k, 0 );
+
+      const __m128i melocalk0 = _mm_loadu_si128( ( const __m128i* )&Elocalk[0] );
+      const __m128i melocalk8 = _mm_loadu_si128( ( const __m128i* )&Elocalk[8] );
+
+      for( int b1 = 0; b1 < numBins; b1++ )
+      {
+        alf_float_t* cov = &alfCovariance.E[b0][b1][k][k];
+
+        int l = k;
+
+        for( ; l < ( shape.numCoeff - 3 ); l += 4 )
+        {
+          __m128i vmacc[4];
+
+          for( int ll = 0; ll < 4; ll++ )
+          {
+            const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l + ll, 0 );
+
+            __m128i melocall0 = _mm_loadu_si128( ( const __m128i* )&Elocall[0] );
+            __m128i melocall8 = _mm_loadu_si128( ( const __m128i* )&Elocall[8] );
+
+            __m128i mmacc0 = _mm_madd_epi16( melocalk0, melocall0 );
+            __m128i mmacc8 = _mm_madd_epi16( melocalk8, melocall8 );
+
+            __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
+
+            vmacc[ll] = mmacc;
+          }
+
+          __m128i mmacc = _mm_hadd_epi32( _mm_hadd_epi32( vmacc[0], vmacc[1] ), _mm_hadd_epi32( vmacc[2], vmacc[3] ) );
+
+          __m128 mmaccf = _mm_cvtepi32_ps( mmacc );
+
+          __m128 mcov = _mm_loadu_ps( cov );
+          mcov = _mm_add_ps( mcov, mmaccf );
+          _mm_storeu_ps( cov, mcov );
+
+          cov += 4;
+        }
+
+        for( ; l < shape.numCoeff; l++ )
+        {
+          const Pel* Elocall = &GET_ALF_COVAR( ELocal, b1, l, 0 );
+
+          __m128i melocall0 = _mm_loadu_si128( ( const __m128i* )&Elocall[0] );
+          __m128i melocall8 = _mm_loadu_si128( ( const __m128i* )&Elocall[8] );
+
+          __m128i mmacc0 = _mm_madd_epi16( melocalk0, melocall0 );
+          __m128i mmacc8 = _mm_madd_epi16( melocalk8, melocall8 );
+
+          __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
+          mmacc = _mm_hadd_epi32( mmacc, mmacc );
+          mmacc = _mm_hadd_epi32( mmacc, mmacc );
+
+          __m128 mmaccf = _mm_cvtepi32_ps( mmacc );
+
+          *cov++ += _mm_cvtss_f32( mmaccf );
+        }
+      }
+
+      const __m128i mmacc0 = _mm_madd_epi16( melocalk0, mylocal0 );
+      const __m128i mmacc8 = _mm_madd_epi16( melocalk8, mylocal8 );
+
+      __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
+      mmacc = _mm_hadd_epi32( mmacc, mmacc );
+      mmacc = _mm_hadd_epi32( mmacc, mmacc );
+
+      alfCovariance.y[b0][k] += _mm_cvtsi128_si32( mmacc );
+    }
+  }
+
+  const __m128i mmacc0 = _mm_madd_epi16( mylocal0, mylocal0 );
+  const __m128i mmacc8 = _mm_madd_epi16( mylocal8, mylocal8 );
+
+  __m128i mmacc = _mm_add_epi32( mmacc0, mmacc8 );
+  mmacc = _mm_hadd_epi32( mmacc, mmacc );
+  mmacc = _mm_hadd_epi32( mmacc, mmacc );
+
+  alfCovariance.pixAcc += _mm_cvtsi128_si32( mmacc );
+}
+
+template<X86_VEXT vext>
+void EncAdaptiveLoopFilter::_initEncAdaptiveLoopFilter_X86()
+{
+  m_getPreBlkStatsAccum = simdGetPreBlkStatsAccum<vext>;
+  m_getPreBlkStatsWeightedAccum = simdGetPreBlkStatsWeightedAccum<vext>;
+}
+
+template void EncAdaptiveLoopFilter::_initEncAdaptiveLoopFilter_X86<SIMDX86>();
+
+#undef GET_ALF_COVAR
+#undef NL_COVAR_xstride
+#undef NL_COVAR_kstride
+#undef NL_COVAR_bstride
+
+} // namespace vvenc
+
+#endif // TARGET_SIMD_X86
+
+//! \}
+

--- a/source/Lib/EncoderLib/x86/sse41/EncAdaptiveLoopFilter_sse41.cpp
+++ b/source/Lib/EncoderLib/x86/sse41/EncAdaptiveLoopFilter_sse41.cpp
@@ -1,0 +1,43 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED UNDER
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#include "../EncAdaptiveLoopFilterX86.h"

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -24,13 +24,13 @@ endif()
 
 if( VVENC_ENABLE_X86_SIMD )
   # get x86 source files
-  file( GLOB X86_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.cpp" )
+  file( GLOB X86_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.cpp" "../EncoderLib/x86/*.cpp" )
 
   # get x86 source files
-  file( GLOB X86_INC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.h" )
+  file( GLOB X86_INC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/*.h" "../EncoderLib/x86/*.h" )
 
   # get sse4.1 source files
-  file( GLOB SSE41_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/sse41/*.cpp" )
+  file( GLOB SSE41_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/sse41/*.cpp" "../EncoderLib/x86/sse41/*.cpp" )
   
   # get sse4.2 source files
   file( GLOB SSE42_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/x86/sse42/*.cpp" )

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -82,26 +82,31 @@ namespace po = apputils::program_options;
 
 static bool g_fastUnitTest = false;
 
-template<typename T>
-static inline bool compare_value( const std::string& context, const T ref, const T opt )
+template<typename T, typename U>
+static inline U abs_diff( const T value1, const T value2 )
 {
-  if( opt != ref )
+  return static_cast<U>( value1 > value2 ? value1 - value2 : value2 - value1 );
+}
+
+template<typename T, typename U = T>
+static inline bool compare_value( const std::string& context, const T ref, const T opt, U tolerance = U( 0 ) )
+{
+  if( abs_diff<T, U>( ref, opt ) > tolerance )
   {
     std::cerr << "failed: " << context << "\n"
               << "  mismatch:  ref=" << +ref << "  opt=" << +opt << "\n";
+    return false;
   }
-  return opt == ref;
+  return true;
 }
 
 template<typename T, typename U = T>
 static inline bool compare_values_1d( const std::string& context, const T* ref, const T* opt, unsigned length,
                                       U tolerance = U( 0 ) )
 {
-  auto abs_diff = []( T value1, T value2 ) -> U { return static_cast<U>( std::abs( value1 - value2 ) ); };
-
   for( unsigned idx = 0; idx < length; ++idx )
   {
-    if( abs_diff( ref[idx], opt[idx] ) > tolerance )
+    if( abs_diff<T, U>( ref[idx], opt[idx] ) > tolerance )
     {
       std::cout << "failed: " << context << "\n"
                 << "  mismatch:  ref[" << idx << "]=" << +ref[idx] << "  opt[" << idx << "]=" << +opt[idx] << "\n";
@@ -117,14 +122,12 @@ static inline bool compare_values_2d( const std::string& context, const T* ref, 
 {
   stride = stride != 0 ? stride : cols;
 
-  auto abs_diff = []( T value1, T value2 ) -> U { return static_cast<U>( std::abs( value1 - value2 ) ); };
-
   for( unsigned row = 0; row < rows; ++row )
   {
     for( unsigned col = 0; col < cols; ++col )
     {
       unsigned idx = row * stride + col;
-      if( abs_diff( ref[idx], opt[idx] ) > tolerance )
+      if( abs_diff<T, U>( ref[idx], opt[idx] ) > tolerance )
       {
         std::cout << "failed: " << context << "\n"
                   << "  mismatch:  ref[" << row << "*" << stride << "+" << col << "]=" << +ref[idx] << "  opt[" << row
@@ -3295,6 +3298,122 @@ static bool test_AlfCovariance( unsigned num_cases )
   return passed;
 }
 
+template<bool Weighted>
+static bool check_getPreBlkStatsAccum( EncAdaptiveLoopFilter* ref, EncAdaptiveLoopFilter* opt, int filterSize,
+                                       int numBins, unsigned num_cases )
+{
+  const char* testName =
+      Weighted ? "EncAdaptiveLoopFilter::getPreBlkStatsWeightedAccum" : "EncAdaptiveLoopFilter::getPreBlkStatsAccum";
+  std::cout << "Testing " << testName << " filterSize=" << filterSize << " numBins=" << numBins << '\n';
+
+  bool passed = true;
+
+  DimensionGenerator rng;
+  InputGenerator<Pel> g8{ 8, /*is_signed=*/true };
+  InputGenerator<Pel> g10{ 10, /*is_signed=*/true };
+  FloatGenerator fg( -1000.0f, 1000.0f );
+  FloatGenerator fgPix( 0.0f, 1000.0f );
+
+  AlfFilterShape shape( filterSize );
+  AlfCovariance covRef;
+  AlfCovariance covOpt;
+  covRef.create( shape.numCoeff, numBins );
+  covOpt.create( shape.numCoeff, numBins );
+
+  static constexpr int MaxAlfNumClippingValues = 4;
+
+  Pel y[4][4];
+  std::vector<Pel> e( MaxAlfNumClippingValues * ( MAX_NUM_ALF_LUMA_COEFF << 4 ) );
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    covRef.reset();
+    covOpt.reset();
+
+    std::generate_n( &y[0][0], 4 * 4, g8 );
+    std::generate( e.begin(), e.end(), g10 );
+
+    for( int b = 0; b < numBins; ++b )
+    {
+      std::generate_n( &covRef.E[b][0][0][0], numBins * MAX_NUM_ALF_LUMA_COEFF * MAX_NUM_ALF_LUMA_COEFF, fg );
+    }
+    std::generate_n( &covRef.y[0][0], numBins * MAX_NUM_ALF_LUMA_COEFF, fg );
+
+    covRef.pixAcc = fgPix();
+    covOpt = covRef;
+
+    if( Weighted )
+    {
+      auto gen_luma_weight = []( int i )
+      {
+        // Use the same PQ luma-to-weight mapping used by initLumaLevelToWeightTableReshape().
+        double y = 0.015 * i - 1.5 - 6;
+        y = y < -3 ? -3 : y > 6 ? 6 : y;
+        return pow( 2.0, y / 3.0 );
+      };
+
+      alf_float_t weight[4][4];
+      for( int ii = 0; ii < 4; ++ii )
+      {
+        for( int jj = 0; jj < 4; ++jj )
+        {
+          weight[ii][jj] = gen_luma_weight( rng.get( 0, 1023 ) );
+        }
+      }
+
+      ref->m_getPreBlkStatsWeightedAccum( covRef, shape, e.data(), y, weight, numBins );
+      opt->m_getPreBlkStatsWeightedAccum( covOpt, shape, e.data(), y, weight, numBins );
+    }
+    else
+    {
+      ref->m_getPreBlkStatsAccum( covRef, shape, e.data(), y, numBins );
+      opt->m_getPreBlkStatsAccum( covOpt, shape, e.data(), y, numBins );
+    }
+
+    std::ostringstream sstm;
+    sstm << "getPreBlkStatsAccum filterSize=" << filterSize << " numBins=" << numBins;
+
+    passed = compare_value( sstm.str() + " pixAcc", covRef.pixAcc, covOpt.pixAcc, Weighted ? 0.1f : 0.0f ) && passed;
+    passed = compare_values_2d( sstm.str() + " y", &covRef.y[0][0], &covOpt.y[0][0], covRef.numBins, covRef.numCoeff,
+                                MAX_NUM_ALF_LUMA_COEFF, Weighted ? 0.2f : 0.0f ) &&
+             passed;
+
+    for( int b0 = 0; b0 < covRef.numBins; ++b0 )
+    {
+      for( int b1 = 0; b1 < covRef.numBins; ++b1 )
+      {
+        passed = compare_values_2d( sstm.str() + " E b0=" + std::to_string( b0 ) + " b1=" + std::to_string( b1 ),
+                                    &covRef.E[b0][b1][0][0], &covOpt.E[b0][b1][0][0], covRef.numCoeff, covRef.numCoeff,
+                                    MAX_NUM_ALF_LUMA_COEFF, Weighted ? 1.0f : 0.0f ) &&
+                 passed;
+      }
+    }
+  }
+
+  covRef.destroy();
+  covOpt.destroy();
+
+  return passed;
+}
+
+static bool test_EncAdaptiveLoopFilter( unsigned num_cases )
+{
+  EncAdaptiveLoopFilter ref( /*enableOpt=*/false );
+  EncAdaptiveLoopFilter opt( /*enableOpt=*/true );
+  bool passed = true;
+
+  for( int numBin : { 1, AdaptiveLoopFilter::AlfNumClippingValues } )
+  {
+    for( int filterSize : { 5, 7 } )
+    {
+      passed = check_getPreBlkStatsAccum<false>( &ref, &opt, filterSize, numBin, num_cases ) && passed;
+      passed = check_getPreBlkStatsAccum<true>( &ref, &opt, filterSize, numBin, num_cases ) && passed;
+    }
+  }
+
+  return passed;
+}
+
 static bool test_AdaptiveLoopFilter()
 {
   AdaptiveLoopFilter ref{ /*enableOpt=*/false };
@@ -3304,6 +3423,7 @@ static bool test_AdaptiveLoopFilter()
   bool passed = true;
 
   passed = test_AlfCovariance( num_cases ) && passed;
+  passed = test_EncAdaptiveLoopFilter( num_cases ) && passed;
 
   for( unsigned w : { 8, 16, 32, 48, 64, 128 } )
   {


### PR DESCRIPTION
Refactor EncAdaptiveLoopFilter::getPreBlkStats

    Refactor the weighted and unweighted covariance accumulation paths out
    of `EncAdaptiveLoopFilter::getPreBlkStats()` into dispatchable helper
    functions.
    
    Introduce function pointers `m_getPreBlkStatsAccum` and
    `m_getPreBlkStatsWeightedAccum` to `EncAdaptiveLoopFilter` class.
    Move the x86 implementations into the EncoderLib x86 SIMD layer and
    assign them during EncAdaptiveLoopFilter x86 initialization, while
    keeping scalar helpers as the default fallback.
    
    Also include the EncoderLib x86 sources in the VVenC CMake x86 file
    lists.

Add unit tests for EncAdaptiveLoopFilter::getPreBlkStats functions.
    
    Modify the EncAdaptiveLoopFilter constructor to include a new
    'enableOpt' parameter to create a reference object and an optimized
    object for testing.
    
    Add optional `tolerance` handling to `compare_value` so unit tests can
    compare results that are numerically equivalent but not bit-exact. This
    allows small floating-point accuracy differences in
    `getPreBlkStatsWeightedAccum` test cases. SIMD implementations can
    change the order of floating-point operations compared with the scalar
    reference, which may produce tiny differences while still being
    mathematically correct.


