### PR TITLE
Arm: Add Neon implementation for FGA calcVar and calcMean

### DIFF
--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/AdaptiveLoopFilter.h"
 #include "CommonLib/SampleAdaptiveOffset.h"
 #include "EncoderLib/EncAdaptiveLoopFilter.h"
+#include "EncoderLib/SEIFilmGrainAnalyzer.h"
 
 namespace vvenc
 {
@@ -237,6 +238,17 @@ void LoopFilter::initLoopFilterARM()
   }
 }
 #endif  // ENABLE_SIMD_DBLF
+
+#if ENABLE_SIMD_OPT_FGA
+void FGAnalyzer::initFGAnalyzerARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initFGAnalyzerARM<NEON>();
+  }
+}
+#endif  // ENABLE_SIMD_OPT_FGA
 
 #endif  // TARGET_SIMD_ARM
 

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -133,17 +133,6 @@ void FGAnalyzer::_initFGAnalyzerARM()
 
 template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
 
-// Entry points for the unit test (the function pointers are private to init).
-double calcVarNeonEntry( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
-{
-  return calcVarNeon( org, origStride, w, h );
-}
-
-int calcMeanNeonEntry( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
-{
-  return calcMeanNeon( org, origStride, w, h );
-}
-
 }  // namespace vvenc
 
 #endif  // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_FGA

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -1,0 +1,149 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/** \file     FGA_neon.cpp
+    \brief    film grain analysis, Neon version
+*/
+
+#include "CommonDefARM.h"
+#include "CommonLib/CommonDef.h"
+#include "CommonLib/Rom.h"
+#include "EncoderLib/SEIFilmGrainAnalyzer.h"
+#include "sum_neon.h"
+
+#include <arm_neon.h>
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
+
+namespace vvenc
+{
+
+// Mirrors calcMeanSse: returns the integer sum of all w*h pixels (w is a
+// multiple of 8). The caller divides by the block size.
+static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
+{
+  // Two independent accumulators allow out-of-order execution to overlap
+  // the add chains and avoid the per-row int16 accumulator reset overhead.
+  int32x4_t acc0 = vdupq_n_s32( 0 );
+  int32x4_t acc1 = vdupq_n_s32( 0 );
+  for( int y = 0; y < h; y++, org += origStride )
+  {
+    int x = 0;
+    for( ; x < w - 8; x += 16 )
+    {
+      acc0 = vaddq_s32( acc0, vpaddlq_s16( vld1q_s16( org + x ) ) );
+      acc1 = vaddq_s32( acc1, vpaddlq_s16( vld1q_s16( org + x + 8 ) ) );
+    }
+    for( ; x < w; x += 8 )
+      acc0 = vaddq_s32( acc0, vpaddlq_s16( vld1q_s16( org + x ) ) );
+  }
+  return horizontal_add_s32x4( vaddq_s32( acc0, acc1 ) );
+}
+
+// Mirrors calcVarSse: integer accumulation throughout, single final divide.
+static double calcVarNeon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
+{
+  // Pass 1: mean — same dual-accumulator pattern as calcMean.
+  int32x4_t avgAcc0 = vdupq_n_s32( 0 );
+  int32x4_t avgAcc1 = vdupq_n_s32( 0 );
+  const Pel* p      = org;
+  for( int y = 0; y < h; y++, p += origStride )
+  {
+    int x = 0;
+    for( ; x < w - 8; x += 16 )
+    {
+      avgAcc0 = vaddq_s32( avgAcc0, vpaddlq_s16( vld1q_s16( p + x ) ) );
+      avgAcc1 = vaddq_s32( avgAcc1, vpaddlq_s16( vld1q_s16( p + x + 8 ) ) );
+    }
+    for( ; x < w; x += 8 )
+      avgAcc0 = vaddq_s32( avgAcc0, vpaddlq_s16( vld1q_s16( p + x ) ) );
+  }
+  const int shift    = Log2( w ) + Log2( h ) - 4;
+  const int avg      = horizontal_add_s32x4( vaddq_s32( avgAcc0, avgAcc1 ) ) >> shift;
+  // Match _mm_packs_epi32 saturation to the int16 range.
+  const int16x8_t vavg = vdupq_n_s16( (int16_t)Clip3( -32768, 32767, avg ) );
+
+  // Pass 2: variance — dual int64 accumulators to hide add-chain latency.
+  int64x2_t var0 = vdupq_n_s64( 0 );
+  int64x2_t var1 = vdupq_n_s64( 0 );
+  p = org;
+  for( int y = 0; y < h; y++, p += origStride )
+  {
+    for( int x = 0; x < w; x += 8 )
+    {
+      int16x8_t pix = vshlq_n_s16( vld1q_s16( p + x ), 4 );
+      pix           = vsubq_s16( pix, vavg );
+      const int32x4_t lo = vmull_s16( vget_low_s16( pix ), vget_low_s16( pix ) );
+      const int32x4_t hi = vmull_s16( vget_high_s16( pix ), vget_high_s16( pix ) );
+      // Match _mm_madd_epi16 + _mm_cvtepi32_epi64: add adjacent products in
+      // 32-bit (wrapping), then sign-extend to 64-bit before accumulating.
+      var0 = vaddq_s64( var0, vmovl_s32( vpadd_s32( vget_low_s32( lo ), vget_high_s32( lo ) ) ) );
+      var1 = vaddq_s64( var1, vmovl_s32( vpadd_s32( vget_low_s32( hi ), vget_high_s32( hi ) ) ) );
+    }
+  }
+
+  return horizontal_add_s64x2( vaddq_s64( var0, var1 ) ) / 256.0;
+}
+
+template <ARM_VEXT vext>
+void FGAnalyzer::_initFGAnalyzerARM()
+{
+  calcVar  = calcVarNeon;
+  calcMean = calcMeanNeon;
+}
+
+template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
+
+// Entry points for the unit test (the function pointers are private to init).
+double calcVarNeonEntry( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
+{
+  return calcVarNeon( org, origStride, w, h );
+}
+
+int calcMeanNeonEntry( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
+{
+  return calcMeanNeon( org, origStride, w, h );
+}
+
+}  // namespace vvenc
+
+#endif  // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_FGA

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -62,7 +62,8 @@ namespace vvenc
 static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
 {
   // Two independent accumulators allow out-of-order execution to overlap
-  // the add chains and avoid the per-row int16 accumulator reset overhead.
+  // the add chains. vpadalq_s16 folds the pairwise widen and accumulate
+  // into a single instruction.
   int32x4_t acc0 = vdupq_n_s32( 0 );
   int32x4_t acc1 = vdupq_n_s32( 0 );
   for( int y = 0; y < h; y++, org += origStride )
@@ -70,11 +71,11 @@ static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w
     int x = 0;
     for( ; x < w - 8; x += 16 )
     {
-      acc0 = vaddq_s32( acc0, vpaddlq_s16( vld1q_s16( org + x ) ) );
-      acc1 = vaddq_s32( acc1, vpaddlq_s16( vld1q_s16( org + x + 8 ) ) );
+      acc0 = vpadalq_s16( acc0, vld1q_s16( org + x ) );
+      acc1 = vpadalq_s16( acc1, vld1q_s16( org + x + 8 ) );
     }
     for( ; x < w; x += 8 )
-      acc0 = vaddq_s32( acc0, vpaddlq_s16( vld1q_s16( org + x ) ) );
+      acc0 = vpadalq_s16( acc0, vld1q_s16( org + x ) );
   }
   return horizontal_add_s32x4( vaddq_s32( acc0, acc1 ) );
 }
@@ -82,7 +83,7 @@ static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w
 // Mirrors calcVarSse: integer accumulation throughout, single final divide.
 static double calcVarNeon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
 {
-  // Pass 1: mean — same dual-accumulator pattern as calcMean.
+  // Pass 1: mean — same dual-accumulator + vpadalq_s16 pattern as calcMean.
   int32x4_t avgAcc0 = vdupq_n_s32( 0 );
   int32x4_t avgAcc1 = vdupq_n_s32( 0 );
   const Pel* p      = org;
@@ -91,18 +92,19 @@ static double calcVarNeon( const Pel* org, const ptrdiff_t origStride, const int
     int x = 0;
     for( ; x < w - 8; x += 16 )
     {
-      avgAcc0 = vaddq_s32( avgAcc0, vpaddlq_s16( vld1q_s16( p + x ) ) );
-      avgAcc1 = vaddq_s32( avgAcc1, vpaddlq_s16( vld1q_s16( p + x + 8 ) ) );
+      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
+      avgAcc1 = vpadalq_s16( avgAcc1, vld1q_s16( p + x + 8 ) );
     }
     for( ; x < w; x += 8 )
-      avgAcc0 = vaddq_s32( avgAcc0, vpaddlq_s16( vld1q_s16( p + x ) ) );
+      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
   }
   const int shift    = Log2( w ) + Log2( h ) - 4;
   const int avg      = horizontal_add_s32x4( vaddq_s32( avgAcc0, avgAcc1 ) ) >> shift;
   // Match _mm_packs_epi32 saturation to the int16 range.
   const int16x8_t vavg = vdupq_n_s16( (int16_t)Clip3( -32768, 32767, avg ) );
 
-  // Pass 2: variance — dual int64 accumulators to hide add-chain latency.
+  // Pass 2: variance — dual int64 accumulators; vpadalq_s32 pairwise-adds
+  // adjacent squared products and widens to int64 in a single instruction.
   int64x2_t var0 = vdupq_n_s64( 0 );
   int64x2_t var1 = vdupq_n_s64( 0 );
   p = org;
@@ -114,10 +116,8 @@ static double calcVarNeon( const Pel* org, const ptrdiff_t origStride, const int
       pix           = vsubq_s16( pix, vavg );
       const int32x4_t lo = vmull_s16( vget_low_s16( pix ), vget_low_s16( pix ) );
       const int32x4_t hi = vmull_s16( vget_high_s16( pix ), vget_high_s16( pix ) );
-      // Match _mm_madd_epi16 + _mm_cvtepi32_epi64: add adjacent products in
-      // 32-bit (wrapping), then sign-extend to 64-bit before accumulating.
-      var0 = vaddq_s64( var0, vmovl_s32( vpadd_s32( vget_low_s32( lo ), vget_high_s32( lo ) ) ) );
-      var1 = vaddq_s64( var1, vmovl_s32( vpadd_s32( vget_low_s32( hi ), vget_high_s32( hi ) ) ) );
+      var0 = vpadalq_s32( var0, lo );
+      var1 = vpadalq_s32( var1, hi );
     }
   }
 

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -611,6 +611,8 @@ int calcMeanCore ( const Pel* org,
 // ====================================================================================================================
 FGAnalyzer::FGAnalyzer()
 {
+  calcVar  = calcVarCore;
+  calcMean = calcMeanCore;
 }
 
 FGAnalyzer::~FGAnalyzer()

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -609,10 +609,20 @@ int calcMeanCore ( const Pel* org,
 // ====================================================================================================================
 // Film Grain Analysis Functions
 // ====================================================================================================================
-FGAnalyzer::FGAnalyzer()
+FGAnalyzer::FGAnalyzer( bool enableOpt )
 {
   calcVar  = calcVarCore;
   calcMean = calcMeanCore;
+
+  if( enableOpt )
+  {
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
+    initFGAnalyzerX86();
+#endif
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+    initFGAnalyzerARM();
+#endif
+  }
 }
 
 FGAnalyzer::~FGAnalyzer()
@@ -748,16 +758,7 @@ void FGAnalyzer::init ( const int width,
     m_DCTtemp = ( TCoeff* ) xMalloc( TCoeff, DATA_BASE_SIZE * DATA_BASE_SIZE );
   }
 
-  calcVar=calcVarCore;
-  calcMean=calcMeanCore;
   fastDCT2_64 = fastForwardDCT2_B64;
-
-#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
-  initFGAnalyzerX86();
-#endif
-#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
-  initFGAnalyzerARM();
-#endif
 
 }
 

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -752,7 +752,8 @@ void FGAnalyzer::init ( const int width,
 
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
   initFGAnalyzerX86();
-#elif ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+#endif
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
   initFGAnalyzerARM();
 #endif
 

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -752,6 +752,8 @@ void FGAnalyzer::init ( const int width,
 
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
   initFGAnalyzerX86();
+#elif ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+  initFGAnalyzerARM();
 #endif
 
 }

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -611,8 +611,9 @@ int calcMeanCore ( const Pel* org,
 // ====================================================================================================================
 FGAnalyzer::FGAnalyzer( bool enableOpt )
 {
-  calcVar  = calcVarCore;
-  calcMean = calcMeanCore;
+  calcVar     = calcVarCore;
+  calcMean    = calcMeanCore;
+  fastDCT2_64 = fastForwardDCT2_B64;
 
   if( enableOpt )
   {
@@ -757,8 +758,6 @@ void FGAnalyzer::init ( const int width,
   {
     m_DCTtemp = ( TCoeff* ) xMalloc( TCoeff, DATA_BASE_SIZE * DATA_BASE_SIZE );
   }
-
-  fastDCT2_64 = fastForwardDCT2_B64;
 
 }
 

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -195,6 +195,20 @@ public:
 
   SeiFgc::CompModel  getCompModel( int idx ) { return m_compModel[idx];  };
 
+  double (*calcVar) ( const Pel* org,
+                      const ptrdiff_t origStride,
+                      const int w,
+                      const int h );
+
+  int (*calcMean) ( const Pel* org,
+                    const ptrdiff_t origStride,
+                    const int w,
+                    const int h );
+
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+  void initFGAnalyzerARM();
+#endif
+
 private:
   int                             *m_bitDepths;
   ChromaFormat                    m_inputChromaFormat;
@@ -314,16 +328,6 @@ private:
                               uint32_t bitDepth,
                               ComponentID compId );
 
-  double (*calcVar) ( const Pel* org,
-                      const ptrdiff_t origStride,
-                      const int w,
-                      const int h );
-
-  int (*calcMean) ( const Pel* org,
-                    const ptrdiff_t origStride,
-                    const int w,
-                    const int h );
-
   void (*fastDCT2_64) ( const TCoeff* src,
                         TCoeff* dst,
                         int shift,
@@ -337,7 +341,6 @@ private:
   void _initFGAnalyzerX86();
 #endif
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
-  void initFGAnalyzerARM();
   template <ARM_VEXT vext>
   void _initFGAnalyzerARM();
 #endif

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -205,6 +205,13 @@ public:
                     const int w,
                     const int h );
 
+  void (*fastDCT2_64) ( const TCoeff* src,
+                        TCoeff* dst,
+                        int shift,
+                        int line,
+                        int iSkipLine,
+                        int iSkipLine2 );
+
 private:
   int                             *m_bitDepths;
   ChromaFormat                    m_inputChromaFormat;
@@ -323,13 +330,6 @@ private:
                               PelStorage& buff2,
                               uint32_t bitDepth,
                               ComponentID compId );
-
-  void (*fastDCT2_64) ( const TCoeff* src,
-                        TCoeff* dst,
-                        int shift,
-                        int line,
-                        int iSkipLine,
-                        int iSkipLine2 );
 
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
   void initFGAnalyzerX86();

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -177,7 +177,7 @@ public:
 class FGAnalyzer
 {
 public:
-  FGAnalyzer();
+  FGAnalyzer( bool enableOpt = true );
   ~FGAnalyzer();
 
   int                             prevAnalysisPoc                = -1;
@@ -204,10 +204,6 @@ public:
                     const ptrdiff_t origStride,
                     const int w,
                     const int h );
-
-#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
-  void initFGAnalyzerARM();
-#endif
 
 private:
   int                             *m_bitDepths;
@@ -341,6 +337,7 @@ private:
   void _initFGAnalyzerX86();
 #endif
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+  void initFGAnalyzerARM();
   template <ARM_VEXT vext>
   void _initFGAnalyzerARM();
 #endif

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -336,6 +336,11 @@ private:
   template <X86_VEXT vext>
   void _initFGAnalyzerX86();
 #endif
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+  void initFGAnalyzerARM();
+  template <ARM_VEXT vext>
+  void _initFGAnalyzerARM();
+#endif
 };
 
 } // namespace vvenc

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3489,6 +3489,56 @@ static bool test_LoopFilterPandQ()
 
 #endif // TARGET_SIMD_ARM && ENABLE_SIMD_DBLF
 
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
+
+namespace vvenc {
+  double calcVarCore( const Pel*, const ptrdiff_t, const int, const int );
+  double calcVarNeonEntry( const Pel*, const ptrdiff_t, const int, const int );
+  int    calcMeanNeonEntry( const Pel*, const ptrdiff_t, const int, const int );
+}
+// calcMeanCore is a global free function (SEIFilmGrainAnalyzer.cpp uses
+// "using namespace vvenc;", so it is not inside namespace vvenc).
+int calcMeanCore( const Pel*, const ptrdiff_t, const int, const int );
+
+static bool test_FGAnalyzer()
+{
+  printf( "Testing FGAnalyzer::calcVar / calcMean\n" );
+
+  bool                passed    = true;
+  InputGenerator<Pel> gen{ 10, /*is_signed=*/false };
+  unsigned            num_cases = g_fastUnitTest ? 10 : NUM_CASES;
+
+  // FGA block sizes are power-of-two squares; widths are multiples of 8.
+  const int sizes[] = { 8, 16, 32, 64 };
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    for( int w : sizes )
+    {
+      for( int h : sizes )
+      {
+        const ptrdiff_t  stride = w + 8;  // stride != width
+        std::vector<Pel> buf( stride * h );
+        std::generate( buf.begin(), buf.end(), gen );
+
+        std::ostringstream ctx;
+        ctx << "calcVar/calcMean w=" << w << " h=" << h;
+
+        const double varRef = vvenc::calcVarCore( buf.data(), stride, w, h );
+        const double varOpt = vvenc::calcVarNeonEntry( buf.data(), stride, w, h );
+        passed = compare_value( ctx.str() + " var", varRef, varOpt ) && passed;
+
+        const int meanRef = calcMeanCore( buf.data(), stride, w, h );
+        const int meanOpt = vvenc::calcMeanNeonEntry( buf.data(), stride, w, h );
+        passed = compare_value( ctx.str() + " mean", meanRef, meanOpt ) && passed;
+      }
+    }
+  }
+  return passed;
+}
+
+#endif // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_FGA
+
 struct UnitTestEntry
 {
   std::string name;
@@ -3531,6 +3581,9 @@ static const UnitTestEntry test_suites[] = {
 #endif
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
     { "LoopFilterPandQ", test_LoopFilterPandQ },
+#endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
+    { "FGAnalyzer", test_FGAnalyzer },
 #endif
 };
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3490,15 +3490,14 @@ static bool test_LoopFilterPandQ()
 
 #endif // TARGET_SIMD_ARM && ENABLE_SIMD_DBLF
 
-#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
+#if ENABLE_SIMD_OPT_FGA
 
 static bool test_FGAnalyzer()
 {
   printf( "Testing FGAnalyzer::calcVar / calcMean\n" );
 
-  vvenc::FGAnalyzer ref;
-  vvenc::FGAnalyzer opt;
-  opt.initFGAnalyzerARM();
+  vvenc::FGAnalyzer ref{ /*enableOpt=*/false };
+  vvenc::FGAnalyzer opt{ /*enableOpt=*/true };
 
   bool                passed    = true;
   InputGenerator<Pel> gen{ 10, /*is_signed=*/false };
@@ -3532,7 +3531,7 @@ static bool test_FGAnalyzer()
   return passed;
 }
 
-#endif // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_FGA
+#endif // ENABLE_SIMD_OPT_FGA
 
 struct UnitTestEntry
 {
@@ -3577,7 +3576,7 @@ static const UnitTestEntry test_suites[] = {
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
     { "LoopFilterPandQ", test_LoopFilterPandQ },
 #endif
-#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
+#if ENABLE_SIMD_OPT_FGA
     { "FGAnalyzer", test_FGAnalyzer },
 #endif
 };

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -71,6 +71,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonLib/Unit.h"
 
 #include "EncoderLib/EncAdaptiveLoopFilter.h"
+#include "EncoderLib/SEIFilmGrainAnalyzer.h"
 
 #include "apputils/ParseArg.h"
 #include "vvenc/vvenc.h"
@@ -3491,24 +3492,18 @@ static bool test_LoopFilterPandQ()
 
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_FGA
 
-namespace vvenc {
-  double calcVarCore( const Pel*, const ptrdiff_t, const int, const int );
-  double calcVarNeonEntry( const Pel*, const ptrdiff_t, const int, const int );
-  int    calcMeanNeonEntry( const Pel*, const ptrdiff_t, const int, const int );
-}
-// calcMeanCore is a global free function (SEIFilmGrainAnalyzer.cpp uses
-// "using namespace vvenc;", so it is not inside namespace vvenc).
-int calcMeanCore( const Pel*, const ptrdiff_t, const int, const int );
-
 static bool test_FGAnalyzer()
 {
   printf( "Testing FGAnalyzer::calcVar / calcMean\n" );
+
+  vvenc::FGAnalyzer ref;
+  vvenc::FGAnalyzer opt;
+  opt.initFGAnalyzerARM();
 
   bool                passed    = true;
   InputGenerator<Pel> gen{ 10, /*is_signed=*/false };
   unsigned            num_cases = g_fastUnitTest ? 10 : NUM_CASES;
 
-  // FGA block sizes are power-of-two squares; widths are multiples of 8.
   const int sizes[] = { 8, 16, 32, 64 };
 
   for( unsigned i = 0; i < num_cases; ++i )
@@ -3517,19 +3512,19 @@ static bool test_FGAnalyzer()
     {
       for( int h : sizes )
       {
-        const ptrdiff_t  stride = w + 8;  // stride != width
+        const ptrdiff_t  stride = w + 8;
         std::vector<Pel> buf( stride * h );
         std::generate( buf.begin(), buf.end(), gen );
 
         std::ostringstream ctx;
         ctx << "calcVar/calcMean w=" << w << " h=" << h;
 
-        const double varRef = vvenc::calcVarCore( buf.data(), stride, w, h );
-        const double varOpt = vvenc::calcVarNeonEntry( buf.data(), stride, w, h );
+        const double varRef = ref.calcVar( buf.data(), stride, w, h );
+        const double varOpt = opt.calcVar( buf.data(), stride, w, h );
         passed = compare_value( ctx.str() + " var", varRef, varOpt ) && passed;
 
-        const int meanRef = calcMeanCore( buf.data(), stride, w, h );
-        const int meanOpt = vvenc::calcMeanNeonEntry( buf.data(), stride, w, h );
+        const int meanRef = ref.calcMean( buf.data(), stride, w, h );
+        const int meanOpt = opt.calcMean( buf.data(), stride, w, h );
         passed = compare_value( ctx.str() + " mean", meanRef, meanOpt ) && passed;
       }
     }


### PR DESCRIPTION
Add Neon implementations for the FGAnalyzer calcVar/calcMean hooks,
which are called during FGA parameter estimation on analyzed frames
when `--fga` is enabled.

## Implementation

`calcMeanNeon` accumulates pixel sums directly into `int32x4_t` via
`vpaddlq_s16` per load, using a 16-pixel unrolled main loop with two
independent accumulators to expose instruction-level parallelism. The
outer loop advances the row pointer by `origStride` instead of
multiplying per iteration.

`calcVarNeon` follows the same two-pass structure as `calcVarSse`
(mean first, then variance). The mean pass uses the same dual-
accumulator pattern. The variance pass uses two independent `int64x2_t`
accumulators to reduce add-chain latency, matching the
`_mm_madd_epi16` + `_mm_cvtepi32_epi64` semantics of the SSE path.

## Performance

Benchmarked on Neoverse N1 (GCP T2A, 2 vCPU, Ubuntu 22.04,
gcc -O3 -mcpu=native), median of 7 runs, single core:

| Block size | calcVar scalar→Neon | calcMean scalar→Neon |
|------------|--------------------|--------------------|
| 8×8        | 49.0 → 41.5 ns (1.18×) | 18.4 → 17.5 ns (1.05×) |
| 16×16      | 135.3 → 116.0 ns (1.17×) | 43.0 → 32.6 ns (1.32×) |
| 32×32      | 451.9 → 422.3 ns (1.07×) | 136.8 → 114.1 ns (1.20×) |
| 64×64      | 1678.3 → 1511.7 ns (1.11×) | 395.5 → 309.9 ns (1.28×) |

## Testing

Unit test `FGAnalyzer` added to `vvenc_unit_test`, covering all
combinations of width and height in {8, 16, 32, 64} with 100 random
10-bit inputs (10 in fast mode), verified bit-exact against the scalar
reference (tolerance = 0). Tested on Apple M1 and Neoverse N1.

Relates to #711.