### PR TITLE
Arm: Fix Windows compilation with Clang and MSYS2

### DIFF
--- a/cmake/modules/vvencCompilerSupport.cmake
+++ b/cmake/modules/vvencCompilerSupport.cmake
@@ -134,11 +134,7 @@ endfunction()
 # Check if the compiler supports the AArch64 SVE and SVE2 extensions, and set
 # variables for flags used to enable them to avoid duplication.
 function( set_if_compiler_supports_arm_extensions output_flag_sve output_flag_sve2 )
-  if( NOT(( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" ) OR
-          ( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64" )))
-    return()
-  endif()
-  if( UNIX OR MINGW )
+  if( NOT MSVC )
     # SVE is an optional feature from Armv8.2-A.
     set( _flag_sve "-march=armv8.2-a+sve" )
     _set_if_compiler_supports_sve_flag( _sve_supported "${_flag_sve}" )

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -150,9 +150,7 @@ namespace vvenc {
 #else
 #define NVM_ONARCH    "[on 32-bit] "
 #endif
-#endif
-
-#ifdef __INTEL_COMPILER
+#elif __INTEL_COMPILER
 #define NVM_COMPILEDBY  "[ICC %d]", __INTEL_COMPILER
 #elif  _MSC_VER
 #define NVM_COMPILEDBY  "[VS %d]", _MSC_VER
@@ -685,7 +683,7 @@ static inline unsigned int bit_scan_reverse( int a )
 // {
 //   return _bit_scan_reverse( a );
 // }
-#elif defined( __GNUC__ )
+#elif defined( __GNUC__ ) || defined( __clang__ )
 static inline unsigned int bit_scan_reverse( int a )
 {
   return __builtin_clz( a ) ^ ( 8 * sizeof( a ) - 1 );


### PR DESCRIPTION
The existing Windows build with Clang and MSYS2 fails in a couple of ways:

* The environment is not `UNIX OR MINGW` so the build currently fails to pick up the SVE and SVE2 flags. Change this to just `NOT MSVC`.

* `NVM_COMPILEDBY` is defined twice, causing compilation to fail on the duplicate `#define`. Fix the `#elif` chain so it only gets defined once.

* `bit_scan_reverse` was undefined since Clang appears not to define `__GNUC__` when on Windows, so add `|| defined( __clang__ )` to cover it.

* Delete the `CMAKE_SYSTEM_PROCESSOR` guard since this function is only called when `VVDEC_TARGET_ARCH` already matches.