### PR TITLE
Arm: Add Neon and SVE implementations for getPreBlkStatsAccum

### DIFF
--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -85,6 +85,15 @@ void AlfCovariance::initAlfCovarianceARM()
     _initAlfCovarianceARM<NEON>();
   }
 }
+
+void EncAdaptiveLoopFilter::initEncAdaptiveLoopFilterARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initEncAdaptiveLoopFilterARM<NEON>();
+  }
+}
 #endif
 
 #if ENABLE_SIMD_OPT_AFFINE_ME

--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -93,6 +93,12 @@ void EncAdaptiveLoopFilter::initEncAdaptiveLoopFilterARM()
   {
     _initEncAdaptiveLoopFilterARM<NEON>();
   }
+#if TARGET_SIMD_ARM_SVE
+  if( vext >= SVE )
+  {
+    _initEncAdaptiveLoopFilterARM<SVE>();
+  }
+#endif
 }
 #endif
 

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.cpp
@@ -1105,6 +1105,9 @@ EncAdaptiveLoopFilter::EncAdaptiveLoopFilter( bool enableOpt )
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_ALF
     initEncAdaptiveLoopFilter_X86();
 #endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
+    initEncAdaptiveLoopFilterARM();
+#endif
   }
 }
 

--- a/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
+++ b/source/Lib/EncoderLib/EncAdaptiveLoopFilter.h
@@ -453,6 +453,11 @@ public:
   template<X86_VEXT vext>
   void _initEncAdaptiveLoopFilter_X86();
 #endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
+  void initEncAdaptiveLoopFilterARM();
+  template<ARM_VEXT vext>
+  void _initEncAdaptiveLoopFilterARM();
+#endif
 
   void   xStoreAlfAsuEnabledFlag    ( CodingStructure& cs, int ctuX, int ctuY, int ctuIdx, const int compIdx, bool flag );
   void   xStoreAlfAsuAlternative    ( CodingStructure& cs, int ctuX, int ctuY, int ctuIdx, const int compIdx, const uint8_t alt );

--- a/source/Lib/EncoderLib/arm/neon/EncAdaptiveLoopFilter_neon.cpp
+++ b/source/Lib/EncoderLib/arm/neon/EncAdaptiveLoopFilter_neon.cpp
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "EncoderLib/EncAdaptiveLoopFilter.h"
+#include "CommonLib/arm/neon/sum_neon.h"
 #include <arm_neon.h>
 
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
@@ -475,10 +476,127 @@ int gnsSolveByChol_neon( AlfCovariance::TE lhs, alf_float_t* rhs, alf_float_t* x
   return 0;
 }
 
+static inline int32x4_t dot_s16x8x2_neon( const int16x8_t v1, const int16x8_t v2, const int16x8_t v3,
+                                          const int16x8_t v4 )
+{
+  int32x4_t sum = vmull_s16( vget_low_s16( v1 ), vget_low_s16( v2 ) );
+  sum = vmlal_s16( sum, vget_high_s16( v1 ), vget_high_s16( v2 ) );
+  sum = vmlal_s16( sum, vget_low_s16( v3 ), vget_low_s16( v4 ) );
+  sum = vmlal_s16( sum, vget_high_s16( v3 ), vget_high_s16( v4 ) );
+  return sum;
+}
+
+template<int NumBins, int NumCoeff>
+void getPreBlkStatsAccumFixedSize_neon( AlfCovariance& alfCovariance, const Pel* ELocal, const Pel yLocal[4][4] )
+{
+  static constexpr int bstride = MAX_NUM_ALF_LUMA_COEFF << 4;
+  static constexpr int kstride = 1 << 4;
+
+  const int16x8_t y0 = vld1q_s16( &yLocal[0][0] );
+  const int16x8_t y1 = vld1q_s16( &yLocal[2][0] );
+
+  auto y = alfCovariance.y;
+  auto E = alfCovariance.E;
+
+  for( int b0 = 0; b0 < NumBins; b0++ )
+  {
+    // ELocal is one flat buffer, but logically it is ELocal[NumBins][MAX_NUM_ALF_LUMA_COEFF][16].
+    const Pel* Elocalk = ELocal + b0 * bstride;
+
+    for( int k = 0; k < NumCoeff; k++ )
+    {
+      const int16x8_t ek0 = vld1q_s16( Elocalk + 0 );
+      const int16x8_t ek1 = vld1q_s16( Elocalk + 8 );
+
+      y[b0][k] += horizontal_add_s32x4( dot_s16x8x2_neon( ek0, y0, ek1, y1 ) );
+
+      for( int b1 = 0; b1 < NumBins; b1++ )
+      {
+        alf_float_t* cov = &E[b0][b1][k][k];
+        const Pel* Elocall = ELocal + b1 * bstride + k * kstride;
+
+        int l = k;
+
+        for( ; l < NumCoeff - 3; l += 4 )
+        {
+          const int16x8_t el00 = vld1q_s16( Elocall + 0 * 16 + 0 );
+          const int16x8_t el01 = vld1q_s16( Elocall + 0 * 16 + 8 );
+          const int16x8_t el10 = vld1q_s16( Elocall + 1 * 16 + 0 );
+          const int16x8_t el11 = vld1q_s16( Elocall + 1 * 16 + 8 );
+          const int16x8_t el20 = vld1q_s16( Elocall + 2 * 16 + 0 );
+          const int16x8_t el21 = vld1q_s16( Elocall + 2 * 16 + 8 );
+          const int16x8_t el30 = vld1q_s16( Elocall + 3 * 16 + 0 );
+          const int16x8_t el31 = vld1q_s16( Elocall + 3 * 16 + 8 );
+
+          int32x4_t sum0 = dot_s16x8x2_neon( el00, ek0, el01, ek1 );
+          int32x4_t sum1 = dot_s16x8x2_neon( el10, ek0, el11, ek1 );
+          int32x4_t sum2 = dot_s16x8x2_neon( el20, ek0, el21, ek1 );
+          int32x4_t sum3 = dot_s16x8x2_neon( el30, ek0, el31, ek1 );
+
+          float32x4_t vCov = vld1q_f32( cov );
+          const int32x4_t vSum = horizontal_add_4d_s32x4( sum0, sum1, sum2, sum3 );
+          vCov = vaddq_f32( vcvtq_f32_s32( vSum ), vCov );
+          vst1q_f32( cov, vCov );
+
+          cov += 4;
+          Elocall += 4 * 16;
+        }
+
+        for( ; l < NumCoeff; l++ )
+        {
+          const int16x8_t el0 = vld1q_s16( Elocall + 0 );
+          const int16x8_t el1 = vld1q_s16( Elocall + 8 );
+
+          *cov++ += horizontal_add_s32x4( dot_s16x8x2_neon( el0, ek0, el1, ek1 ) );
+          Elocall += 16;
+        }
+      }
+
+      Elocalk += 16;
+    }
+  }
+
+  alfCovariance.pixAcc += horizontal_add_s32x4( dot_s16x8x2_neon( y0, y0, y1, y1 ) );
+}
+
+void getPreBlkStatsAccum_neon( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                               const Pel yLocal[4][4], const int numBins )
+{
+  if( shape.numCoeff == 7 )
+  {
+    if( numBins == 1 )
+    {
+      return getPreBlkStatsAccumFixedSize_neon</*NumBins=*/1, /*NumCoeff=*/7>( alfCovariance, ELocal, yLocal );
+    }
+    else if( numBins == 4 )
+    {
+      return getPreBlkStatsAccumFixedSize_neon</*NumBins=*/4, /*NumCoeff=*/7>( alfCovariance, ELocal, yLocal );
+    }
+  }
+  else if( shape.numCoeff == 13 )
+  {
+    if( numBins == 1 )
+    {
+      return getPreBlkStatsAccumFixedSize_neon</*NumBins=*/1, /*NumCoeff=*/13>( alfCovariance, ELocal, yLocal );
+    }
+    else if( numBins == 4 )
+    {
+      return getPreBlkStatsAccumFixedSize_neon</*NumBins=*/4, /*NumCoeff=*/13>( alfCovariance, ELocal, yLocal );
+    }
+  }
+  CHECK( true, "Unsupported ALF filter shape or number of bins" );
+}
+
 template<>
 void AlfCovariance::_initAlfCovarianceARM<NEON>()
 {
   m_gnsSolveByChol = gnsSolveByChol_neon;
+}
+
+template<>
+void EncAdaptiveLoopFilter::_initEncAdaptiveLoopFilterARM<NEON>()
+{
+  m_getPreBlkStatsAccum = getPreBlkStatsAccum_neon;
 }
 
 } // namespace vvenc

--- a/source/Lib/EncoderLib/arm/sve/EncAdaptiveLoopFilter_sve.cpp
+++ b/source/Lib/EncoderLib/arm/sve/EncAdaptiveLoopFilter_sve.cpp
@@ -1,0 +1,180 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/**
+ * \file EncAdaptiveLoopFilter_sve.cpp
+ * \brief SVE helpers for encoder-side adaptive loop filter code.
+ */
+
+#include <arm_neon.h>
+#include <arm_sve.h>
+
+#include "EncoderLib/EncAdaptiveLoopFilter.h"
+#include "CommonLib/arm/neon/sum_neon.h"
+#include "CommonLib/arm/sve/neon_sve_bridge.h"
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_ALF
+
+namespace vvenc
+{
+
+static inline int64x2_t dot_s16x8x2_sve( const int16x8_t v1, const int16x8_t v2, const int16x8_t v3,
+                                         const int16x8_t v4 )
+{
+  int64x2_t sum = vvenc_sdotq_s16( vdupq_n_s64( 0 ), v1, v2 );
+  sum = vvenc_sdotq_s16( sum, v3, v4 );
+  return sum;
+}
+
+template<int NumBins, int NumCoeff>
+void getPreBlkStatsAccumFixedSize_sve( AlfCovariance& alfCovariance, const Pel* ELocal, const Pel yLocal[4][4] )
+{
+  static constexpr int bstride = MAX_NUM_ALF_LUMA_COEFF << 4;
+  static constexpr int kstride = 1 << 4;
+
+  const int16x8_t y0 = vld1q_s16( &yLocal[0][0] );
+  const int16x8_t y1 = vld1q_s16( &yLocal[2][0] );
+
+  auto y = alfCovariance.y;
+  auto E = alfCovariance.E;
+
+  for( int b0 = 0; b0 < NumBins; b0++ )
+  {
+    // ELocal is one flat buffer, but logically it is ELocal[NumBins][MAX_NUM_ALF_LUMA_COEFF][16].
+    const Pel* Elocalk = ELocal + b0 * bstride;
+
+    for( int k = 0; k < NumCoeff; k++ )
+    {
+      const int16x8_t ek0 = vld1q_s16( Elocalk + 0 );
+      const int16x8_t ek1 = vld1q_s16( Elocalk + 8 );
+
+      for( int b1 = 0; b1 < NumBins; b1++ )
+      {
+        alf_float_t* cov = &E[b0][b1][k][k];
+        const Pel* Elocall = ELocal + b1 * bstride + k * kstride;
+
+        int l = k;
+
+        for( ; l < NumCoeff - 3; l += 4 )
+        {
+          const int16x8_t el00 = vld1q_s16( Elocall + 0 * 16 + 0 );
+          const int16x8_t el10 = vld1q_s16( Elocall + 1 * 16 + 0 );
+          const int16x8_t el20 = vld1q_s16( Elocall + 2 * 16 + 0 );
+          const int16x8_t el30 = vld1q_s16( Elocall + 3 * 16 + 0 );
+          const int16x8_t el01 = vld1q_s16( Elocall + 0 * 16 + 8 );
+          const int16x8_t el11 = vld1q_s16( Elocall + 1 * 16 + 8 );
+          const int16x8_t el21 = vld1q_s16( Elocall + 2 * 16 + 8 );
+          const int16x8_t el31 = vld1q_s16( Elocall + 3 * 16 + 8 );
+
+          const int64x2_t sum0 = dot_s16x8x2_sve( el00, ek0, el01, ek1 );
+          const int64x2_t sum1 = dot_s16x8x2_sve( el10, ek0, el11, ek1 );
+          const int64x2_t sum2 = dot_s16x8x2_sve( el20, ek0, el21, ek1 );
+          const int64x2_t sum3 = dot_s16x8x2_sve( el30, ek0, el31, ek1 );
+
+          const int64x2_t sum01 = pairwise_add_s64x2( sum0, sum1 );
+          const int64x2_t sum23 = pairwise_add_s64x2( sum2, sum3 );
+          const int32x4_t sum = vuzp1q_s32( vreinterpretq_s32_s64( sum01 ), vreinterpretq_s32_s64( sum23 ) );
+
+          float32x4_t vCov = vld1q_f32( cov );
+          vCov = vaddq_f32( vcvtq_f32_s32( sum ), vCov );
+          vst1q_f32( cov, vCov );
+
+          cov += 4;
+          Elocall += 4 * 16;
+        }
+
+        for( ; l < NumCoeff; l++ )
+        {
+          const int16x8_t el0 = vld1q_s16( Elocall + 0 );
+          const int16x8_t el1 = vld1q_s16( Elocall + 8 );
+
+          *cov++ += horizontal_add_s64x2( dot_s16x8x2_sve( el0, ek0, el1, ek1 ) );
+          Elocall += 16;
+        }
+      }
+
+      y[b0][k] += horizontal_add_s64x2( dot_s16x8x2_sve( ek0, y0, ek1, y1 ) );
+
+      Elocalk += 16;
+    }
+  }
+
+  alfCovariance.pixAcc += horizontal_add_s64x2( dot_s16x8x2_sve( y0, y0, y1, y1 ) );
+}
+
+void getPreBlkStatsAccum_sve( AlfCovariance& alfCovariance, const AlfFilterShape& shape, const Pel* ELocal,
+                              const Pel yLocal[4][4], const int numBins )
+{
+  if( shape.numCoeff == 7 )
+  {
+    if( numBins == 1 )
+    {
+      return getPreBlkStatsAccumFixedSize_sve</*NumBins=*/1, /*NumCoeff=*/7>( alfCovariance, ELocal, yLocal );
+    }
+    else if( numBins == 4 )
+    {
+      return getPreBlkStatsAccumFixedSize_sve</*NumBins=*/4, /*NumCoeff=*/7>( alfCovariance, ELocal, yLocal );
+    }
+  }
+  else if( shape.numCoeff == 13 )
+  {
+    if( numBins == 1 )
+    {
+      return getPreBlkStatsAccumFixedSize_sve</*NumBins=*/1, /*NumCoeff=*/13>( alfCovariance, ELocal, yLocal );
+    }
+    else if( numBins == 4 )
+    {
+      return getPreBlkStatsAccumFixedSize_sve</*NumBins=*/4, /*NumCoeff=*/13>( alfCovariance, ELocal, yLocal );
+    }
+  }
+  CHECK( true, "Unsupported ALF filter shape or number of bins" );
+}
+
+template<>
+void EncAdaptiveLoopFilter::_initEncAdaptiveLoopFilterARM<SVE>()
+{
+  m_getPreBlkStatsAccum = getPreBlkStatsAccum_sve;
+}
+
+} // namespace vvenc
+
+#endif

--- a/source/Lib/vvenc/CMakeLists.txt
+++ b/source/Lib/vvenc/CMakeLists.txt
@@ -49,7 +49,7 @@ if( VVENC_ENABLE_ARM_SIMD )
   file( GLOB ARM_INC_FILES CONFIGURE_DEPENDS      "../CommonLib/arm/*.h"        )
 
   file( GLOB ARM_NEON_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/neon/*.cpp" "../EncoderLib/arm/neon/*.cpp" )
-  file( GLOB ARM_SVE_SRC_FILES  CONFIGURE_DEPENDS "../CommonLib/arm/sve/*.cpp" )
+  file( GLOB ARM_SVE_SRC_FILES  CONFIGURE_DEPENDS "../CommonLib/arm/sve/*.cpp" "../EncoderLib/arm/sve/*.cpp" )
   file( GLOB ARM_SVE2_SRC_FILES CONFIGURE_DEPENDS "../CommonLib/arm/sve2/*.cpp" )
 endif()
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -88,9 +88,29 @@ static inline U abs_diff( const T value1, const T value2 )
   return static_cast<U>( value1 > value2 ? value1 - value2 : value2 - value1 );
 }
 
-template<typename T, typename U = T>
-static inline bool compare_value( const std::string& context, const T ref, const T opt, U tolerance = U( 0 ) )
+// Selects a tolerance from the reference value range:
+// max( minTolerance, abs(ref) * relTolerance ), optionally capped by maxTolerance.
+// If maxTolerance is omitted or zero, no upper cut off is applied.
+template<typename T, typename U>
+static inline U scaled_tolerance( const T ref, const T opt, U minTolerance, U relTolerance, U maxTolerance = U( 0 ) )
 {
+  CHECK( maxTolerance > U( 0 ) && minTolerance > maxTolerance,
+         "Minimum tolerance must be less than or equal to maximum tolerance" );
+
+  double tolerance = std::fabs( static_cast<double>( ref ) ) * relTolerance;
+  const double minimum = static_cast<double>( minTolerance );
+  const double maximum = static_cast<double>( maxTolerance );
+
+  tolerance = tolerance > minimum ? tolerance : minimum;
+  return static_cast<U>( maximum > 0.0 && tolerance > maximum ? maximum : tolerance );
+}
+
+template<typename T, typename U = T>
+static inline bool compare_value( const std::string& context, const T ref, const T opt, U minTolerance = U( 0 ),
+                                  U relTolerance = U( 0 ), U maxTolerance = U( 0 ) )
+{
+  const U tolerance =
+      relTolerance > U( 0 ) ? scaled_tolerance( ref, opt, minTolerance, relTolerance, maxTolerance ) : minTolerance;
   if( abs_diff<T, U>( ref, opt ) > tolerance )
   {
     std::cerr << "failed: " << context << "\n"
@@ -102,10 +122,13 @@ static inline bool compare_value( const std::string& context, const T ref, const
 
 template<typename T, typename U = T>
 static inline bool compare_values_1d( const std::string& context, const T* ref, const T* opt, unsigned length,
-                                      U tolerance = U( 0 ) )
+                                      U minTolerance = U( 0 ), U relTolerance = U( 0 ), U maxTolerance = U( 0 ) )
 {
   for( unsigned idx = 0; idx < length; ++idx )
   {
+    const U tolerance = relTolerance > U( 0 )
+                            ? scaled_tolerance( ref[idx], opt[idx], minTolerance, relTolerance, maxTolerance )
+                            : minTolerance;
     if( abs_diff<T, U>( ref[idx], opt[idx] ) > tolerance )
     {
       std::cout << "failed: " << context << "\n"
@@ -118,7 +141,8 @@ static inline bool compare_values_1d( const std::string& context, const T* ref, 
 
 template<typename T, typename U = T>
 static inline bool compare_values_2d( const std::string& context, const T* ref, const T* opt, unsigned rows,
-                                      unsigned cols, unsigned stride = 0, U tolerance = U( 0 ) )
+                                      unsigned cols, unsigned stride = 0, U minTolerance = U( 0 ),
+                                      U relTolerance = U( 0 ), U maxTolerance = U( 0 ) )
 {
   stride = stride != 0 ? stride : cols;
 
@@ -127,6 +151,9 @@ static inline bool compare_values_2d( const std::string& context, const T* ref, 
     for( unsigned col = 0; col < cols; ++col )
     {
       unsigned idx = row * stride + col;
+      const U tolerance = relTolerance > U( 0 )
+                              ? scaled_tolerance( ref[idx], opt[idx], minTolerance, relTolerance, maxTolerance )
+                              : minTolerance;
       if( abs_diff<T, U>( ref[idx], opt[idx] ) > tolerance )
       {
         std::cout << "failed: " << context << "\n"
@@ -3320,6 +3347,13 @@ static bool check_getPreBlkStatsAccum( EncAdaptiveLoopFilter* ref, EncAdaptiveLo
   covRef.create( shape.numCoeff, numBins );
   covOpt.create( shape.numCoeff, numBins );
 
+  static constexpr alf_float_t weightedMinTolerance = 0.1f;
+  static constexpr alf_float_t weightedRelTolerance = 1e-6f; // Gives about 1.0f tolerance for values around 1.0e6.
+  static constexpr alf_float_t weightedMaxTolerance = 1.0f;
+  static constexpr alf_float_t weightedEMinTolerance = 0.3f;
+  static constexpr alf_float_t weightedERelTolerance = 1e-3f; // Gives about 1.0f tolerance for E values around 1.0e3.
+  static constexpr alf_float_t weightedEMaxTolerance = 2.0f;
+
   static constexpr int MaxAlfNumClippingValues = 4;
 
   Pel y[4][4];
@@ -3371,11 +3405,20 @@ static bool check_getPreBlkStatsAccum( EncAdaptiveLoopFilter* ref, EncAdaptiveLo
     }
 
     std::ostringstream sstm;
-    sstm << "getPreBlkStatsAccum filterSize=" << filterSize << " numBins=" << numBins;
+    sstm << testName << " filterSize=" << filterSize << " numBins=" << numBins;
 
-    passed = compare_value( sstm.str() + " pixAcc", covRef.pixAcc, covOpt.pixAcc, Weighted ? 0.1f : 0.0f ) && passed;
+    const alf_float_t minTolerance = Weighted ? weightedMinTolerance : alf_float_t( 0 );
+    const alf_float_t relTolerance = Weighted ? weightedRelTolerance : alf_float_t( 0 );
+    const alf_float_t maxTolerance = Weighted ? weightedMaxTolerance : alf_float_t( 0 );
+    const alf_float_t eMinTolerance = Weighted ? weightedEMinTolerance : alf_float_t( 0 );
+    const alf_float_t eRelTolerance = Weighted ? weightedERelTolerance : alf_float_t( 0 );
+    const alf_float_t eMaxTolerance = Weighted ? weightedEMaxTolerance : alf_float_t( 0 );
+
+    passed = compare_value( sstm.str() + " pixAcc", covRef.pixAcc, covOpt.pixAcc, minTolerance, relTolerance,
+                            maxTolerance ) &&
+             passed;
     passed = compare_values_2d( sstm.str() + " y", &covRef.y[0][0], &covOpt.y[0][0], covRef.numBins, covRef.numCoeff,
-                                MAX_NUM_ALF_LUMA_COEFF, Weighted ? 0.2f : 0.0f ) &&
+                                MAX_NUM_ALF_LUMA_COEFF, minTolerance, relTolerance, maxTolerance ) &&
              passed;
 
     for( int b0 = 0; b0 < covRef.numBins; ++b0 )
@@ -3384,7 +3427,7 @@ static bool check_getPreBlkStatsAccum( EncAdaptiveLoopFilter* ref, EncAdaptiveLo
       {
         passed = compare_values_2d( sstm.str() + " E b0=" + std::to_string( b0 ) + " b1=" + std::to_string( b1 ),
                                     &covRef.E[b0][b1][0][0], &covOpt.E[b0][b1][0][0], covRef.numCoeff, covRef.numCoeff,
-                                    MAX_NUM_ALF_LUMA_COEFF, Weighted ? 1.0f : 0.0f ) &&
+                                    MAX_NUM_ALF_LUMA_COEFF, eMinTolerance, eRelTolerance, eMaxTolerance ) &&
                  passed;
       }
     }


### PR DESCRIPTION
- Add Neon and SVE implementation for getPreBlkStatsAccum.

Neon implementation improves performance by approximately 25% compared to the SIMDe version when benchmarked on a Neoverse V2 with LLVM 22.

SVE implementation improves performance by approximately 35% compared to the Neon version when benchmarked on a Neoverse V2 with LLVM 22.

- Add range-scaled tolerance support to unit tests

Add dynamic tolerance support to the unit-test comparison helpers using
minimum, relative, and maximum tolerance bounds. Apply it to weighted
`getPreBlkStatsWeightedAccum` checks, so small values remain bounded
by a floor while larger accumulated values get proportional tolerance.