### PR TITLE
Unify the initialization of SIMD function pointers

### DIFF
--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -447,8 +447,6 @@ uint64_t AvgHighPassWithDownsamplingDiff2ndCore (const int width,const int heigh
 
 PelBufferOps::PelBufferOps()
 {
-  isInitX86Done = false;
-
   addAvg            = addAvgCore<Pel>;
   reco              = recoCore<Pel>;
   copyClip          = copyClipCore<Pel>;
@@ -495,6 +493,27 @@ PelBufferOps::PelBufferOps()
   AvgHighPassWithDownsamplingDiff2nd = AvgHighPassWithDownsamplingDiff2ndCore;
   HDHighPass = HDHighPassCore;
   HDHighPass2 = HDHighPass2Core;
+}
+
+void PelBufferOps::initPelBufOps( bool enableOpt )
+{
+  if( isInitSIMDDone )
+  {
+    return;
+  }
+  isInitSIMDDone = true;
+
+  if( enableOpt )
+  {
+#if ENABLE_SIMD_OPT_BUFFER
+#  if defined( TARGET_SIMD_X86 )
+    g_pelBufOP.initPelBufOpsX86();
+#  endif
+#  if defined( TARGET_SIMD_ARM )
+    g_pelBufOP.initPelBufOpsARM();
+#  endif
+#endif   // ENABLE_SIMD_OPT_BUFFER
+  }
 }
 
 PelBufferOps g_pelBufOP = PelBufferOps();

--- a/source/Lib/CommonLib/Buffer.h
+++ b/source/Lib/CommonLib/Buffer.h
@@ -81,20 +81,7 @@ using namespace arm_simd;
 struct PelBufferOps
 {
   PelBufferOps();
-
-  bool isInitX86Done;
-
-#if ENABLE_SIMD_OPT_BUFFER && defined(TARGET_SIMD_X86)
-  void initPelBufOpsX86();
-  template<X86_VEXT vext>
-  void _initPelBufOpsX86();
-#endif
-	
-#if ENABLE_SIMD_OPT_BUFFER && defined( TARGET_SIMD_ARM )
-  void initPelBufOpsARM();
-  template<ARM_VEXT vext>
-  void _initPelBufOpsARM();
-#endif
+  void initPelBufOps( bool enableOpt = true );
 
 #define INCX( ptr, stride ) { ptr++; }
 #define INCY( ptr, stride ) { ptr += ( stride ); }
@@ -140,6 +127,21 @@ struct PelBufferOps
   uint64_t ( *AvgHighPassWithDownsamplingDiff2nd) (const int width,const int height,const Pel* pSrc,const Pel* pSM1,const Pel* pS21,const int iSrcStride,const int iSM1Stride,const int iSM2Stride);
   uint64_t ( *HDHighPass) (const int width, const int height,const Pel*  pSrc,const Pel* pSM1,const int iSrcStride,const int iSM1Stride);
   uint64_t ( *HDHighPass2)  (const int width, const int height,const Pel*  pSrc,const Pel* pSM1,const Pel* pSM2,const int iSrcStride,const int iSM1Stride,const int iSM2Stride);
+
+private:
+  bool isInitSIMDDone = false;
+
+#if ENABLE_SIMD_OPT_BUFFER && defined(TARGET_SIMD_X86)
+  void initPelBufOpsX86();
+  template<X86_VEXT vext>
+  void _initPelBufOpsX86();
+#endif
+
+#if ENABLE_SIMD_OPT_BUFFER && defined( TARGET_SIMD_ARM )
+  void initPelBufOpsARM();
+  template<ARM_VEXT vext>
+  void _initPelBufOpsARM();
+#endif
 };
 
 extern PelBufferOps g_pelBufOP;

--- a/source/Lib/CommonLib/LoopFilter.cpp
+++ b/source/Lib/CommonLib/LoopFilter.cpp
@@ -344,7 +344,7 @@ static inline void xPelFilterChroma( Pel* piSrc, const ptrdiff_t iOffset, const 
 // Constructor / destructor / create / destroy
 // ====================================================================================================================
 
-LoopFilter::LoopFilter()
+LoopFilter::LoopFilter( bool enableOpt )
 {
   m_origin[0] = Position{ 0, 0 };
   m_origin[1] = Position{ 0, 0 };
@@ -352,16 +352,18 @@ LoopFilter::LoopFilter()
   xPelFilterLuma  = xPelFilterLumaCore;
   xFilteringPandQ = xFilteringPandQCore;
 
+  if( enableOpt )
+  {
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_DBLF
-  initLoopFilterX86();
+    initLoopFilterX86();
 #endif
 #if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
-  initLoopFilterARM();
+    initLoopFilterARM();
 #endif
+  }
 }
 
-LoopFilter::~LoopFilter()
-{}
+
 
 // ====================================================================================================================
 // Public member functions

--- a/source/Lib/CommonLib/LoopFilter.h
+++ b/source/Lib/CommonLib/LoopFilter.h
@@ -76,8 +76,6 @@ private:
   static const uint16_t sm_tcTable  [MAX_QP + 3];
   static const uint8_t  sm_betaTable[MAX_QP + 1];
 
-  void( *xPelFilterLuma  )( Pel* piSrc, const ptrdiff_t step, const ptrdiff_t offset, const int tc, const bool sw, const int iThrCut, const bool bFilterSecondP, const bool bFilterSecondQ, const ClpRng& clpRng );
-  void( *xFilteringPandQ )( Pel* src, ptrdiff_t step, const ptrdiff_t offset, int numberPSide, int numberQSide, int tc );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_DBLF
   void initLoopFilterX86();
@@ -92,9 +90,8 @@ private:
 #endif
 
 public:
-
-  LoopFilter();
-  ~LoopFilter();
+  LoopFilter( bool enableOpt = true );
+  ~LoopFilter() = default;
 
   /// picture-level deblocking filter
   static void calcFilterStrengthsCTU  ( CodingStructure& cs, const UnitArea& ctuArea, const bool clearLFP );
@@ -106,6 +103,9 @@ public:
   void xDeblockArea                   ( const CodingStructure& cs, const UnitArea& area, const ChannelType chType, PelUnitBuf& picReco ) const;
   void loopFilterCu                   ( const CodingUnit& cu, ChannelType chType, DeblockEdgeDir edgeDir, PelUnitBuf& dbBuffer );
   void setOrigin( const ChannelType chType, const Position& pos ) { m_origin[chType] = pos; }
+
+  void( *xPelFilterLuma  )( Pel* piSrc, const ptrdiff_t step, const ptrdiff_t offset, const int tc, const bool sw, const int iThrCut, const bool bFilterSecondP, const bool bFilterSecondQ, const ClpRng& clpRng );
+  void( *xFilteringPandQ )( Pel* src, ptrdiff_t step, const ptrdiff_t offset, int numberPSide, int numberQSide, int tc );
 
 private:
 

--- a/source/Lib/CommonLib/TrQuant_EMT.cpp
+++ b/source/Lib/CommonLib/TrQuant_EMT.cpp
@@ -2025,6 +2025,19 @@ TCoeffOps::TCoeffOps()
   fastFwdCore_2D[4] = fastFwdCore<64>;
 }
 
+void TCoeffOps::initTCoeffOps( bool enableOpt )
+{
+  if( enableOpt )
+  {
+# if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_TRAFO
+    initTCoeffOpsX86();
+# endif
+# if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_TRAFO
+    initTCoeffOpsARM();
+# endif
+  }
+}
+
 TCoeffOps g_tCoeffOps;
 
 #endif

--- a/source/Lib/CommonLib/TrQuant_EMT.h
+++ b/source/Lib/CommonLib/TrQuant_EMT.h
@@ -63,17 +63,7 @@ using namespace arm_simd;
 struct TCoeffOps
 {
   TCoeffOps();
-
-#if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_TRAFO
-  void initTCoeffOpsX86();
-  template<X86_VEXT vext>
-  void _initTCoeffOpsX86();
-#endif
-#if defined(TARGET_SIMD_ARM)  && ENABLE_SIMD_TRAFO
-  void initTCoeffOpsARM();
-  template<ARM_VEXT vext>
-  void _initTCoeffOpsARM();
-#endif
+  void initTCoeffOps( bool enableOpt = true );
 
   void( *cpyResi8 )         ( const TCoeff*      src,        Pel*    dst, ptrdiff_t stride, unsigned width, unsigned height );
   void( *cpyResi4 )         ( const TCoeff*      src,        Pel*    dst, ptrdiff_t stride, unsigned width, unsigned height );
@@ -84,6 +74,18 @@ struct TCoeffOps
   void( *fastFwdCore_1D[5] )( const TMatrixCoeff* it,  const TCoeff* src, TCoeff* dst, unsigned lines, unsigned reducedLines, unsigned cutoff, int shift );
   void( *roundClip4 )       (                                             TCoeff *dst, unsigned width, unsigned height, unsigned stride, const TCoeff outputMin, const TCoeff outputMax, const TCoeff round, const TCoeff shift );
   void( *roundClip8 )       (                                             TCoeff *dst, unsigned width, unsigned height, unsigned stride, const TCoeff outputMin, const TCoeff outputMax, const TCoeff round, const TCoeff shift );
+
+private:
+#if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_TRAFO
+  void initTCoeffOpsX86();
+  template<X86_VEXT vext>
+  void _initTCoeffOpsX86();
+#endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_TRAFO
+  void initTCoeffOpsARM();
+  template<ARM_VEXT vext>
+  void _initTCoeffOpsARM();
+#endif
 };
 
 extern TCoeffOps g_tCoeffOps;

--- a/source/Lib/CommonLib/x86/InitX86.cpp
+++ b/source/Lib/CommonLib/x86/InitX86.cpp
@@ -105,11 +105,6 @@ void InterpolationFilter::initInterpolationFilterX86( /*int iBitDepthY, int iBit
 #if ENABLE_SIMD_OPT_BUFFER
 void PelBufferOps::initPelBufOpsX86()
 {
-  if( isInitX86Done )
-    return;
-
-  isInitX86Done = true;
-
   auto vext = read_x86_extension_flags();
   switch (vext){
     case AVX512:

--- a/source/Lib/vvenc/vvencimpl.cpp
+++ b/source/Lib/vvenc/vvencimpl.cpp
@@ -852,12 +852,7 @@ const char* VVEncImpl::setSIMDExtension( const char* simdId )
 # endif   // ENABLE_SIMD_OPT_BUFFER
 
 # if ENABLE_SIMD_TRAFO
-#  if defined( TARGET_SIMD_X86 )
-    g_tCoeffOps.initTCoeffOpsX86();
-#  endif   // TARGET_SIMD_X86
-#  if defined( TARGET_SIMD_ARM )
-    g_tCoeffOps.initTCoeffOpsARM();
-#  endif   // TARGET_SIMD_ARM
+    g_tCoeffOps.initTCoeffOps();
 # endif    // ENABLE_SIMD_TRAFO
 
 # if defined( TARGET_SIMD_ARM )

--- a/source/Lib/vvenc/vvencimpl.cpp
+++ b/source/Lib/vvenc/vvencimpl.cpp
@@ -843,12 +843,7 @@ const char* VVEncImpl::setSIMDExtension( const char* simdId )
 # endif  // defined( TARGET_SIMD_X86 )
 
 # if ENABLE_SIMD_OPT_BUFFER
-#  if defined( TARGET_SIMD_X86 )
-    g_pelBufOP.initPelBufOpsX86();
-#  endif
-#  if defined( TARGET_SIMD_ARM )
-    g_pelBufOP.initPelBufOpsARM();
-#  endif
+    g_pelBufOP.initPelBufOps();
 # endif   // ENABLE_SIMD_OPT_BUFFER
 
 # if ENABLE_SIMD_TRAFO

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -2253,7 +2253,7 @@ static bool test_AffineGradientSearch()
 }
 #endif // ENABLE_SIMD_OPT_AFFINE_ME
 
-#ifdef ENABLE_SIMD_OPT_BUFFER
+#if ENABLE_SIMD_OPT_BUFFER
 static bool check_addAvg( PelBufferOps* ref, PelBufferOps* opt, unsigned num_cases )
 {
   static constexpr unsigned bd = 10;
@@ -2416,12 +2416,8 @@ static bool test_PelBufferOps()
   PelBufferOps ref;
   PelBufferOps opt;
 
-#if defined( TARGET_SIMD_X86 )
-  opt.initPelBufOpsX86();
-#endif
-#if defined( TARGET_SIMD_ARM )
-  opt.initPelBufOpsARM();
-#endif
+  ref.initPelBufOps( /*enableOpt=*/false );
+  opt.initPelBufOps( /*enableOpt=*/true  );
 
   unsigned num_cases = NUM_CASES;
   bool passed = true;

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3514,16 +3514,12 @@ static bool test_SampleAdaptiveOffset()
 
 #endif // ENABLE_SIMD_OPT_SAO
 
-#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+#if ENABLE_SIMD_DBLF
 
-namespace vvenc {
-  void xFilteringPandQCore( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int );
-  void xFilteringPandQNeonEntry( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int );
-}
 
-static bool check_xFilteringPandQ( void ( *neon )( Pel*, ptrdiff_t, const ptrdiff_t, int, int, int ),
-                                    const std::vector<Pel>& input,
-                                    ptrdiff_t step, ptrdiff_t offset, int nP, int nQ, int tc )
+static bool check_xFilteringPandQ( LoopFilter& ref, LoopFilter& opt,
+                                   const std::vector<Pel>& input,
+                                   ptrdiff_t step, ptrdiff_t offset, int nP, int nQ, int tc )
 {
   const ptrdiff_t stride = 32;
   std::vector<Pel> buf_ref  = input;
@@ -3533,8 +3529,8 @@ static bool check_xFilteringPandQ( void ( *neon )( Pel*, ptrdiff_t, const ptrdif
   // Vertical   (step==stride): boundary at row 0, col 8 -- needs cols [0..16]
   ptrdiff_t src_idx = ( step == 1 ) ? 8 * stride : 8;
 
-  vvenc::xFilteringPandQCore( buf_ref.data()  + src_idx, step, offset, nP, nQ, tc );
-  neon(                        buf_neon.data() + src_idx, step, offset, nP, nQ, tc );
+  ref.xFilteringPandQ( buf_ref.data() + src_idx, step, offset, nP, nQ, tc );
+  opt.xFilteringPandQ( buf_neon.data() + src_idx, step, offset, nP, nQ, tc );
 
   std::ostringstream ctx;
   ctx << "xFilteringPandQ step=" << step << " offset=" << offset
@@ -3546,7 +3542,8 @@ static bool test_LoopFilterPandQ()
 {
   printf( "Testing LoopFilter::xFilteringPandQ\n" );
 
-  auto neon = vvenc::xFilteringPandQNeonEntry;
+  LoopFilter ref( /*enableOpt=*/false );
+  LoopFilter opt( /*enableOpt=*/true );
 
   const ptrdiff_t stride   = 32;
   const int       buf_rows = 20;
@@ -3575,8 +3572,8 @@ static bool test_LoopFilterPandQ()
     for( int k = 0; k < 8; ++k )
     {
       int nP = nP_vals[k], nQ = nQ_vals[k];
-      passed = check_xFilteringPandQ( neon, *f.buf, 1,      stride, nP, nQ, f.tc ) && passed;
-      passed = check_xFilteringPandQ( neon, *f.buf, stride, 1,      nP, nQ, f.tc ) && passed;
+      passed = check_xFilteringPandQ( ref, opt, *f.buf, 1,      stride, nP, nQ, f.tc ) && passed;
+      passed = check_xFilteringPandQ( ref, opt, *f.buf, stride, 1,      nP, nQ, f.tc ) && passed;
     }
   }
 
@@ -3593,14 +3590,14 @@ static bool test_LoopFilterPandQ()
     for( int k = 0; k < 8; ++k )
     {
       int nP = nP_vals[k], nQ = nQ_vals[k];
-      passed = check_xFilteringPandQ( neon, buf_rand, 1,      stride, nP, nQ, tc ) && passed;
-      passed = check_xFilteringPandQ( neon, buf_rand, stride, 1,      nP, nQ, tc ) && passed;
+      passed = check_xFilteringPandQ( ref, opt, buf_rand, 1,      stride, nP, nQ, tc ) && passed;
+      passed = check_xFilteringPandQ( ref, opt, buf_rand, stride, 1,      nP, nQ, tc ) && passed;
     }
   }
   return passed;
 }
 
-#endif // TARGET_SIMD_ARM && ENABLE_SIMD_DBLF
+#endif   // ENABLE_SIMD_DBLF
 
 struct UnitTestEntry
 {
@@ -3642,7 +3639,7 @@ static const UnitTestEntry test_suites[] = {
 #if ENABLE_SIMD_OPT_SAO
     { "SAO", test_SampleAdaptiveOffset },
 #endif
-#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_DBLF
+#if ENABLE_SIMD_DBLF
     { "LoopFilterPandQ", test_LoopFilterPandQ },
 #endif
 };

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -1148,12 +1148,9 @@ static bool test_TCoeffOps()
 {
   TCoeffOps ref;
   TCoeffOps opt;
-#if defined( TARGET_SIMD_X86 )
-  opt.initTCoeffOpsX86();
-#endif
-#if defined( TARGET_SIMD_ARM )
-  opt.initTCoeffOpsARM();
-#endif
+
+  ref.initTCoeffOps( /*enableOpt=*/false );
+  opt.initTCoeffOps( /*enableOpt=*/true );
 
   unsigned num_cases = NUM_CASES;
   bool passed        = true;


### PR DESCRIPTION
Clean up and unify the initialization of the SIMD function pointers in TCoeffOps, PelBufferOps, and LoopFilter. They accept a `bool enableOpt` parameter now like all other classes with SIMD implementations.