### PR TITLE
Arm: Share calcVar_neon between MCTF and FGA

### DIFF
--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -46,7 +46,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CommonDefARM.h"
 #include "CommonLib/CommonDef.h"
-#include "CommonLib/Rom.h"
 #include "EncoderLib/SEIFilmGrainAnalyzer.h"
 #include "sum_neon.h"
 
@@ -80,54 +79,18 @@ static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w
   return horizontal_add_s32x4( vaddq_s32( acc0, acc1 ) );
 }
 
-// Mirrors calcVarSse: integer accumulation throughout, single final divide.
-static double calcVarNeon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
-{
-  // Pass 1: mean — same dual-accumulator + vpadalq_s16 pattern as calcMean.
-  int32x4_t avgAcc0 = vdupq_n_s32( 0 );
-  int32x4_t avgAcc1 = vdupq_n_s32( 0 );
-  const Pel* p      = org;
-  for( int y = 0; y < h; y++, p += origStride )
-  {
-    int x = 0;
-    for( ; x < w - 8; x += 16 )
-    {
-      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
-      avgAcc1 = vpadalq_s16( avgAcc1, vld1q_s16( p + x + 8 ) );
-    }
-    for( ; x < w; x += 8 )
-      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
-  }
-  const int shift    = Log2( w ) + Log2( h ) - 4;
-  const int avg      = horizontal_add_s32x4( vaddq_s32( avgAcc0, avgAcc1 ) ) >> shift;
-  // Match _mm_packs_epi32 saturation to the int16 range.
-  const int16x8_t vavg = vdupq_n_s16( (int16_t)Clip3( -32768, 32767, avg ) );
-
-  // Pass 2: variance — dual int64 accumulators; vpadalq_s32 pairwise-adds
-  // adjacent squared products and widens to int64 in a single instruction.
-  int64x2_t var0 = vdupq_n_s64( 0 );
-  int64x2_t var1 = vdupq_n_s64( 0 );
-  p = org;
-  for( int y = 0; y < h; y++, p += origStride )
-  {
-    for( int x = 0; x < w; x += 8 )
-    {
-      int16x8_t pix = vshlq_n_s16( vld1q_s16( p + x ), 4 );
-      pix           = vsubq_s16( pix, vavg );
-      const int32x4_t lo = vmull_s16( vget_low_s16( pix ), vget_low_s16( pix ) );
-      const int32x4_t hi = vmull_s16( vget_high_s16( pix ), vget_high_s16( pix ) );
-      var0 = vpadalq_s32( var0, lo );
-      var1 = vpadalq_s32( var1, hi );
-    }
-  }
-
-  return horizontal_add_s64x2( vaddq_s64( var0, var1 ) ) / 256.0;
-}
+#if ENABLE_SIMD_OPT_MCTF
+// Defined in MCTF_neon.cpp and reused here, mirroring how the x86 build
+// shares calcVarSse between MCTF and the film grain analyzer.
+double calcVar_neon( const Pel* org, const ptrdiff_t origStride, const int w, const int h );
+#endif
 
 template <ARM_VEXT vext>
 void FGAnalyzer::_initFGAnalyzerARM()
 {
-  calcVar  = calcVarNeon;
+#if ENABLE_SIMD_OPT_MCTF
+  calcVar  = calcVar_neon;
+#endif
   calcMean = calcMeanNeon;
 }
 

--- a/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/MCTF_neon.cpp
@@ -48,6 +48,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // ====================================================================================================================
 
 #include "MCTF.h"
+#include "CommonLib/Rom.h"
 #include "sum_neon.h"
 
 #include <arm_neon.h>
@@ -1211,6 +1212,55 @@ void applyFrac6Tap_4x_neon( const Pel* org, const ptrdiff_t origStride, Pel* dst
   }
 }
 
+// Bit-exact port of the x86 calcVarSse: integer accumulation throughout with a
+// single final divide. The mean is computed with a Log2(w)+Log2(h) shift, so it
+// matches the scalar calcVarCore only for power-of-two w,h; for other multiples
+// of 8 it follows the same rounding as calcVarSse. Shared with the film grain
+// analyzer (see FGA_neon.cpp), as on x86.
+double calcVar_neon( const Pel* org, const ptrdiff_t origStride, const int w, const int h )
+{
+  // Pass 1: mean. Dual accumulators with vpadalq_s16, which folds the pairwise
+  // widen and accumulate into a single instruction.
+  int32x4_t avgAcc0 = vdupq_n_s32( 0 );
+  int32x4_t avgAcc1 = vdupq_n_s32( 0 );
+  const Pel* p      = org;
+  for( int y = 0; y < h; y++, p += origStride )
+  {
+    int x = 0;
+    for( ; x < w - 8; x += 16 )
+    {
+      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
+      avgAcc1 = vpadalq_s16( avgAcc1, vld1q_s16( p + x + 8 ) );
+    }
+    for( ; x < w; x += 8 )
+      avgAcc0 = vpadalq_s16( avgAcc0, vld1q_s16( p + x ) );
+  }
+  const int shift    = Log2( w ) + Log2( h ) - 4;
+  const int avg      = horizontal_add_s32x4( vaddq_s32( avgAcc0, avgAcc1 ) ) >> shift;
+  // Match _mm_packs_epi32 saturation to the int16 range.
+  const int16x8_t vavg = vdupq_n_s16( (int16_t)Clip3( -32768, 32767, avg ) );
+
+  // Pass 2: variance. Dual int64 accumulators; vpadalq_s32 pairwise-adds
+  // adjacent squared products and widens to int64 in a single instruction.
+  int64x2_t var0 = vdupq_n_s64( 0 );
+  int64x2_t var1 = vdupq_n_s64( 0 );
+  p = org;
+  for( int y = 0; y < h; y++, p += origStride )
+  {
+    for( int x = 0; x < w; x += 8 )
+    {
+      int16x8_t pix = vshlq_n_s16( vld1q_s16( p + x ), 4 );
+      pix           = vsubq_s16( pix, vavg );
+      const int32x4_t lo = vmull_s16( vget_low_s16( pix ), vget_low_s16( pix ) );
+      const int32x4_t hi = vmull_s16( vget_high_s16( pix ), vget_high_s16( pix ) );
+      var0 = vpadalq_s32( var0, lo );
+      var1 = vpadalq_s32( var1, hi );
+    }
+  }
+
+  return horizontal_add_s64x2( vaddq_s64( var0, var1 ) ) / 256.0;
+}
+
 template<>
 void MCTF::_initMCTF_ARM<NEON>()
 {
@@ -1220,6 +1270,7 @@ void MCTF::_initMCTF_ARM<NEON>()
   m_applyBlock              = applyBlock_neon;
   m_applyFrac[0][0]         = applyFrac6Tap_8x_neon;
   m_applyFrac[1][0]         = applyFrac6Tap_4x_neon;
+  m_calcVar                 = calcVar_neon;
 }
 
 } // namespace vvenc

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -1559,6 +1559,36 @@ static bool check_motionErrorLumaInt8( MCTF* ref, MCTF* opt, unsigned num_cases,
   return true;
 }
 
+// calcVar's mean uses a Log2(w)+Log2(h) shift, so the optimized path only
+// matches the scalar reference for power-of-two block sizes. MCTF edge blocks
+// can be non-power-of-two multiples of 8 (e.g. 24), where the optimized result
+// intentionally follows the x86 calcVarSse behavior instead; those sizes are
+// not exercised here. For the power-of-two sizes below both paths are
+// integer-exact up to the final /256.0 divide, so an exact compare is valid.
+static bool check_calcVar( MCTF* ref, MCTF* opt, unsigned num_cases, int w, int h )
+{
+  printf( "Testing MCTF::calcVar w=%d h=%d\n", w, h );
+  InputGenerator<Pel> gen{ 10, /*is_signed=*/false };
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    const ptrdiff_t  stride = w + 8;  // stride != width
+    std::vector<Pel> buf( stride * h );
+    std::generate( buf.begin(), buf.end(), gen );
+
+    std::ostringstream sstm;
+    sstm << "MCTF::calcVar w=" << w << " h=" << h;
+    const double varRef = ref->m_calcVar( buf.data(), stride, w, h );
+    const double varOpt = opt->m_calcVar( buf.data(), stride, w, h );
+    if( !compare_value( sstm.str(), varRef, varOpt ) )
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static bool test_MCTF()
 {
   MCTF ref{ /*enableOpt=*/false };
@@ -1610,6 +1640,14 @@ static bool test_MCTF()
       passed = check_motionErrorLumaFrac8</*lowRes=*/false>( &ref, &opt, w, h ) && passed;
 
       passed = check_motionErrorLumaInt8( &ref, &opt, num_cases, w, h ) && passed;
+    }
+  }
+
+  for( int w : { 8, 16, 32, 64 } )
+  {
+    for( int h : { 8, 16, 32, 64 } )
+    {
+      passed = check_calcVar( &ref, &opt, num_cases, w, h ) && passed;
     }
   }
   return passed;


### PR DESCRIPTION
Follow-up to #713. As suggested by @K-os, this shares the NEON calcVar implementation between MCTF and the film grain analyzer, mirroring the x86 build where MCTF owns `calcVarSse` and FGA reuses it.

## Changes
- Move `calcVar_neon` from `FGA_neon.cpp` into `MCTF_neon.cpp` (the owner, as on x86) and wire it into `MCTF::_initMCTF_ARM<NEON>()`.
- FGA forward-declares `calcVar_neon` and binds it under `ENABLE_SIMD_OPT_MCTF`, matching the x86 guard. `calcMeanNeon` stays FGA-local.
- SVE inherits the pointer through the existing NEON-then-SVE init stacking.

## Behavior note
MCTF previously had no NEON calcVar. The mean is computed with a `Log2(w)+Log2(h)` shift, so for non-power-of-two edge blocks the result now matches the existing x86 `calcVarSse` behavior rather than the Arm scalar path. In other words this aligns Arm MCTF with x86; it is not bit-exact against the Arm scalar path for those sizes. The added MCTF calcVar unit test covers the power-of-two sizes where the optimized and scalar paths are bit-exact.