### PR TITLE
Fix typo in ALF comment in configuration file

### DIFF
--- a/cfg/randomaccess_medium.cfg
+++ b/cfg/randomaccess_medium.cfg
@@ -66,7 +66,7 @@ MaxNumGeoCand                 : 3
 
 # Tools configuration
 Affine                        : 4      # Affine prediction: 0: disabled, 1: vtm, 2-5: fast modes
-ALF                           : 1      # Adpative Loop Filter: 0: disabled, 1: enabled
+ALF                           : 1      # Adaptive Loop Filter: 0: disabled, 1: enabled
 ALFSpeed                      : 0      # ALF speed (skip filtering of non-referenced frames) [0-1]
 AllowDisFracMMVD              : 1      # Disable fractional MVD in MMVD mode adaptively
 BCW                           : 0      # Enable Generalized Bi-prediction(Bcw) 0: disabled, 1: enabled, 2: fast


### PR DESCRIPTION
The ALF comment currently reads "Adpative". I have changed it such that it retains the correct spelling, "Adaptive".