### PR TITLE
Arm: Add Neon implementation for Morph dilation

### DIFF
--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -263,6 +263,15 @@ void FGAnalyzer::initFGAnalyzerARM()
     _initFGAnalyzerARM<NEON>();
   }
 }
+
+void Morph::initFGAMorphARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initFGAMorphARM<NEON>();
+  }
+}
 #endif  // ENABLE_SIMD_OPT_FGA
 
 #endif  // TARGET_SIMD_ARM

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -102,7 +102,7 @@ template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
 // never alias at real call sites. The two buffers generally have different
 // strides (buff has a margin, Wbuf usually has none), so they are indexed
 // with their own strides.
-static int dilationNeon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth, ComponentID compID, int numIter,
+static int dilation_neon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth, ComponentID compID, int numIter,
                          int iter, Pel Value )
 {
   CHECKD( buff == Wbuf, "buff and Wbuf must not alias" );
@@ -189,7 +189,7 @@ static int dilationNeon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth, 
 template <ARM_VEXT vext>
 void Morph::_initFGAMorphARM()
 {
-  dilation = dilationNeon;
+  dilation = dilation_neon;
 }
 
 template void Morph::_initFGAMorphARM<NEON>();

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -96,6 +96,104 @@ void FGAnalyzer::_initFGAnalyzerARM()
 
 template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
 
+// Morphological dilation: a pixel becomes Value if any of its 3x3 neighbours
+// (including itself) equals Value, otherwise it keeps its original value.
+// buff carries the (border-extended) input, Wbuf receives the output; they
+// never alias at real call sites. The two buffers generally have different
+// strides (buff has a margin, Wbuf usually has none), so they are indexed
+// with their own strides.
+static int dilationNeon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth, ComponentID compID, int numIter,
+                         int iter, Pel Value )
+{
+  CHECKD( buff == Wbuf, "buff and Wbuf must not alias" );
+
+  for( ; iter != numIter; ++iter )
+  {
+    Wbuf->bufs[0].copyFrom( buff->get( compID ) );
+    buff->get( compID ).extendBorderPel( 1, 1 );
+
+    const int       width  = buff->get( compID ).width;
+    const int       height = buff->get( compID ).height;
+    const Pel*      src    = buff->get( compID ).buf;
+    const ptrdiff_t sStr   = buff->get( compID ).stride;
+    Pel*            dst    = Wbuf->bufs[0].buf;
+    const ptrdiff_t dStr   = Wbuf->bufs[0].stride;
+
+    if( width >= 8 )
+    {
+      const int16x8_t vVal = vdupq_n_s16( Value );
+
+      auto rowMask = [vVal]( const Pel* row ) -> uint16x8_t {
+        int16x8_t  l = vld1q_s16( row - 1 );
+        int16x8_t  c = vld1q_s16( row );
+        int16x8_t  r = vld1q_s16( row + 1 );
+        uint16x8_t m = vceqq_s16( c, vVal );
+        m            = vorrq_u16( m, vceqq_s16( l, vVal ) );
+        m            = vorrq_u16( m, vceqq_s16( r, vVal ) );
+        return m;
+      };
+
+      for( int x = 0; ; x += 8 )
+      {
+        if( x + 8 > width ) x = width - 8;   // overlapping tail strip; safe, dst != src within an iteration
+        const Pel* p = src + x;
+
+        uint16x8_t mTop = rowMask( p - sStr );
+        uint16x8_t mMid = rowMask( p );
+        int16x8_t  cMid = vld1q_s16( p );
+
+        for( int y = 0; y < height; y++ )
+        {
+          uint16x8_t mBot    = rowMask( p + ( (ptrdiff_t)y + 1 ) * sStr );
+          uint16x8_t strong  = vorrq_u16( mTop, vorrq_u16( mMid, mBot ) );
+          int16x8_t  res     = vbslq_s16( strong, vVal, cMid );
+          vst1q_s16( dst + (ptrdiff_t)y * dStr + x, res );
+
+          mTop = mMid;
+          mMid = mBot;
+          cMid = vld1q_s16( p + ( (ptrdiff_t)y + 1 ) * sStr );
+        }
+
+        if( x + 8 >= width ) break;
+      }
+    }
+    else
+    {
+      // scalar fallback for width < 8, same 3x3 test as dilation_core
+      for( int y = 0; y < height; y++ )
+      {
+        for( int x = 0; x < width; x++ )
+        {
+          bool strong = false;
+          for( int dy = -1; dy <= 1 && !strong; dy++ )
+          {
+            for( int dx = -1; dx <= 1; dx++ )
+            {
+              if( buff->get( compID ).at( x + dx, y + dy ) == Value )
+              {
+                strong = true;
+                break;
+              }
+            }
+          }
+          dst[y * dStr + x] = strong ? Value : src[y * sStr + x];
+        }
+      }
+    }
+
+    buff->get( compID ).copyFrom( Wbuf->bufs[0] );
+  }
+  return iter;
+}
+
+template <ARM_VEXT vext>
+void Morph::_initFGAMorphARM()
+{
+  dilation = dilationNeon;
+}
+
+template void Morph::_initFGAMorphARM<NEON>();
+
 }  // namespace vvenc
 
 #endif  // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_FGA

--- a/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/FGA_neon.cpp
@@ -85,17 +85,6 @@ static int calcMeanNeon( const Pel* org, const ptrdiff_t origStride, const int w
 double calcVar_neon( const Pel* org, const ptrdiff_t origStride, const int w, const int h );
 #endif
 
-template <ARM_VEXT vext>
-void FGAnalyzer::_initFGAnalyzerARM()
-{
-#if ENABLE_SIMD_OPT_MCTF
-  calcVar  = calcVar_neon;
-#endif
-  calcMean = calcMeanNeon;
-}
-
-template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
-
 // Morphological dilation: a pixel becomes Value if any of its 3x3 neighbours
 // (including itself) equals Value, otherwise it keeps its original value.
 // buff carries the (border-extended) input, Wbuf receives the output; they
@@ -103,9 +92,17 @@ template void FGAnalyzer::_initFGAnalyzerARM<NEON>();
 // strides (buff has a margin, Wbuf usually has none), so they are indexed
 // with their own strides.
 static int dilation_neon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth, ComponentID compID, int numIter,
-                         int iter, Pel Value )
+                          int iter, Pel Value )
 {
   CHECKD( buff == Wbuf, "buff and Wbuf must not alias" );
+
+  // width doesn't change across iterations, so a width<8 buffer stays that
+  // way for the whole call; let the scalar reference handle it rather than
+  // duplicating its 3x3 test here.
+  if( buff->get( compID ).width < 8 )
+  {
+    return dilation_core( buff, Wbuf, bitDepth, compID, numIter, iter, Value );
+  }
 
   for( ; iter != numIter; ++iter )
   {
@@ -119,65 +116,37 @@ static int dilation_neon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth,
     Pel*            dst    = Wbuf->bufs[0].buf;
     const ptrdiff_t dStr   = Wbuf->bufs[0].stride;
 
-    if( width >= 8 )
+    const int16x8_t vVal = vdupq_n_s16( Value );
+
+    auto rowMask = [vVal]( const Pel* row ) -> uint16x8_t {
+      int16x8_t  l = vld1q_s16( row - 1 );
+      int16x8_t  c = vld1q_s16( row );
+      int16x8_t  r = vld1q_s16( row + 1 );
+      uint16x8_t m = vceqq_s16( c, vVal );
+      m            = vorrq_u16( m, vceqq_s16( l, vVal ) );
+      m            = vorrq_u16( m, vceqq_s16( r, vVal ) );
+      return m;
+    };
+
+    for( int y = 0; y < height; y++ )
     {
-      const int16x8_t vVal = vdupq_n_s16( Value );
+      const Pel* srcRow = src + (ptrdiff_t)y * sStr;
+      Pel*       dstRow = dst + (ptrdiff_t)y * dStr;
 
-      auto rowMask = [vVal]( const Pel* row ) -> uint16x8_t {
-        int16x8_t  l = vld1q_s16( row - 1 );
-        int16x8_t  c = vld1q_s16( row );
-        int16x8_t  r = vld1q_s16( row + 1 );
-        uint16x8_t m = vceqq_s16( c, vVal );
-        m            = vorrq_u16( m, vceqq_s16( l, vVal ) );
-        m            = vorrq_u16( m, vceqq_s16( r, vVal ) );
-        return m;
-      };
-
-      for( int x = 0; ; x += 8 )
+      for( int x = 0; x < width; x += 8 )
       {
         if( x + 8 > width ) x = width - 8;   // overlapping tail strip; safe, dst != src within an iteration
-        const Pel* p = src + x;
+        const Pel* p = srcRow + x;
 
-        uint16x8_t mTop = rowMask( p - sStr );
-        uint16x8_t mMid = rowMask( p );
+        // The centre row's vector is needed both for the compare and as
+        // the blend source, so compute its mask inline instead of going
+        // through rowMask() a second time for the same load.
         int16x8_t  cMid = vld1q_s16( p );
-
-        for( int y = 0; y < height; y++ )
-        {
-          uint16x8_t mBot    = rowMask( p + ( (ptrdiff_t)y + 1 ) * sStr );
-          uint16x8_t strong  = vorrq_u16( mTop, vorrq_u16( mMid, mBot ) );
-          int16x8_t  res     = vbslq_s16( strong, vVal, cMid );
-          vst1q_s16( dst + (ptrdiff_t)y * dStr + x, res );
-
-          mTop = mMid;
-          mMid = mBot;
-          cMid = vld1q_s16( p + ( (ptrdiff_t)y + 1 ) * sStr );
-        }
-
-        if( x + 8 >= width ) break;
-      }
-    }
-    else
-    {
-      // scalar fallback for width < 8, same 3x3 test as dilation_core
-      for( int y = 0; y < height; y++ )
-      {
-        for( int x = 0; x < width; x++ )
-        {
-          bool strong = false;
-          for( int dy = -1; dy <= 1 && !strong; dy++ )
-          {
-            for( int dx = -1; dx <= 1; dx++ )
-            {
-              if( buff->get( compID ).at( x + dx, y + dy ) == Value )
-              {
-                strong = true;
-                break;
-              }
-            }
-          }
-          dst[y * dStr + x] = strong ? Value : src[y * sStr + x];
-        }
+        uint16x8_t mMid = vorrq_u16( vceqq_s16( cMid, vVal ),
+                                     vorrq_u16( vceqq_s16( vld1q_s16( p - 1 ), vVal ),
+                                                vceqq_s16( vld1q_s16( p + 1 ), vVal ) ) );
+        uint16x8_t strong = vorrq_u16( rowMask( p - sStr ), vorrq_u16( mMid, rowMask( p + sStr ) ) );
+        vst1q_s16( dstRow + x, vbslq_s16( strong, vVal, cMid ) );
       }
     }
 
@@ -186,13 +155,20 @@ static int dilation_neon( PelStorage* buff, PelStorage* Wbuf, uint32_t bitDepth,
   return iter;
 }
 
-template <ARM_VEXT vext>
-void Morph::_initFGAMorphARM()
+template<>
+void FGAnalyzer::_initFGAnalyzerARM<NEON>()
+{
+#if ENABLE_SIMD_OPT_MCTF
+  calcVar  = calcVar_neon;
+#endif
+  calcMean = calcMeanNeon;
+}
+
+template<>
+void Morph::_initFGAMorphARM<NEON>()
 {
   dilation = dilation_neon;
 }
-
-template void Morph::_initFGAMorphARM<NEON>();
 
 }  // namespace vvenc
 

--- a/source/Lib/CommonLib/x86/FGAX86.h
+++ b/source/Lib/CommonLib/x86/FGAX86.h
@@ -642,8 +642,8 @@ int dilation_SIMD ( PelStorage *buff,
   // The vectorized path below requires width to be a multiple of eight and
   // strictly greater than sixteen: at exactly 16, the AVX2 branch's 16-wide
   // main loop runs zero times, leaving its tail write to read an
-  // uninitialized column -1 (width 16 is fine under SSE alone, but this
-  // guard can't tell which one vext will pick, so it excludes 16 either
+  // uninitialized column -1 (width 16 is fine under SSE alone, but it's not
+  // worth special-casing vext for a single width, so it's excluded either
   // way). It also assumes at least two rows: at height == 1 the y == 0 case
   // makes p_buf_down point past the single row, an out-of-bounds read.
   // Anything outside those bounds falls back to the scalar reference, which

--- a/source/Lib/CommonLib/x86/FGAX86.h
+++ b/source/Lib/CommonLib/x86/FGAX86.h
@@ -639,6 +639,18 @@ int dilation_SIMD ( PelStorage *buff,
   unsigned int windowSize = KERNELSIZE;
   unsigned int padding    = windowSize / 2;
 
+  // The vectorized path below assumes it can always load a full 16-pixel
+  // window on the first column and leave a distinct final chunk for the tail
+  // handling, so it requires width to be a multiple of eight and strictly
+  // greater than sixteen (at exactly 16, the AVX2 branch's main loop runs
+  // zero times and its tail write reads uninitialized column -1). Smaller,
+  // non-multiple-of-eight, or exactly-16 widths fall back to the scalar
+  // reference, which handles all remaining iterations itself.
+  if( width <= 16 || ( width % 8 ) != 0 )
+  {
+    return dilation_core( buff, Wbuf, bitDepth, compID, numIter, iter, Value );
+  }
+
   Wbuf->bufs[0].copyFrom( buff->get(compID) );
 
   Pel* p_buf;

--- a/source/Lib/CommonLib/x86/FGAX86.h
+++ b/source/Lib/CommonLib/x86/FGAX86.h
@@ -639,14 +639,16 @@ int dilation_SIMD ( PelStorage *buff,
   unsigned int windowSize = KERNELSIZE;
   unsigned int padding    = windowSize / 2;
 
-  // The vectorized path below assumes it can always load a full 16-pixel
-  // window on the first column and leave a distinct final chunk for the tail
-  // handling, so it requires width to be a multiple of eight and strictly
-  // greater than sixteen (at exactly 16, the AVX2 branch's main loop runs
-  // zero times and its tail write reads uninitialized column -1). Smaller,
-  // non-multiple-of-eight, or exactly-16 widths fall back to the scalar
-  // reference, which handles all remaining iterations itself.
-  if( width <= 16 || ( width % 8 ) != 0 )
+  // The vectorized path below requires width to be a multiple of eight and
+  // strictly greater than sixteen: at exactly 16, the AVX2 branch's 16-wide
+  // main loop runs zero times, leaving its tail write to read an
+  // uninitialized column -1 (width 16 is fine under SSE alone, but this
+  // guard can't tell which one vext will pick, so it excludes 16 either
+  // way). It also assumes at least two rows: at height == 1 the y == 0 case
+  // makes p_buf_down point past the single row, an out-of-bounds read.
+  // Anything outside those bounds falls back to the scalar reference, which
+  // handles all remaining iterations itself.
+  if( width <= 16 || ( width % 8 ) != 0 || height == 1 )
   {
     return dilation_core( buff, Wbuf, bitDepth, compID, numIter, iter, Value );
   }

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.cpp
@@ -530,13 +530,20 @@ int dilation_core ( PelStorage *buff,
 
 }
 
-Morph::Morph()
+Morph::Morph( bool enableOpt )
 {
   // init();
   dilation=dilation_core;
+
+  if( enableOpt )
+  {
 #if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_X86 )
-  initFGAMorphX86();
+    initFGAMorphX86();
 #endif
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+    initFGAMorphARM();
+#endif
+  }
 }
 
 Morph::~Morph()
@@ -610,6 +617,7 @@ int calcMeanCore ( const Pel* org,
 // Film Grain Analysis Functions
 // ====================================================================================================================
 FGAnalyzer::FGAnalyzer( bool enableOpt )
+  : m_morphOperation( enableOpt )
 {
   calcVar     = calcVarCore;
   calcMean    = calcMeanCore;

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -146,7 +146,7 @@ private:
 class Morph
 {
 public:
-  Morph();
+  Morph( bool enableOpt = true );
   ~Morph();
 
   void init ( uint32_t width,
@@ -166,6 +166,11 @@ public:
   void initFGAMorphX86();
   template <X86_VEXT vext>
   void _initFGAMorphX86();
+#endif
+#if ENABLE_SIMD_OPT_FGA && defined( TARGET_SIMD_ARM )
+  void initFGAMorphARM();
+  template <ARM_VEXT vext>
+  void _initFGAMorphARM();
 #endif
 
   PelStorage* m_dilationBuf = nullptr;

--- a/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
+++ b/source/Lib/EncoderLib/SEIFilmGrainAnalyzer.h
@@ -350,6 +350,14 @@ private:
 
 } // namespace vvenc
 
+// Scalar reference for Morph::dilation. Global (not vvenc::) because this
+// header's .cpp only does "using namespace vvenc;" rather than wrapping its
+// definitions in the namespace. SIMD dilation implementations that need a
+// fallback for widths their vectorized path can't handle delegate to it
+// directly instead of duplicating the 3x3 test.
+int dilation_core( vvenc::PelStorage* buff, vvenc::PelStorage* Wbuf, uint32_t bitDepth, vvenc::ComponentID compID,
+                   int numIter, int iter, vvenc::Pel Value );
+
 #endif // __SEIFILMGRAINANALYZER__
 
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3625,6 +3625,69 @@ static bool test_FGAnalyzer()
   return passed;
 }
 
+static bool test_MorphDilation()
+{
+  printf( "Testing Morph::dilation\n" );
+  vvenc::Morph ref{ /*enableOpt=*/false };
+  vvenc::Morph opt{ /*enableOpt=*/true };
+
+  bool     passed    = true;
+  unsigned num_cases = g_fastUnitTest ? 5 : NUM_CASES;
+
+  const int widths[]     = { 4, 8, 24, 44, 64 };
+  const int heights[]    = { 4, 8, 33, 44, 64 };
+  const int iters_list[] = { 1, 2, 4 };
+  const int bitDepth     = 10;
+  const Pel strongPel    = ( (Pel)1 << bitDepth ) - 1;
+  const Pel values[]     = { strongPel, 0 };
+
+  for( unsigned c = 0; c < num_cases; ++c )
+  {
+    for( int w : widths )
+    {
+      for( int h : heights )
+      {
+        for( int numIter : iters_list )
+        {
+          for( Pel value : values )
+          {
+            // Input buffers need margin >= 1 (extendBorderPel requirement). Output/working
+            // buffers use margin 0, matching real call sites (m_maskBuf vs m_dilationBuf).
+            vvenc::PelStorage buffRef, buffOpt, wbufRef, wbufOpt;
+            buffRef.create( VVENC_CHROMA_400, Area( 0, 0, w, h ), 0, 2, 0, false );
+            buffOpt.create( VVENC_CHROMA_400, Area( 0, 0, w, h ), 0, 2, 0, false );
+            wbufRef.create( VVENC_CHROMA_400, Area( 0, 0, w, h ) );
+            wbufOpt.create( VVENC_CHROMA_400, Area( 0, 0, w, h ) );
+
+            InputGenerator<Pel> gen{ (unsigned)bitDepth, /*is_signed=*/false };
+            for( int y = 0; y < h; y++ )
+            {
+              for( int x = 0; x < w; x++ )
+              {
+                Pel v = gen();
+                if( ( rand() % 16 ) == 0 ) v = value;   // sprinkle strong pixels
+                buffRef.getBuf( COMP_Y ).at( x, y ) = v;
+                buffOpt.getBuf( COMP_Y ).at( x, y ) = v;
+              }
+            }
+
+            int rRef = ref.dilation( &buffRef, &wbufRef, bitDepth, COMP_Y, numIter, 0, value );
+            int rOpt = opt.dilation( &buffOpt, &wbufOpt, bitDepth, COMP_Y, numIter, 0, value );
+
+            std::ostringstream ctx;
+            ctx << "Morph::dilation w=" << w << " h=" << h << " numIter=" << numIter << " value=" << value;
+            passed = compare_value( ctx.str() + " ret", rRef, rOpt ) && passed;
+            passed = compare_values_2d( ctx.str(), buffRef.getBuf( COMP_Y ).bufAt( 0, 0 ),
+                                        buffOpt.getBuf( COMP_Y ).bufAt( 0, 0 ), h, w,
+                                        buffRef.getBuf( COMP_Y ).stride ) && passed;
+          }
+        }
+      }
+    }
+  }
+  return passed;
+}
+
 #endif // ENABLE_SIMD_OPT_FGA
 
 struct UnitTestEntry
@@ -3672,6 +3735,7 @@ static const UnitTestEntry test_suites[] = {
 #endif
 #if ENABLE_SIMD_OPT_FGA
     { "FGAnalyzer", test_FGAnalyzer },
+    { "MorphDilation", test_MorphDilation },
 #endif
 };
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3634,9 +3634,9 @@ static bool test_MorphDilation()
   bool     passed    = true;
   unsigned num_cases = g_fastUnitTest ? 5 : NUM_CASES;
 
-  const int widths[]     = { 4, 8, 24, 44, 64 };
+  const int widths[]     = { 4, 8, 16, 24, 44, 64 };
   const int heights[]    = { 4, 8, 33, 44, 64 };
-  const int iters_list[] = { 1, 2, 4 };
+  const int iters_list[] = { 1, 2, 3, 4 };
   const int bitDepth     = 10;
   const Pel strongPel    = ( (Pel)1 << bitDepth ) - 1;
   const Pel values[]     = { strongPel, 0 };

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3634,8 +3634,8 @@ static bool test_MorphDilation()
   bool     passed    = true;
   unsigned num_cases = g_fastUnitTest ? 5 : NUM_CASES;
 
-  const int widths[]     = { 4, 8, 16, 24, 44, 64 };
-  const int heights[]    = { 4, 8, 33, 44, 64 };
+  const int widths[]     = { 4, 8, 16, 24, 32, 44, 64 };
+  const int heights[]    = { 1, 4, 8, 33, 44, 64 };
   const int iters_list[] = { 1, 2, 3, 4 };
   const int bitDepth     = 10;
   const Pel strongPel    = ( (Pel)1 << bitDepth ) - 1;


### PR DESCRIPTION
Follow-up to the ARM SIMD porting stream from #713/#717/#718, as called out in #711 (Morph::dilation has no Neon implementation).

## Change
Adds an ARM Neon port of `Morph::dilation`. The scalar/x86 algorithm dilates a "strong pixel" mask: for each pixel, if any of its 3x3 neighbours (including itself) equals a sentinel `Value`, the output becomes `Value`, otherwise it keeps the original value.

Since `extendBorderPel(1,1)` already writes real replicated border pixels on all sides, including corners, before the pixel loop (same as the scalar reference), the Neon kernel does plain unaligned loads for the left/right/top/bottom taps instead of the in-register lane-shift-and-carry approach the x86 SIMD version uses to avoid touching the border. This keeps the kernel considerably simpler than the x86 version while producing the same result as the scalar reference.

Processes 8 pixels per vector, with an overlapping tail strip for widths that are not a multiple of eight (safe since the destination buffer is disjoint from the source within an iteration) and a scalar fallback for widths under eight.

`Morph`'s constructor now takes an `enableOpt` flag (default true), mirroring the pattern already used for `FGAnalyzer` in #713/#717, so the unit test can construct a scalar-only reference instance alongside an optimized one. `FGAnalyzer` forwards its own `enableOpt` to its embedded `Morph` member.

## x86 fix (second commit)
This PR is the first unit test coverage `Morph::dilation` has ever had, and it surfaced a pre-existing bug in the x86 SIMD path (`dilation_SIMD` in `FGAX86.h`): the vectorized loop bound `x < width - 8` underflows for `width < 8` (width is unsigned), causing out-of-bounds SIMD loads, and the loop plus its tail-column write assume width is a multiple of eight and strictly greater than sixteen (at exactly 16 the AVX2 branch's own main loop runs zero times), so other widths either produce silently wrong output (width == 8 or 16) or write past the destination buffer (e.g. width == 44). Added a width check that delegates to the scalar reference (`dilation_core`) for widths that don't meet those assumptions, instead of duplicating its 3x3 test or touching the vectorized code.

## Performance (third commit)
The first version of the Neon kernel used a column-outer traversal with a rolling row mask to cut compare instructions, but that meant each 8-pixel-wide strip re-streamed the whole frame height, which falls out of cache well before 4K. Switched to row-outer traversal (fresh row-mask computations per output vector, no rolling state) instead.

Measured on this machine (Apple M-series, `-O3`):

| resolution | scalar | Neon |
|---|---|---|
| 1920x1080, iter=4 | 36.70 ms | 2.92 ms (12.6x) |
| 3840x2160, iter=4 | 99.17 ms | 12.11 ms (8.2x) |

Both resolutions scale consistently; the column-outer version measured during review dropped noticeably from 1080p to 4K for the same comparison.

## x86 fix, height == 1 (fourth commit)
The same width guard from the second commit missed another pre-existing edge case: the row-pointer setup in `dilation_SIMD` assumes at least two rows, so at `height == 1` the `y == 0` branch makes `p_buf_down` point one stride past the single row, an out-of-bounds read that produces silently wrong output. Extended the same guard to also fall back to `dilation_core` when `height == 1`.

## Testing
`MorphDilation` unit test compares scalar vs optimized output exactly across widths {4,8,16,24,32,44,64} (covering the scalar-fallback path, the exact-vector-width and AVX2-boundary sizes, the overlapping-tail path, and the width needed to reach the vectorized path at height 1) and heights {1,4,8,33,44,64} (including the height == 1 edge case from the fourth commit), with `numIter` in {1,2,3,4} and `Value` in {strongPel, 0}, matching the call-site patterns in `findMask`. Passes on both ARM and x86 (the x86 build exercises the fixes in the second and fourth commits), and the full unit test suite has no regressions on either.
