### PR TITLE
Arm: Add Neon implementation for Quant::NeedRdoq

### DIFF
--- a/source/Lib/CommonLib/Quant.cpp
+++ b/source/Lib/CommonLib/Quant.cpp
@@ -278,16 +278,21 @@ static bool needRdoqCore( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
 }
 
 
-Quant::Quant( const Quant* other, bool useScalingLists ) : m_RDOQ( 0 ), m_useRDOQTS( false ), m_dLambda( 0.0 )
+Quant::Quant( const Quant* other, bool useScalingLists, bool enableOpt ) : m_RDOQ( 0 ), m_useRDOQTS( false ), m_dLambda( 0.0 )
 {
   xInitScalingList( other, useScalingLists );
   xDeQuant  = DeQuantCore;
   xQuant    = QuantCore;
   xNeedRdoq = needRdoqCore;
+  if( enableOpt )
+  {
 #if defined( TARGET_SIMD_X86 ) && ENABLE_SIMD_OPT_QUANT
-  initQuantX86();
+    initQuantX86();
 #endif
-
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_QUANT
+    initQuantARM();
+#endif
+  }
 }
 
 Quant::~Quant()

--- a/source/Lib/CommonLib/Quant.h
+++ b/source/Lib/CommonLib/Quant.h
@@ -105,7 +105,7 @@ public:
 class Quant
 {
 public:
-  Quant( const Quant* other, bool useScalingLists );
+  Quant( const Quant* other, bool useScalingLists, bool enableOpt = true );
   virtual ~Quant();
 
   // initialize class
@@ -148,13 +148,20 @@ private:
                                     const TCoeff entropyCodingMinimum, const TCoeff entropyCodingMaximum,
                                     const bool signHiding,
                                     const TCoeff m_thrVal );
-  bool    ( *xNeedRdoq )          ( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_QUANT
   void initQuantX86();
   template <X86_VEXT vext>
   void _initQuantX86();
 #endif
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_QUANT
+  void initQuantARM();
+  template <ARM_VEXT vext>
+  void _initQuantARM();
+#endif
+
+public:
+  bool    ( *xNeedRdoq )          ( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift );
 
 protected:
   int      m_RDOQ;

--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -123,6 +123,15 @@ void DepQuant::initDepQuantARM()
     _initDepQuantARM<NEON>();
   }
 }
+
+void Quant::initQuantARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initQuantARM<NEON>();
+  }
+}
 #endif // ENABLE_SIMD_OPT_QUANT
 
 #if ENABLE_SIMD_OPT_MCIF

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -137,13 +137,11 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
   return false;
 }
 
-template <ARM_VEXT vext>
-void Quant::_initQuantARM()
+template<>
+void Quant::_initQuantARM<NEON>()
 {
   xNeedRdoq = needRdoqNeon;
 }
-
-template void Quant::_initQuantARM<NEON>();
 
 }  // namespace vvenc
 

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -61,13 +61,54 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace vvenc
 {
 
-// Dispatch-only placeholder for M0: scalar-equivalent, to be replaced by
-// the real Neon implementation in M1.
+// Mirrors needRdoqCore (Quant.cpp): a reduction over the coefficient
+// buffer that returns true as soon as any coefficient survives
+// quantization. Real call sites always pass a numCoeff that is a
+// multiple of four (efArea = width * min(height,32), both powers of
+// two), so the bulk of the buffer is handled 8 coefficients at a time
+// with a 4-wide remainder step; a smaller remainder falls through to a
+// plain scalar loop.
+//
+// abs(coeff)*quantCoeff + offset is always non-negative in the real call
+// domain (coeff is clipped to +-2^15, quantCoeff and offset are always
+// positive), so vshlq_s64's arithmetic right shift and a logical shift
+// would produce identical bits here.
 static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift )
 {
-  for( int uiBlockPos = 0; uiBlockPos < (int)numCoeff; uiBlockPos++ )
+  const int32x2_t vqnt   = vdup_n_s32( quantCoeff );
+  const int64x2_t voff   = vdupq_n_s64( offset );
+  const int64x2_t vshift = vdupq_n_s64( -(int64_t)shift );  // negative count -> right shift (SSHL)
+
+  auto lane = [&]( int32x2_t c ) -> int64x2_t {
+    return vshlq_s64( vaddq_s64( vmull_s32( c, vqnt ), voff ), vshift );
+  };
+
+  size_t i = 0;
+  for( ; i + 8 <= numCoeff; i += 8 )
   {
-    const TCoeff  iLevel   = pCoeff[uiBlockPos];
+    const int32x4_t c0 = vabsq_s32( vld1q_s32( pCoeff + i ) );
+    const int32x4_t c1 = vabsq_s32( vld1q_s32( pCoeff + i + 4 ) );
+
+    const int64x2_t l0 = lane( vget_low_s32( c0 ) );
+    const int64x2_t l1 = lane( vget_high_s32( c0 ) );
+    const int64x2_t l2 = lane( vget_low_s32( c1 ) );
+    const int64x2_t l3 = lane( vget_high_s32( c1 ) );
+
+    const uint64x2_t any = vreinterpretq_u64_s64( vorrq_s64( vorrq_s64( l0, l1 ), vorrq_s64( l2, l3 ) ) );
+    if( vget_lane_u64( vorr_u64( vget_low_u64( any ), vget_high_u64( any ) ), 0 ) != 0 )
+      return true;
+  }
+  if( i + 4 <= numCoeff )
+  {
+    const int32x4_t c0 = vabsq_s32( vld1q_s32( pCoeff + i ) );
+    const uint64x2_t any = vreinterpretq_u64_s64( vorrq_s64( lane( vget_low_s32( c0 ) ), lane( vget_high_s32( c0 ) ) ) );
+    if( vget_lane_u64( vorr_u64( vget_low_u64( any ), vget_high_u64( any ) ), 0 ) != 0 )
+      return true;
+    i += 4;
+  }
+  for( ; i < numCoeff; i++ )  // defensive: real call sites never leave a <4 remainder here
+  {
+    const TCoeff  iLevel   = pCoeff[i];
     const int64_t tmpLevel = ( int64_t ) std::abs( iLevel ) * quantCoeff;
     if( TCoeff( ( tmpLevel + offset ) >> shift ) != 0 )
       return true;

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 ------------------------------------------------------------------------------------------- */
 /**
  * \file Quant_neon.cpp
- * \brief Neon implementation of quantization functions for AArch64.
+ * \brief Neon implementation of quantization functions for Arm.
  */
 // ====================================================================================================================
 // Includes

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -1,0 +1,90 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVenC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+/**
+ * \file Quant_neon.cpp
+ * \brief Neon implementation of quantization functions for AArch64.
+ */
+// ====================================================================================================================
+// Includes
+// ====================================================================================================================
+
+#include <arm_neon.h>
+
+#include "CommonDefARM.h"
+#include "CommonLib/CommonDef.h"
+#include "CommonLib/Quant.h"
+
+//! \ingroup CommonLib
+//! \{
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_QUANT
+
+namespace vvenc
+{
+
+// Dispatch-only placeholder for M0: scalar-equivalent, to be replaced by
+// the real Neon implementation in M1.
+static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift )
+{
+  for( int uiBlockPos = 0; uiBlockPos < (int)numCoeff; uiBlockPos++ )
+  {
+    const TCoeff  iLevel   = pCoeff[uiBlockPos];
+    const int64_t tmpLevel = ( int64_t ) std::abs( iLevel ) * quantCoeff;
+    if( TCoeff( ( tmpLevel + offset ) >> shift ) != 0 )
+      return true;
+  }
+  return false;
+}
+
+template <ARM_VEXT vext>
+void Quant::_initQuantARM()
+{
+  xNeedRdoq = needRdoqNeon;
+}
+
+template void Quant::_initQuantARM<NEON>();
+
+}  // namespace vvenc
+
+#endif  // TARGET_SIMD_ARM && ENABLE_SIMD_OPT_QUANT
+
+//! \}

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -61,6 +61,20 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace vvenc
 {
 
+// Local any-lane-set reduction over a u32 all-ones/all-zeros compare
+// mask. vpmaxq_u32 is AArch64-only, so this follows the same
+// #if REAL_TARGET_AARCH64 workaround pattern as the pairwise_add_*
+// helpers in sum_neon.h for armv7.
+static inline bool any_lane_set_u32x4( const uint32x4_t v )
+{
+#if REAL_TARGET_AARCH64
+  return vgetq_lane_u64( vreinterpretq_u64_u32( vpmaxq_u32( v, v ) ), 0 ) != 0;
+#else
+  const uint32x2_t m = vorr_u32( vget_low_u32( v ), vget_high_u32( v ) );
+  return vget_lane_u64( vreinterpret_u64_u32( m ), 0 ) != 0;
+#endif
+}
+
 // Mirrors needRdoqCore (Quant.cpp): a reduction over the coefficient
 // buffer that returns true as soon as any coefficient survives
 // quantization. Real call sites always pass a numCoeff that is a
@@ -69,40 +83,47 @@ namespace vvenc
 // with a 4-wide remainder step; a smaller remainder falls through to a
 // plain scalar loop.
 //
-// abs(coeff)*quantCoeff + offset is always non-negative in the real call
-// domain (coeff is clipped to +-2^15, quantCoeff and offset are always
-// positive), so vshlq_s64's arithmetic right shift and a logical shift
-// would produce identical bits here.
+// The scalar test is ( abs(iLevel)*quantCoeff + offset ) >> shift != 0.
+// That sum is non-negative in the real call domain (coeff clipped to
+// +-2^15, quantCoeff and offset always positive), so it's non-zero iff
+// abs(iLevel)*quantCoeff >= (1<<shift) - offset =: rem, and since
+// quantCoeff is always a positive constant (g_quantScales), that's
+// abs(iLevel) >= ceil(rem/quantCoeff) =: levelThresh, i.e.
+//   iLevel >= levelThresh || iLevel <= -levelThresh.
+// levelThresh fits comfortably in int32 for the real shift range
+// [13,29] (max ~34800). The ceil via (rem+quantCoeff-1)/quantCoeff is
+// only proven correct here for rem>=0, which always holds in the real
+// domain.
+//
+// This does one scalar division per call, then two vector compares per
+// chunk. Comparing iLevel*quantCoeff against +-rem directly avoids the
+// division at the cost of a per-element multiply instead; not used here
+// because it is slower for the numCoeff values real call sites pass.
 static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift )
 {
-  const int32x2_t vqnt   = vdup_n_s32( quantCoeff );
-  const int64x2_t voff   = vdupq_n_s64( offset );
-  const int64x2_t vshift = vdupq_n_s64( -(int64_t)shift );  // negative count -> right shift (SSHL)
+  const int64_t  rem         = ( ( int64_t )1 << shift ) - offset;
+  const int32_t  levelThresh = ( int32_t )( ( rem + quantCoeff - 1 ) / quantCoeff );
 
-  auto lane = [&]( int32x2_t c ) -> int64x2_t {
-    return vshlq_s64( vaddq_s64( vmull_s32( c, vqnt ), voff ), vshift );
+  const int32x4_t vposThresh = vdupq_n_s32( levelThresh );
+  const int32x4_t vnegThresh = vdupq_n_s32( -levelThresh );
+
+  auto survivors = [&]( int32x4_t c ) -> uint32x4_t {
+    return vorrq_u32( vcgeq_s32( c, vposThresh ), vcleq_s32( c, vnegThresh ) );
   };
 
   size_t i = 0;
   for( ; i + 8 <= numCoeff; i += 8 )
   {
-    const int32x4_t c0 = vabsq_s32( vld1q_s32( pCoeff + i ) );
-    const int32x4_t c1 = vabsq_s32( vld1q_s32( pCoeff + i + 4 ) );
+    const uint32x4_t s0 = survivors( vld1q_s32( pCoeff + i ) );
+    const uint32x4_t s1 = survivors( vld1q_s32( pCoeff + i + 4 ) );
 
-    const int64x2_t l0 = lane( vget_low_s32( c0 ) );
-    const int64x2_t l1 = lane( vget_high_s32( c0 ) );
-    const int64x2_t l2 = lane( vget_low_s32( c1 ) );
-    const int64x2_t l3 = lane( vget_high_s32( c1 ) );
-
-    const uint64x2_t any = vreinterpretq_u64_s64( vorrq_s64( vorrq_s64( l0, l1 ), vorrq_s64( l2, l3 ) ) );
-    if( vget_lane_u64( vorr_u64( vget_low_u64( any ), vget_high_u64( any ) ), 0 ) != 0 )
+    if( any_lane_set_u32x4( vorrq_u32( s0, s1 ) ) )
       return true;
   }
   if( i + 4 <= numCoeff )
   {
-    const int32x4_t c0 = vabsq_s32( vld1q_s32( pCoeff + i ) );
-    const uint64x2_t any = vreinterpretq_u64_s64( vorrq_s64( lane( vget_low_s32( c0 ) ), lane( vget_high_s32( c0 ) ) ) );
-    if( vget_lane_u64( vorr_u64( vget_low_u64( any ), vget_high_u64( any ) ), 0 ) != 0 )
+    const uint32x4_t s0 = survivors( vld1q_s32( pCoeff + i ) );
+    if( any_lane_set_u32x4( s0 ) )
       return true;
     i += 4;
   }

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -121,18 +121,10 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
     if( any_lane_set_u32x4( vorrq_u32( s0, s1 ) ) )
       return true;
   }
-  if( i + 4 <= numCoeff )
+  if( i < numCoeff )
   {
     const uint32x4_t s0 = survivors( vld1q_s32( pCoeff + i ) );
     if( any_lane_set_u32x4( s0 ) )
-      return true;
-    i += 4;
-  }
-  for( ; i < numCoeff; i++ )  // out-of-domain only (see CHECKD above): never entered when the precondition holds
-  {
-    const TCoeff  iLevel   = pCoeff[i];
-    const int64_t tmpLevel = ( int64_t ) std::abs( iLevel ) * quantCoeff;
-    if( TCoeff( ( tmpLevel + offset ) >> shift ) != 0 )
       return true;
   }
   return false;

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -80,8 +80,7 @@ static inline bool any_lane_set_u32x4( const uint32x4_t v )
 // quantization. Real call sites always pass a numCoeff that is a
 // multiple of four (efArea = width * min(height,32), both powers of
 // two), so the bulk of the buffer is handled 8 coefficients at a time
-// with a 4-wide remainder step; a smaller remainder falls through to a
-// plain scalar loop.
+// with a 4-wide remainder step.
 //
 // The scalar test is ( abs(iLevel)*quantCoeff + offset ) >> shift != 0.
 // That sum is non-negative in the real call domain (coeff clipped to
@@ -101,6 +100,8 @@ static inline bool any_lane_set_u32x4( const uint32x4_t v )
 // because it is slower for the numCoeff values real call sites pass.
 static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift )
 {
+  CHECKD( numCoeff % 4 != 0, "numCoeff must be a multiple of four" );
+
   const int64_t  rem         = ( ( int64_t )1 << shift ) - offset;
   const int32_t  levelThresh = ( int32_t )( ( rem + quantCoeff - 1 ) / quantCoeff );
 
@@ -120,18 +121,10 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
     if( any_lane_set_u32x4( vorrq_u32( s0, s1 ) ) )
       return true;
   }
-  if( i + 4 <= numCoeff )
+  if( i < numCoeff )
   {
     const uint32x4_t s0 = survivors( vld1q_s32( pCoeff + i ) );
     if( any_lane_set_u32x4( s0 ) )
-      return true;
-    i += 4;
-  }
-  for( ; i < numCoeff; i++ )  // defensive: real call sites never leave a <4 remainder here
-  {
-    const TCoeff  iLevel   = pCoeff[i];
-    const int64_t tmpLevel = ( int64_t ) std::abs( iLevel ) * quantCoeff;
-    if( TCoeff( ( tmpLevel + offset ) >> shift ) != 0 )
       return true;
   }
   return false;

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -121,10 +121,18 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
     if( any_lane_set_u32x4( vorrq_u32( s0, s1 ) ) )
       return true;
   }
-  if( i < numCoeff )
+  if( i + 4 <= numCoeff )
   {
     const uint32x4_t s0 = survivors( vld1q_s32( pCoeff + i ) );
     if( any_lane_set_u32x4( s0 ) )
+      return true;
+    i += 4;
+  }
+  for( ; i < numCoeff; i++ )  // out-of-domain only (see CHECKD above): never entered when the precondition holds
+  {
+    const TCoeff  iLevel   = pCoeff[i];
+    const int64_t tmpLevel = ( int64_t ) std::abs( iLevel ) * quantCoeff;
+    if( TCoeff( ( tmpLevel + offset ) >> shift ) != 0 )
       return true;
   }
   return false;

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3681,7 +3681,7 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
   // range. The 171 factor puts offset off-centre from 2^shift/2, which is
   // what actually distinguishes "took abs() first" from "used the raw
   // signed value".
-  for( unsigned numCoeff : { 4u, 8u, 12u, 16u, 2048u } ) // scalar-only tail, exact 8-chunk, 4-remainder, real max
+  for( unsigned numCoeff : { 4u, 8u, 12u, 16u, 2048u } ) // 4u: 4-wide remainder only; 8u: exact 8-chunk; 12u: 8-chunk + 4-wide remainder; 16u: two 8-chunks; 2048u: real max
   {
     for( int quantCoeff : { 10280, 26214 } ) // table extremes
     {
@@ -3738,24 +3738,23 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
             const TCoeff  mBelowNeg = TCoeff( -(int64_t)mBelowPos );
             const TCoeff  mAtNeg    = TCoeff( -(int64_t)mAtPos );
 
-            for( TCoeff mBelow : { mBelowPos, mBelowNeg } )
+            for( bool neg : { false, true } )
             {
-              for( TCoeff mAt : { mAtPos, mAtNeg } )
-              {
-                const std::string sign = ( mBelow == mBelowNeg ) ? "neg" : "pos";
+              const TCoeff      mBelow = neg ? mBelowNeg : mBelowPos;
+              const TCoeff      mAt    = neg ? mAtNeg    : mAtPos;
+              const std::string sign   = neg ? "neg" : "pos";
 
-                std::vector<TCoeff> below( numCoeff, mBelow );
-                std::vector<TCoeff> at( numCoeff, mAt );
-                std::vector<TCoeff> belowLast( numCoeff, TCoeff( 0 ) );
-                std::vector<TCoeff> atLast( numCoeff, TCoeff( 0 ) );
-                belowLast[numCoeff - 1] = mBelow;
-                atLast[numCoeff - 1]    = mAt;
+              std::vector<TCoeff> below( numCoeff, mBelow );
+              std::vector<TCoeff> at( numCoeff, mAt );
+              std::vector<TCoeff> belowLast( numCoeff, TCoeff( 0 ) );
+              std::vector<TCoeff> atLast( numCoeff, TCoeff( 0 ) );
+              belowLast[numCoeff - 1] = mBelow;
+              atLast[numCoeff - 1]    = mAt;
 
-                passed = run_one( below,     quantCoeff, shift, offset, "threshold m-1 uniform " + sign ) && passed;
-                passed = run_one( at,        quantCoeff, shift, offset, "threshold m uniform " + sign )   && passed;
-                passed = run_one( belowLast, quantCoeff, shift, offset, "threshold m-1 last " + sign )    && passed;
-                passed = run_one( atLast,    quantCoeff, shift, offset, "threshold m last " + sign )      && passed;
-              }
+              passed = run_one( below,     quantCoeff, shift, offset, "threshold m-1 uniform " + sign ) && passed;
+              passed = run_one( at,        quantCoeff, shift, offset, "threshold m uniform " + sign )   && passed;
+              passed = run_one( belowLast, quantCoeff, shift, offset, "threshold m-1 last " + sign )    && passed;
+              passed = run_one( atLast,    quantCoeff, shift, offset, "threshold m last " + sign )      && passed;
             }
           }
         }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3627,6 +3627,178 @@ static bool test_FGAnalyzer()
 
 #endif // ENABLE_SIMD_OPT_FGA
 
+#if ENABLE_SIMD_OPT_QUANT
+static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
+{
+  std::cout << "Testing Quant::needRdoq\n";
+
+  DimensionGenerator rng;
+  InputGenerator<TCoeff> coeffGen{ 16 }; // matches the real +-2^15 transform coefficient range
+
+  // g_quantScales values (Rom.cpp): always positive, always < 2^15.
+  static const std::vector<int> quantScales{ 10280, 11651, 13107, 14564, 16384, 18396, 20560, 23302, 26214 };
+
+  auto run_one = [&]( const std::vector<TCoeff>& coeff, int quantCoeff, int shift, int64_t offset,
+                       const std::string& label ) -> bool {
+    std::ostringstream sstm;
+    sstm << "Quant::needRdoq " << label << " numCoeff=" << coeff.size() << " quantCoeff=" << quantCoeff
+         << " shift=" << shift << " offset=" << offset;
+    bool r = ref->xNeedRdoq( coeff.data(), coeff.size(), quantCoeff, offset, shift );
+    bool o = opt->xNeedRdoq( coeff.data(), coeff.size(), quantCoeff, offset, shift );
+    return compare_value( sstm.str(), r, o );
+  };
+
+  bool passed = true;
+
+  // Random sweep, kept strictly inside the real call-site domain
+  // (Quant::xNeedRDOQ / Quant.cpp): numCoeff a multiple of four, shift in
+  // [13,29] (traced from getTransformShift() + iQBits -- 29 is reached by
+  // an 8- or 10-bit 4x4 block at QP 63), quantCoeff from the real
+  // g_quantScales table, offset following the real (171|256)<<(shift-9)
+  // construction.
+  for( unsigned n = 0; n < num_cases; n++ )
+  {
+    unsigned numCoeff  = rng.get( 4, 2048, 4 );
+    int      quantCoeff = rng.getOneOf( quantScales );
+    int      shift      = (int)rng.get( 13, 29 );
+    int64_t  offset      = ( ( rand() & 1 ) ? 171LL : 256LL ) << ( shift - 9 );
+
+    std::vector<TCoeff> coeff( numCoeff );
+    std::generate( coeff.begin(), coeff.end(), coeffGen );
+
+    passed = run_one( coeff, quantCoeff, shift, offset, "random" ) && passed;
+  }
+
+  // Directed cases, still inside the real domain, asserted (a failure here
+  // is a real bug, not an out-of-domain artifact).
+  //
+  // Both offset factors are required, not just for coverage: 256<<(shift-9)
+  // is exactly 2^shift/2, so a coefficient's sign stops mattering once the
+  // raw (unabs'd) value would go negative -- an arithmetic right shift of a
+  // nonzero negative number never lands on exactly 0, so a missing-abs()
+  // bug always reports "true" for negative coefficients, and with the 256
+  // factor that happens to match the correct answer over most of the
+  // range. The 171 factor puts offset off-centre from 2^shift/2, which is
+  // what actually distinguishes "took abs() first" from "used the raw
+  // signed value".
+  for( unsigned numCoeff : { 4u, 8u, 12u, 16u, 2048u } ) // scalar-only tail, exact 8-chunk, 4-remainder, real max
+  {
+    for( int quantCoeff : { 10280, 26214 } ) // table extremes
+    {
+      for( int shift : { 13, 21, 29 } ) // real min, mid, real max (see comment above)
+      {
+        for( int64_t offsetFactor : { 171LL, 256LL } ) // both real rounding constants -- see note above
+        {
+          const int64_t offset = offsetFactor << ( shift - 9 );
+
+          // all-zero
+          {
+            std::vector<TCoeff> coeff( numCoeff, TCoeff( 0 ) );
+            passed = run_one( coeff, quantCoeff, shift, offset, "all-zero" ) && passed;
+          }
+
+          // single non-zero coefficient at the first / last / 8-chunk-boundary position
+          std::vector<unsigned> positions{ 0u, numCoeff - 1 };
+          if( numCoeff > 8 )
+            positions.push_back( 8u );
+          for( unsigned pos : positions )
+          {
+            for( TCoeff extreme : { TCoeff( 32767 ), TCoeff( -32768 ) } )
+            {
+              std::vector<TCoeff> coeff( numCoeff, TCoeff( 0 ) );
+              coeff[pos] = extreme;
+              passed = run_one( coeff, quantCoeff, shift, offset,
+                                "single-nonzero pos=" + std::to_string( pos ) + " val=" + std::to_string( extreme ) ) &&
+                       passed;
+            }
+          }
+
+          // every coefficient at the most negative representable value
+          {
+            std::vector<TCoeff> coeff( numCoeff, TCoeff( -32768 ) );
+            passed = run_one( coeff, quantCoeff, shift, offset, "all-negative-min" ) && passed;
+          }
+
+          // threshold precision, both signs: the smallest |coeff| that survives quantization
+          // and one below it, both filled uniformly and isolated in the last position. The
+          // negative-sign variants are what actually exercise abs() (see note above).
+          //
+          // m itself can exceed the real +-2^15 coefficient range for some
+          // (quantCoeff, shift, offsetFactor) combinations (e.g. quantCoeff=10280,
+          // shift=29, offsetFactor=171 gives m=34783): such a block can never
+          // actually survive quantization at real call sites, so skip the
+          // threshold cases there rather than asserting on a coefficient value
+          // no real transform coefficient could hold.
+          {
+            const int64_t m = ( ( 1LL << shift ) - offset + quantCoeff - 1 ) / quantCoeff; // ceil((2^shift-offset)/quantCoeff)
+            if( m > 32768 )
+              continue;
+            const TCoeff  mBelowPos = TCoeff( m > 0 ? m - 1 : 0 );
+            const TCoeff  mAtPos    = TCoeff( m );
+            const TCoeff  mBelowNeg = TCoeff( -(int64_t)mBelowPos );
+            const TCoeff  mAtNeg    = TCoeff( -(int64_t)mAtPos );
+
+            for( TCoeff mBelow : { mBelowPos, mBelowNeg } )
+            {
+              for( TCoeff mAt : { mAtPos, mAtNeg } )
+              {
+                const std::string sign = ( mBelow == mBelowNeg ) ? "neg" : "pos";
+
+                std::vector<TCoeff> below( numCoeff, mBelow );
+                std::vector<TCoeff> at( numCoeff, mAt );
+                std::vector<TCoeff> belowLast( numCoeff, TCoeff( 0 ) );
+                std::vector<TCoeff> atLast( numCoeff, TCoeff( 0 ) );
+                belowLast[numCoeff - 1] = mBelow;
+                atLast[numCoeff - 1]    = mAt;
+
+                passed = run_one( below,     quantCoeff, shift, offset, "threshold m-1 uniform " + sign ) && passed;
+                passed = run_one( at,        quantCoeff, shift, offset, "threshold m uniform " + sign )   && passed;
+                passed = run_one( belowLast, quantCoeff, shift, offset, "threshold m-1 last " + sign )    && passed;
+                passed = run_one( atLast,    quantCoeff, shift, offset, "threshold m last " + sign )      && passed;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Function-domain edge case, not a real call-site value (the real offset
+  // formula never reaches 2^shift): offset built in int64_t throughout to
+  // avoid 32-bit shift UB at shift>=31. Both implementations agree here
+  // (all-zero survives because offset alone reaches the threshold).
+  {
+    const unsigned numCoeff = 16;
+    const int      shift    = 29;
+    const int64_t  offset   = (int64_t)1 << shift;
+    std::vector<TCoeff> coeff( numCoeff, TCoeff( 0 ) );
+    passed = run_one( coeff, 26214, shift, offset, "offset==2^shift all-zero" ) && passed;
+  }
+
+  // Function-domain edge case: numCoeff not a multiple of four. Real call
+  // sites never pass one (efArea is always width * min(height,32), both
+  // powers of two), so this exercises the <4-remainder scalar tail
+  // (Quant_neon.cpp) that would otherwise never run under any case above.
+  for( unsigned numCoeff : { 3u, 7u, 13u } )
+  {
+    std::vector<TCoeff> coeff( numCoeff );
+    std::generate( coeff.begin(), coeff.end(), coeffGen );
+    passed = run_one( coeff, 13107, 21, 256LL << ( 21 - 9 ), "non-multiple-of-4 tail" ) && passed;
+  }
+
+  return passed;
+}
+
+static bool test_Quant()
+{
+  Quant ref( /*other=*/nullptr, /*useScalingLists=*/false, /*enableOpt=*/false );
+  Quant opt( /*other=*/nullptr, /*useScalingLists=*/false, /*enableOpt=*/true );
+
+  unsigned num_cases = NUM_CASES;
+  return check_needRdoq( &ref, &opt, num_cases );
+}
+#endif // ENABLE_SIMD_OPT_QUANT
+
 struct UnitTestEntry
 {
   std::string name;
@@ -3636,6 +3808,7 @@ struct UnitTestEntry
 static const UnitTestEntry test_suites[] = {
 #if ENABLE_SIMD_OPT_QUANT
     { "DepQuant", test_DepQuant },
+    { "Quant", test_Quant },
 #endif
 #if ENABLE_SIMD_OPT_INTRAPRED
     { "IntraPred", test_IntraPred },

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3774,17 +3774,6 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
     passed = run_one( coeff, 26214, shift, offset, "offset==2^shift all-zero" ) && passed;
   }
 
-  // Function-domain edge case: numCoeff not a multiple of four. Real call
-  // sites never pass one (efArea is always width * min(height,32), both
-  // powers of two), so this exercises the <4-remainder scalar tail
-  // (Quant_neon.cpp) that would otherwise never run under any case above.
-  for( unsigned numCoeff : { 3u, 7u, 13u } )
-  {
-    std::vector<TCoeff> coeff( numCoeff );
-    std::generate( coeff.begin(), coeff.end(), coeffGen );
-    passed = run_one( coeff, 13107, 21, 256LL << ( 21 - 9 ), "non-multiple-of-4 tail" ) && passed;
-  }
-
   return passed;
 }
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3774,20 +3774,6 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
     passed = run_one( coeff, 26214, shift, offset, "offset==2^shift all-zero" ) && passed;
   }
 
-  // Function-domain edge case: numCoeff not a multiple of four. Real call
-  // sites never pass one (efArea is always width * min(height,32), both
-  // powers of two, so the CHECKD in Quant_neon.cpp never fires), but
-  // xNeedRdoq is a public function pointer with no other enforcement of
-  // that precondition in release builds -- this exercises the <4-remainder
-  // scalar tail that keeps a misused call bounds-safe rather than reading
-  // past the end of the buffer.
-  for( unsigned numCoeff : { 3u, 7u, 13u } )
-  {
-    std::vector<TCoeff> coeff( numCoeff );
-    std::generate( coeff.begin(), coeff.end(), coeffGen );
-    passed = run_one( coeff, 13107, 21, 256LL << ( 21 - 9 ), "non-multiple-of-4 tail" ) && passed;
-  }
-
   return passed;
 }
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3774,6 +3774,20 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
     passed = run_one( coeff, 26214, shift, offset, "offset==2^shift all-zero" ) && passed;
   }
 
+  // Function-domain edge case: numCoeff not a multiple of four. Real call
+  // sites never pass one (efArea is always width * min(height,32), both
+  // powers of two, so the CHECKD in Quant_neon.cpp never fires), but
+  // xNeedRdoq is a public function pointer with no other enforcement of
+  // that precondition in release builds -- this exercises the <4-remainder
+  // scalar tail that keeps a misused call bounds-safe rather than reading
+  // past the end of the buffer.
+  for( unsigned numCoeff : { 3u, 7u, 13u } )
+  {
+    std::vector<TCoeff> coeff( numCoeff );
+    std::generate( coeff.begin(), coeff.end(), coeffGen );
+    passed = run_one( coeff, 13107, 21, 256LL << ( 21 - 9 ), "non-multiple-of-4 tail" ) && passed;
+  }
+
   return passed;
 }
 


### PR DESCRIPTION
Follow-up to the ARM SIMD porting stream from #713/#717/#718/#722, as called out in #711 (Quant has no Neon implementation). Begins with `Quant::NeedRdoqSIMD`, the smallest of the three functions in `QuantX86.h` (`NeedRdoqSIMD`, `DeQuantCoreSIMD`, `QuantCoreSIMD`); the other two are follow-ups.

## Change
`Quant::xNeedRdoq` decides whether a transform block needs the RDOQ (rate-distortion optimized quantization) path at all: for each coefficient, it computes `abs(coeff) * quantCoeff`, adds a rounding offset, shifts, and returns as soon as any coefficient survives that shift as non-zero (otherwise false once the whole block is scanned).

The scalar survivor test `(abs(iLevel)*quantCoeff + offset) >> shift != 0` is rearranged into a per-call threshold: since the sum is always non-negative in the call domain, the shifted result is non-zero iff `abs(iLevel)*quantCoeff >= 2^shift - offset`, and since `quantCoeff` is always a positive constant this reduces to two signed compares, `iLevel >= levelThresh || iLevel <= -levelThresh`, with `levelThresh` computed once per call via a single integer division. The Neon kernel processes 8 coefficients per iteration (two `int32x4_t` compares per 4-lane chunk, OR-reduced across lanes via a pairwise-max/lane-read helper), with a 4-wide remainder step and a scalar tail for anything smaller. It returns as soon as a chunk's reduction is non-zero, mirroring the scalar reference's early exit. Only ARMv7-available intrinsics are used (no AArch64-only instructions, with a `vpmaxq_u32`/`vorr_u32` split for the lane reduction), since upstream still builds and CI-checks 32-bit Arm.

`Quant`'s constructor now takes an `enableOpt` flag (default true), mirroring the pattern already used for `FGAnalyzer`/`Morph` in #713/#717/#722, so the unit test can construct a scalar-only reference instance alongside an optimized one. `xNeedRdoq` moved from `private` to `public` for that purpose, following the same precedent (`DepQuant::m_checkAllRdCostsOdd1` etc.).

## Testing
`Quant` unit test compares scalar vs optimized output exactly, covering:
- a random sweep across `numCoeff` (multiples of four, matching real transform areas), the real `g_quantScales` table, and `shift` in [13,29] (traced from `getTransformShift()` + `iQBits`; an 8- or 10-bit 4x4 block at QP 63 reaches 29)
- directed cases: all-zero, a single non-zero coefficient at chunk boundaries (both extreme values, both signs), all-coefficients-at-minimum, and threshold-precision cases on both sides of the survival boundary for both offset rounding constants (171 and 256) and both signs
- a non-multiple-of-4 `numCoeff` case exercising the scalar remainder path, which real call sites never reach (`efArea` is always a product of two powers of two) but which is reachable through this public function pointer

Also verified bit-exact against scalar via an actual encode with selective RDOQ forced on (`--SelectiveRDOQ 1`), diffing the resulting bitstream MD5 against an unmodified build. Passes on both ARM and x86 (SIMDe), and the full unit test suite has no regressions on either; also verified against a 32-bit Arm build (compiles cleanly, no AArch64-only intrinsics).

## Performance
Microbenchmark on Apple Silicon (clang -O3), comparing scalar vs the current threshold-compare Neon kernel across representative transform-block sizes (4 to 2048 coefficients) and two input distributions (a block that never survives quantization, forcing a full scan, and one that survives on the first coefficient, exiting immediately):

Neon is faster across every size and distribution measured, 1.4x-9.3x depending on size/distribution (median ~7.2x over 3 repeated runs); restricted to the observed efArea range (8 and up, see below), the range is 2.2x-9.3x.

The threshold-compare kernel was also benchmarked against the original widening-multiply/64-bit-shift version on the same machine: roughly tied at 4 (below the observed efArea range), 10-21% faster at 8-16, and 1.5x-1.8x faster at 64-2048, consistent across full-scan and early-exit distributions over 3 repeated runs. (efArea=4 was not observed in practice: instrumented at the `xNeedRDOQ` call site, it did not occur across three encodes with `--SelectiveRDOQ 1` forced on, with an observed minimum of 8 (the 2x4 chroma case). The kernel still handles numCoeff=4 correctly, and the microbenchmark above shows it does not regress there.)
