### PR TITLE
Arm: Add Neon implementation for Quant::DeQuant

### DIFF
--- a/source/Lib/CommonLib/Quant.h
+++ b/source/Lib/CommonLib/Quant.h
@@ -140,7 +140,6 @@ private:
   void    xDestroyScalingList     ();
   void    xSetFlatScalingList     ( uint32_t list, uint32_t sizeX, uint32_t sizeY, int qp );
   void    xSignBitHidingHDQ       ( TCoeffSig* pQCoef, const TCoeff* pCoef, TCoeff* deltaU, const CoeffCodingContext& cctx, int &lastPos, const int maxLog2TrDynamicRange);
-  void    ( *xDeQuant)            (const int maxX,const int maxY,const int scale,const TCoeffSig*const piQCoef,const size_t piQCfStride,TCoeff   *const piCoef,const int rightShift,const int inputMaximum,const TCoeff transformMaximum);
   void    ( *xQuant )             ( const TransformUnit tu, const ComponentID compID,
                                     const CCoeffBuf& piCoef, CoeffSigBuf piQCoef,
                                     TCoeff& uiAbsSum, int& lastScanPos, TCoeff* deltaU,
@@ -162,6 +161,7 @@ private:
 
 public:
   bool    ( *xNeedRdoq )          ( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff, int64_t offset, int shift );
+  void    ( *xDeQuant )           ( const int maxX, const int maxY, const int scale, const TCoeffSig* const piQCoef, const size_t piQCfStride, TCoeff* const piCoef, const int rightShift, const int inputMaximum, const TCoeff transformMaximum );
 
 protected:
   int      m_RDOQ;

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -146,15 +146,18 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
 // replaces DeQuantCore's Intermediate_Int arithmetic; no 64-bit lanes are
 // needed. Overflow check for the real (bitDepth, QP, shape) domain of this
 // codebase: the most negative rightShift this encoder's parameter formulas
-// can produce is -10, reached by an SBT-quartered 2x2 chroma sub-block (a
-// vertical-half SBT on an 8-wide inter CU, in 4:2:0, halved once more by a
-// second SBT split) at QP_per's maximum (10 at 8-bit, 12 at 10-bit). At that
-// shift inputMaximum -- derived at the call site as
+// can produce is -10, reached by an SBT-halved 2x2 chroma sub-block (e.g.
+// an 8x4 -- or 4x8 -- inter CU in 4:2:0 has 4x2 -- or 2x4 -- chroma, and a
+// single vertical- or horizontal-half SBT split halves that once more to
+// 2x2; SBT cannot recurse into a second split of an already-SBT-split TU,
+// so this is the only way to reach it) at QP_per's maximum (10 at 8-bit, 12
+// at 10-bit). At that shift inputMaximum -- derived at the call site as
 // (1 << (min(16, 25+rightShift) - 1)) - 1 -- is itself only 16383, not
-// 32767, so |q*scale| <= 16383*102 < 2^21, and the largest left shift (10)
-// keeps the shifted product under 2^31 - 1. inputMaximum only reaches its
-// ordinary 32767 for rightShift >= -9, where the same left-shift bound holds
-// a fortiori.
+// 32767, and clip(q, -inputMaximum-1, inputMaximum) admits the asymmetric
+// minimum -16384, so |q*scale| <= 16384*102 < 2^21, and the largest left
+// shift (10) keeps the shifted product under 2^31 - 1. inputMaximum only
+// reaches its ordinary 32767 for rightShift >= -9, where the same argument
+// (|q| <= 32768) holds a fortiori.
 //
 // Real call sites (Quant::dequant's !enableScalingLists path) always pass
 // a width (maxX+1) that is 1 (degenerate ISP), 2 (e.g. 2x4/4x2/2x2 chroma),

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -134,17 +134,18 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
 // Mirrors DeQuantCore (Quant.cpp). Per coefficient:
 //   q  = clip(piQCoef[x], -inputMaximum-1, inputMaximum)
 //   v  = rightShift > 0 ? (q*scale + (1 << (rightShift-1))) >> rightShift
-//                        :  q*scale << -rightShift
+//                        :  q*scale * (1 << -rightShift)
 //   piCoef[x] = clip(v, -transformMaximum-1, transformMaximum)
 //
 // vrshlq_s32 with a per-lane shift count of -rightShift reproduces both
 // branches exactly: for rightShift>0 (negative count) SRSHL adds the same
 // rounding half-unit before an arithmetic right shift; for rightShift<=0
-// (non-negative count) it's a plain left shift, matching the scalar's
-// un-rounded `<< -rightShift`. TCoeffSig is int16, TCoeff/Intermediate_Int
-// are int32, so a single widening multiply (vmull_n_s16) into 32-bit lanes
-// replaces DeQuantCore's Intermediate_Int arithmetic; no 64-bit lanes are
-// needed. Overflow check for the real (bitDepth, QP, shape) domain of this
+// (non-negative count) it's a plain left shift, numerically the same as
+// the scalar's unrounded multiplication by `1 << -rightShift`. TCoeffSig is
+// int16, TCoeff/Intermediate_Int are int32, so a single widening multiply
+// (vmull_n_s16) into 32-bit lanes replaces DeQuantCore's Intermediate_Int
+// arithmetic; no 64-bit lanes are needed. Overflow check for the real
+// (bitDepth, QP, shape) domain of this
 // codebase: the most negative rightShift this encoder's parameter formulas
 // can produce is -10, reached by an SBT-halved 2x2 chroma sub-block (e.g.
 // an 8x4 -- or 4x8 -- inter CU in 4:2:0 has 4x2 -- or 2x4 -- chroma, and a

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -164,6 +164,16 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
 // 4, or a multiple of 8 (ordinary transform sizes up to 64) -- never 3, 5,
 // 6, or 7. Each width uses an exactly-sized tight load/store (no over-read
 // or over-write).
+//
+// Each width gets its own top-level, non-overlapping loop (rather than a
+// width check re-evaluated on every row inside one shared loop), and input
+// clipping is applied once per load at whatever vector width that load
+// already has the data in -- 4 lanes for width 1/2/4, 8 lanes for width>=8
+// -- instead of being repeated separately on the low and high halves of an
+// 8-lane load. width==1 additionally batches four rows (when available)
+// into a single 4-lane vector, since piCoef's row stride is exactly one
+// TCoeff there, so four scalar rows can share one multiply/shift/store
+// instead of doing all three per row.
 static void dequantNeon( const int maxX, const int maxY, const int scale, const TCoeffSig* const piQCoef,
                           const size_t piQCfStride, TCoeff* const piCoef, const int rightShift,
                           const int inputMaximum, const TCoeff transformMaximum )
@@ -172,14 +182,17 @@ static void dequantNeon( const int maxX, const int maxY, const int scale, const 
   CHECKD( !( width == 1 || width == 2 || width == 4 || ( width >= 8 && ( width & 7 ) == 0 ) ),
           "width must be 1, 2, 4, or a multiple of eight" );
 
-  const int16x4_t vInputMax = vdup_n_s16( ( int16_t )inputMaximum );
-  const int16x4_t vInputMin = vdup_n_s16( ( int16_t )( -inputMaximum - 1 ) );
-  const int32x4_t vShift    = vdupq_n_s32( -rightShift );
-  const int32x4_t vTMax     = vdupq_n_s32( transformMaximum );
-  const int32x4_t vTMin     = vdupq_n_s32( -transformMaximum - 1 );
+  const int16x4_t vInputMax  = vdup_n_s16( ( int16_t )inputMaximum );
+  const int16x4_t vInputMin  = vdup_n_s16( ( int16_t )( -inputMaximum - 1 ) );
+  const int16x8_t vInputMaxQ = vdupq_n_s16( ( int16_t )inputMaximum );
+  const int16x8_t vInputMinQ = vdupq_n_s16( ( int16_t )( -inputMaximum - 1 ) );
+  const int32x4_t vShift     = vdupq_n_s32( -rightShift );
+  const int32x4_t vTMax      = vdupq_n_s32( transformMaximum );
+  const int32x4_t vTMin      = vdupq_n_s32( -transformMaximum - 1 );
 
-  auto convert = [&]( int16x4_t q ) -> int32x4_t {
-    q = vmax_s16( vmin_s16( q, vInputMax ), vInputMin );
+  // Multiply/round-shift/output-clip only; callers input-clip q themselves,
+  // once, before calling this.
+  auto scaleShiftClip = [&]( int16x4_t q ) -> int32x4_t {
     int32x4_t v = vmull_n_s16( q, ( int16_t )scale );
     v           = vrshlq_s32( v, vShift );
     return vmaxq_s32( vminq_s32( v, vTMax ), vTMin );
@@ -187,10 +200,42 @@ static void dequantNeon( const int maxX, const int maxY, const int scale, const 
 
   if( width == 1 )
   {
+    int y = 0;
+    for( ; y + 4 <= maxY + 1; y += 4 )
+    {
+      int16x4_t q = vdup_n_s16( 0 );
+      q = vld1_lane_s16( piQCoef + ( size_t )( y + 0 ) * piQCfStride, q, 0 );
+      q = vld1_lane_s16( piQCoef + ( size_t )( y + 1 ) * piQCfStride, q, 1 );
+      q = vld1_lane_s16( piQCoef + ( size_t )( y + 2 ) * piQCfStride, q, 2 );
+      q = vld1_lane_s16( piQCoef + ( size_t )( y + 3 ) * piQCfStride, q, 3 );
+      q = vmax_s16( vmin_s16( q, vInputMax ), vInputMin );
+      vst1q_s32( piCoef + y, scaleShiftClip( q ) );
+    }
+    for( ; y <= maxY; y++ )
+    {
+      int16x4_t q = vld1_lane_s16( piQCoef + ( size_t )y * piQCfStride, vdup_n_s16( 0 ), 0 );
+      q           = vmax_s16( vmin_s16( q, vInputMax ), vInputMin );
+      vst1q_lane_s32( piCoef + y, scaleShiftClip( q ), 0 );
+    }
+    return;
+  }
+
+  if( width == 2 )
+  {
     for( int y = 0; y <= maxY; y++ )
     {
-      const int16x4_t q = vld1_lane_s16( piQCoef + y * piQCfStride, vdup_n_s16( 0 ), 0 );
-      vst1q_lane_s32( piCoef + y, convert( q ), 0 );
+      int16x4_t q = vmax_s16( vmin_s16( load_s16x2( piQCoef + y * piQCfStride ), vInputMax ), vInputMin );
+      vst1_s32( piCoef + y * width, vget_low_s32( scaleShiftClip( q ) ) );
+    }
+    return;
+  }
+
+  if( width == 4 )
+  {
+    for( int y = 0; y <= maxY; y++ )
+    {
+      int16x4_t q = vmax_s16( vmin_s16( vld1_s16( piQCoef + y * piQCfStride ), vInputMax ), vInputMin );
+      vst1q_s32( piCoef + y * width, scaleShiftClip( q ) );
     }
     return;
   }
@@ -200,22 +245,12 @@ static void dequantNeon( const int maxX, const int maxY, const int scale, const 
     const TCoeffSig* src = piQCoef + y * piQCfStride;
     TCoeff*          dst = piCoef + y * width;
 
-    if( width == 2 )
+    for( int x = 0; x < width; x += 8 )
     {
-      vst1_s32( dst, vget_low_s32( convert( load_s16x2( src ) ) ) );
-    }
-    else if( width == 4 )
-    {
-      vst1q_s32( dst, convert( vld1_s16( src ) ) );
-    }
-    else
-    {
-      for( int x = 0; x < width; x += 8 )
-      {
-        const int16x8_t s = vld1q_s16( src + x );
-        vst1q_s32( dst + x, convert( vget_low_s16( s ) ) );
-        vst1q_s32( dst + x + 4, convert( vget_high_s16( s ) ) );
-      }
+      int16x8_t s = vld1q_s16( src + x );
+      s           = vmaxq_s16( vminq_s16( s, vInputMaxQ ), vInputMinQ );
+      vst1q_s32( dst + x, scaleShiftClip( vget_low_s16( s ) ) );
+      vst1q_s32( dst + x + 4, scaleShiftClip( vget_high_s16( s ) ) );
     }
   }
 }

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -145,15 +145,22 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
 // are int32, so a single widening multiply (vmull_n_s16) into 32-bit lanes
 // replaces DeQuantCore's Intermediate_Int arithmetic; no 64-bit lanes are
 // needed. Overflow check for the real (bitDepth, QP, shape) domain of this
-// codebase: |q*scale| <= 32767*102 < 2^22, and the most negative rightShift
-// this encoder's parameter formulas can produce is -9, so the largest left
-// shift is 9 and the shifted product stays under 2^31 - 1.
+// codebase: the most negative rightShift this encoder's parameter formulas
+// can produce is -10, reached by an SBT-quartered 2x2 chroma sub-block (a
+// vertical-half SBT on an 8-wide inter CU, in 4:2:0, halved once more by a
+// second SBT split) at QP_per's maximum (10 at 8-bit, 12 at 10-bit). At that
+// shift inputMaximum -- derived at the call site as
+// (1 << (min(16, 25+rightShift) - 1)) - 1 -- is itself only 16383, not
+// 32767, so |q*scale| <= 16383*102 < 2^21, and the largest left shift (10)
+// keeps the shifted product under 2^31 - 1. inputMaximum only reaches its
+// ordinary 32767 for rightShift >= -9, where the same left-shift bound holds
+// a fortiori.
 //
 // Real call sites (Quant::dequant's !enableScalingLists path) always pass
-// a width (maxX+1) that is 1 (degenerate ISP), 2 (e.g. 2x4/4x2 chroma), 4,
-// or a multiple of 8 (ordinary transform sizes up to 64) -- never 3, 5, 6,
-// or 7. Each width uses an exactly-sized tight load/store (no over-read or
-// over-write).
+// a width (maxX+1) that is 1 (degenerate ISP), 2 (e.g. 2x4/4x2/2x2 chroma),
+// 4, or a multiple of 8 (ordinary transform sizes up to 64) -- never 3, 5,
+// 6, or 7. Each width uses an exactly-sized tight load/store (no over-read
+// or over-write).
 static void dequantNeon( const int maxX, const int maxY, const int scale, const TCoeffSig* const piQCoef,
                           const size_t piQCfStride, TCoeff* const piCoef, const int rightShift,
                           const int inputMaximum, const TCoeff transformMaximum )

--- a/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Quant_neon.cpp
@@ -52,6 +52,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "CommonDefARM.h"
 #include "CommonLib/CommonDef.h"
 #include "CommonLib/Quant.h"
+#include "CommonLib/arm/mem_neon.h"
 
 //! \ingroup CommonLib
 //! \{
@@ -130,10 +131,90 @@ static bool needRdoqNeon( const TCoeff* pCoeff, size_t numCoeff, int quantCoeff,
   return false;
 }
 
+// Mirrors DeQuantCore (Quant.cpp). Per coefficient:
+//   q  = clip(piQCoef[x], -inputMaximum-1, inputMaximum)
+//   v  = rightShift > 0 ? (q*scale + (1 << (rightShift-1))) >> rightShift
+//                        :  q*scale << -rightShift
+//   piCoef[x] = clip(v, -transformMaximum-1, transformMaximum)
+//
+// vrshlq_s32 with a per-lane shift count of -rightShift reproduces both
+// branches exactly: for rightShift>0 (negative count) SRSHL adds the same
+// rounding half-unit before an arithmetic right shift; for rightShift<=0
+// (non-negative count) it's a plain left shift, matching the scalar's
+// un-rounded `<< -rightShift`. TCoeffSig is int16, TCoeff/Intermediate_Int
+// are int32, so a single widening multiply (vmull_n_s16) into 32-bit lanes
+// replaces DeQuantCore's Intermediate_Int arithmetic; no 64-bit lanes are
+// needed. Overflow check for the real (bitDepth, QP, shape) domain of this
+// codebase: |q*scale| <= 32767*102 < 2^22, and the most negative rightShift
+// this encoder's parameter formulas can produce is -9, so the largest left
+// shift is 9 and the shifted product stays under 2^31 - 1.
+//
+// Real call sites (Quant::dequant's !enableScalingLists path) always pass
+// a width (maxX+1) that is 1 (degenerate ISP), 2 (e.g. 2x4/4x2 chroma), 4,
+// or a multiple of 8 (ordinary transform sizes up to 64) -- never 3, 5, 6,
+// or 7. Each width uses an exactly-sized tight load/store (no over-read or
+// over-write).
+static void dequantNeon( const int maxX, const int maxY, const int scale, const TCoeffSig* const piQCoef,
+                          const size_t piQCfStride, TCoeff* const piCoef, const int rightShift,
+                          const int inputMaximum, const TCoeff transformMaximum )
+{
+  const int width = maxX + 1;
+  CHECKD( !( width == 1 || width == 2 || width == 4 || ( width >= 8 && ( width & 7 ) == 0 ) ),
+          "width must be 1, 2, 4, or a multiple of eight" );
+
+  const int16x4_t vInputMax = vdup_n_s16( ( int16_t )inputMaximum );
+  const int16x4_t vInputMin = vdup_n_s16( ( int16_t )( -inputMaximum - 1 ) );
+  const int32x4_t vShift    = vdupq_n_s32( -rightShift );
+  const int32x4_t vTMax     = vdupq_n_s32( transformMaximum );
+  const int32x4_t vTMin     = vdupq_n_s32( -transformMaximum - 1 );
+
+  auto convert = [&]( int16x4_t q ) -> int32x4_t {
+    q = vmax_s16( vmin_s16( q, vInputMax ), vInputMin );
+    int32x4_t v = vmull_n_s16( q, ( int16_t )scale );
+    v           = vrshlq_s32( v, vShift );
+    return vmaxq_s32( vminq_s32( v, vTMax ), vTMin );
+  };
+
+  if( width == 1 )
+  {
+    for( int y = 0; y <= maxY; y++ )
+    {
+      const int16x4_t q = vld1_lane_s16( piQCoef + y * piQCfStride, vdup_n_s16( 0 ), 0 );
+      vst1q_lane_s32( piCoef + y, convert( q ), 0 );
+    }
+    return;
+  }
+
+  for( int y = 0; y <= maxY; y++ )
+  {
+    const TCoeffSig* src = piQCoef + y * piQCfStride;
+    TCoeff*          dst = piCoef + y * width;
+
+    if( width == 2 )
+    {
+      vst1_s32( dst, vget_low_s32( convert( load_s16x2( src ) ) ) );
+    }
+    else if( width == 4 )
+    {
+      vst1q_s32( dst, convert( vld1_s16( src ) ) );
+    }
+    else
+    {
+      for( int x = 0; x < width; x += 8 )
+      {
+        const int16x8_t s = vld1q_s16( src + x );
+        vst1q_s32( dst + x, convert( vget_low_s16( s ) ) );
+        vst1q_s32( dst + x + 4, convert( vget_high_s16( s ) ) );
+      }
+    }
+  }
+}
+
 template<>
 void Quant::_initQuantARM<NEON>()
 {
   xNeedRdoq = needRdoqNeon;
+  xDeQuant  = dequantNeon;
 }
 
 }  // namespace vvenc

--- a/source/Lib/CommonLib/x86/QuantX86.h
+++ b/source/Lib/CommonLib/x86/QuantX86.h
@@ -95,7 +95,13 @@ static void DeQuantCoreSIMD(const int maxX,const int maxY,const int scale,const 
     {
       for( int y = 0; y <= maxY; y++)
       {
-        __m128i v_level = maxX == 1 ? _mm_set1_epi32( *( ( int const* ) & piQCoef[y * piQCfStride] ) ) : _vv_loadl_epi64( ( __m128i const* ) &piQCoef[y * piQCfStride] );
+        // maxX==0 (width 1) reads/writes exactly one coefficient: a plain
+        // scalar load/store avoids the 6-byte input over-read and 12-byte
+        // output over-write that _vv_loadl_epi64/_mm_storeu_si128 would
+        // cause on a row that only owns 2/4 bytes.
+        __m128i v_level = maxX == 0 ? _mm_set1_epi16( piQCoef[y * piQCfStride] )
+                         : maxX == 1 ? _mm_set1_epi32( *( ( int const* ) & piQCoef[y * piQCfStride] ) )
+                         : _vv_loadl_epi64( ( __m128i const* ) &piQCoef[y * piQCfStride] );
         v_level = _mm_and_si128(v_level,vlevmask);
         v_level = _mm_max_epi16 (v_level, v_min);
         v_level = _mm_min_epi16 (v_level, v_max);
@@ -108,7 +114,9 @@ static void DeQuantCoreSIMD(const int maxX,const int maxY,const int scale,const 
 
         v_level = _mm_max_epi32 (v_level, v_Tmin);
         v_level = _mm_min_epi32 (v_level, v_Tmax);
-        if( maxX == 1 )
+        if( maxX == 0 )
+          piCoef[y * width] = _mm_cvtsi128_si32( v_level );
+        else if( maxX == 1 )
           _vv_storel_epi64( (__m128i*)(piCoef + y * width), v_level );
         else
           _mm_storeu_si128( (__m128i*)(piCoef + y * width), v_level );
@@ -159,7 +167,12 @@ static void DeQuantCoreSIMD(const int maxX,const int maxY,const int scale,const 
     {
       for( int y = 0; y <= maxY; y++)
       {
-        __m128i v_level = maxX == 1 ? _mm_set1_epi32( *( ( int const* ) & piQCoef[y * piQCfStride] ) ) : _vv_loadl_epi64( ( __m128i const* ) &piQCoef[y * piQCfStride] );
+        // See the rightShift>0 branch above for why maxX==0 needs its own
+        // scalar load/store: the shared-with-maxX>=2 vector load/store
+        // would over-read/over-write a row that only owns 2/4 bytes.
+        __m128i v_level = maxX == 0 ? _mm_set1_epi16( piQCoef[y * piQCfStride] )
+                         : maxX == 1 ? _mm_set1_epi32( *( ( int const* ) & piQCoef[y * piQCfStride] ) )
+                         : _vv_loadl_epi64( ( __m128i const* ) &piQCoef[y * piQCfStride] );
         v_level = _mm_and_si128(v_level,vlevmask);
 
         v_level = _mm_max_epi16 (v_level, v_min);
@@ -173,7 +186,11 @@ static void DeQuantCoreSIMD(const int maxX,const int maxY,const int scale,const 
         v_level = _mm_max_epi32 (v_level, v_Tmin);
         v_level = _mm_min_epi32 (v_level, v_Tmax);
 
-        if( maxX == 1 )
+        if( maxX == 0 )
+        {
+          piCoef[y * width] = _mm_cvtsi128_si32( v_level );
+        }
+        else if( maxX == 1 )
         {
           _vv_storel_epi64( (__m128i*)(piCoef + y * width), v_level );
         }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -4103,6 +4103,28 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
              passed;
   }
 
+  // width==1's batch-of-4-rows loop (see dequantNeon) falls through to a
+  // scalar-style per-row tail for a non-multiple-of-4 remainder. Directed
+  // heights crossing that boundary: 3 (tail only, no full batch), 5/6/7
+  // (one full batch plus a 1/2/3-row tail), both with a tight and a padded
+  // (piQCfStride != width) input stride, to catch a lane-to-row mixup that
+  // a uniform or saturating buffer (as used elsewhere above) could hide.
+  // Coefficients are small, distinct per row, and alternate sign so a
+  // batch that silently permuted or dropped a row would show up as a
+  // mismatch instead of coincidentally matching via clipping.
+  for( int height : { 3, 5, 6, 7 } )
+  {
+    for( size_t stride : { ( size_t )1, ( size_t )1 + 3 } )
+    {
+      std::vector<TCoeffSig> coeff( ( size_t )height * stride, TCoeffSig( 0 ) );
+      for( int y = 0; y < height; y++ )
+        coeff[( size_t )y * stride] = TCoeffSig( ( y % 2 == 0 ) ? ( 10 + y ) : -( 10 + y ) );
+      passed = run_one( 0, height - 1, 64, coeff, stride, 1, realInputMaximumFor( 1 ), kRealTransformMaximum,
+                        "width=1 batch-tail boundary, stride=" + std::to_string( stride ) ) &&
+               passed;
+    }
+  }
+
   return passed;
 }
 

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3841,25 +3841,52 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
 }
 
 // Quant::dequant's !enableScalingLists path (Quant.cpp) always passes
-// inputMaximum == transformMaximum == 32767: maxLog2TrDynamicRange is a
-// fixed 15 (Slice.h), so transformMaximum = (1<<15)-1 unconditionally, and
-// the input clip depth d = min(16, 25+rightShift) is always 16 (see
-// kMinRealRightShift below), so inputMaximum = (1<<16>>1)-1 = 32767 too.
-static constexpr int kRealInputMaximum     = 32767;
+// transformMaximum == 32767: maxLog2TrDynamicRange is a fixed 15 (Slice.h),
+// so transformMaximum = (1<<15)-1 unconditionally. inputMaximum, however,
+// is NOT always 32767 -- see realInputMaximumFor() below, which mirrors the
+// call site's own derivation and must be used instead of a flat constant
+// once rightShift can reach -10 (see kMinRealRightShift).
 static constexpr TCoeff kRealTransformMaximum = 32767;
 
 // rightShift = IQUANT_SHIFT(6) - ((isTransformSkip?0:iTransformShift) + QP_per).
 // iTransformShift = 15 - bitDepth - ((log2(w)+log2(h))>>1) - (sqrtAdj?1:0)
 // (Quant.h/Quant.cpp), with bitDepth in {8,10} and QP_per bounded by baseQp's
 // clip to [0, 63+6*(bitDepth-8)] (Quant.cpp). Over the reachable ordinary
-// (power-of-two, 4..64) and ISP-degenerate (1x16/1x32/1x64 and mirrored)
-// shapes this gives non-transform-skip range [-9,7] and transform-skip range
-// [-6,6], so [-9,7] overall. Overflow check for that range: |q*scale| <=
-// 32767*102 < 2^22, and left-shifting that by the largest reachable
-// magnitude (9, from rightShift=-9) stays under 2^31-1, so int32 lanes
-// never overflow.
-static constexpr int kMinRealRightShift = -9;
+// (power-of-two, 4..64), ISP-degenerate (1x16/1x32/1x64 and mirrored), and
+// 4:2:0 narrow-chroma (2xN/Nx2, including SBT-quartered 2x2 -- see below)
+// shapes this gives non-transform-skip range [-10,7] and transform-skip
+// range [-6,6], so [-10,7] overall.
+//
+// The -10 endpoint: CU::checkAllowedSbt (UnitTools.cpp) permits a vertical
+// SBT half-split at luma CU width 8, the minimum SBT-eligible size, and
+// getSbtTuTiling (UnitPartitioner.cpp) applies that same split factor to
+// every component's own area, not just luma's. An 8-wide, 8-tall inter CU
+// in 4:2:0 has 4x4 chroma; halving that by SBT gives a 2x4 (or 4x2) chroma
+// residual TU -- already in realShapes below -- and a second SBT split (or
+// an 8x4 CU to begin with) halves the surviving chroma dimension again to
+// 2x2. At (log2(2)+log2(2))>>1 = 1 and QP_per's maximum (10 at 8-bit, 12 at
+// 10-bit), rightShift = 6 - (15-bitDepth-1) - QP_per bottoms out at -10.
+//
+// inputMaximum tracks rightShift at that endpoint too: the call site's
+// input clip depth d = min(16, 25+rightShift) is 16 (inputMaximum=32767)
+// for rightShift in [-9,7], but drops to 15 (inputMaximum=16383) at
+// rightShift==-10 -- see realInputMaximumFor(). Overflow check for the full
+// range: at rightShift==-10, |q*scale| <= 16383*102 < 2^21, and the left
+// shift by 10 stays under 2^31-1. For rightShift in [-9,7] the same bound
+// holds a fortiori with inputMaximum=32767 (|q*scale| <= 32767*102 < 2^22,
+// shifted by at most 9). int32 lanes never overflow.
+static constexpr int kMinRealRightShift = -10;
 static constexpr int kMaxRealRightShift = 7;
+
+// Mirrors Quant::dequant's !enableScalingLists inputMaximum derivation
+// (Quant.cpp): targetInputBitDepth = min(maxLog2TrDynamicRange+1, 32+rightShift-scaleBits)
+// = min(16, 25+rightShift), since maxLog2TrDynamicRange is fixed at 15,
+// Intermediate_Int is 32-bit, and scaleBits = IQUANT_SHIFT(6)+1 = 7.
+static int realInputMaximumFor( int rightShift )
+{
+  const int targetInputBitDepth = std::min( 16, 25 + rightShift );
+  return ( 1 << ( targetInputBitDepth - 1 ) ) - 1;
+}
 
 static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
 {
@@ -3902,13 +3929,14 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
 
   // Random sweep across the real call-site domain: shapes reachable via
   // ordinary (power-of-two) transforms, ISP-degenerate 1xN/Nx1 blocks, and
-  // 4:2:0 chroma narrow 2xN/Nx2 blocks; scale from the real table;
+  // 4:2:0 chroma narrow 2xN/Nx2 blocks (including the SBT-quartered 2x2
+  // case -- see kMinRealRightShift above); scale from the real table;
   // rightShift from the domain derived above.
   static const std::pair<int, int> realShapes[] = {
     { 4, 4 },   { 4, 8 },   { 8, 4 },   { 8, 8 },   { 8, 16 },  { 16, 8 },  { 16, 16 }, { 16, 32 },
     { 32, 16 }, { 32, 32 }, { 32, 64 }, { 64, 32 }, { 64, 64 }, { 1, 16 },  { 1, 32 },  { 1, 64 },
     { 16, 1 },  { 32, 1 },  { 64, 1 },  { 2, 4 },   { 4, 2 },   { 2, 8 },   { 8, 2 },   { 2, 16 },
-    { 16, 2 },  { 2, 32 },  { 32, 2 },
+    { 16, 2 },  { 2, 32 },  { 32, 2 },  { 2, 2 },
   };
 
   for( unsigned n = 0; n < num_cases; n++ )
@@ -3921,8 +3949,8 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
     const size_t stride     = w;
 
     std::vector<TCoeffSig> coeff = makeTightBuffer( w - 1, h - 1, stride, 0, /*useGen=*/true );
-    passed = run_one( w - 1, h - 1, scale, coeff, stride, rightShift, kRealInputMaximum, kRealTransformMaximum,
-                      "random" ) &&
+    passed = run_one( w - 1, h - 1, scale, coeff, stride, rightShift, realInputMaximumFor( rightShift ),
+                      kRealTransformMaximum, "random" ) &&
              passed;
   }
 
@@ -3930,18 +3958,19 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
   const int directedShifts[] = { kMinRealRightShift, -1, 0, 1, kMaxRealRightShift };
   for( int width : { 1, 2, 4, 8, 16, 32, 64 } )
   {
-    for( int height : { 1, 4 } )
+    for( int height : { 1, 2, 4 } )
     {
       for( int scale : { 40, 64, 102 } ) // table extremes plus a power-of-two middle value
       {
         for( int rightShift : directedShifts )
         {
-          const size_t stride = width;
+          const size_t stride        = width;
+          const int    inputMaximum  = realInputMaximumFor( rightShift );
 
           // all-zero
           {
             std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, false );
-            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, inputMaximum,
                               kRealTransformMaximum, "all-zero" ) &&
                      passed;
           }
@@ -3949,7 +3978,7 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
           for( TCoeffSig extreme : { TCoeffSig( 32767 ), TCoeffSig( -32768 ) } )
           {
             std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, extreme, false );
-            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, inputMaximum,
                               kRealTransformMaximum, "all-extreme " + std::to_string( extreme ) ) &&
                      passed;
           }
@@ -3958,7 +3987,7 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
             std::vector<TCoeffSig> coeff( (size_t)height * stride, TCoeffSig( 0 ) );
             for( size_t i = 0; i < coeff.size(); i++ )
               coeff[i] = ( i & 1 ) ? TCoeffSig( -32768 ) : TCoeffSig( 32767 );
-            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, inputMaximum,
                               kRealTransformMaximum, "alternating-sign" ) &&
                      passed;
           }
@@ -3968,7 +3997,7 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
           {
             std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, false );
             coeff[7] = TCoeffSig( -32768 );
-            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, inputMaximum,
                               kRealTransformMaximum, "isolated pos=7" ) &&
                      passed;
           }
@@ -3977,11 +4006,34 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
     }
   }
 
+  // Directed real-domain boundary case: an 8-wide inter CU's SBT-quartered
+  // 2x2 chroma residual TU (see kMinRealRightShift above) at QP_per's
+  // maximum drives rightShift to -10, which is also the only real-domain
+  // value where inputMaximum drops below 32767 -- to 16383. This is the
+  // production combination the [-9,7]/32767-only assumption used to miss;
+  // exercise the kernel's input-clamp branch right at that real boundary,
+  // not just the synthetic inputMaximum==100 case above.
+  {
+    const int width = 2, height = 2, scale = 64, rightShift = kMinRealRightShift;
+    const int inputMaximum = realInputMaximumFor( rightShift );
+    CHECK( inputMaximum != 16383, "expected the real rightShift=-10 call site to clip at 16383" );
+    for( TCoeffSig q : { TCoeffSig( 16382 ), TCoeffSig( 16383 ), TCoeffSig( 16384 ), TCoeffSig( -16384 ),
+                        TCoeffSig( -16385 ), TCoeffSig( -16386 ), TCoeffSig( 32767 ), TCoeffSig( -32768 ) } )
+    {
+      std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, width, q, false );
+      passed = run_one( width - 1, height - 1, scale, coeff, width, rightShift, inputMaximum, kRealTransformMaximum,
+                        "2x2 SBT chroma input-clip q=" + std::to_string( q ) ) &&
+               passed;
+    }
+  }
+
   // Function-domain edge case, not a real call-site value: an inputMaximum
-  // below the real 32767 (real call sites always pass 32767, since the input
-  // clip depth is always 16 in-domain -- see kMinRealRightShift above), so
-  // this is the only way to exercise the input-clamp branch of the kernel
-  // at all. Coefficients just below/at/above the clip boundary, both signs.
+  // this far below 32767 never occurs at a real call site (the smallest
+  // real inputMaximum is 16383, at rightShift==-10 -- see
+  // realInputMaximumFor() and the directed 2x2-chroma case above), but it's
+  // the cheapest way to exercise the kernel's input-clamp branch at a small,
+  // easy-to-reason-about boundary. Coefficients just below/at/above the
+  // clip boundary, both signs.
   {
     const int inputMaximum = 100;
     const int width = 4, height = 2, scale = 64, rightShift = 1;
@@ -4006,7 +4058,7 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
     const int    height = 4;
     const size_t stride = width + 3;
     std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, /*useGen=*/true );
-    passed = run_one( width - 1, height - 1, 64, coeff, stride, 2, kRealInputMaximum, kRealTransformMaximum,
+    passed = run_one( width - 1, height - 1, 64, coeff, stride, 2, realInputMaximumFor( 2 ), kRealTransformMaximum,
                       "padded-stride" ) &&
              passed;
   }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3853,28 +3853,34 @@ static constexpr TCoeff kRealTransformMaximum = 32767;
 // (Quant.h/Quant.cpp), with bitDepth in {8,10} and QP_per bounded by baseQp's
 // clip to [0, 63+6*(bitDepth-8)] (Quant.cpp). Over the reachable ordinary
 // (power-of-two, 4..64), ISP-degenerate (1x16/1x32/1x64 and mirrored), and
-// 4:2:0 narrow-chroma (2xN/Nx2, including SBT-quartered 2x2 -- see below)
+// 4:2:0 narrow-chroma (2xN/Nx2, including SBT-halved 2x2 -- see below)
 // shapes this gives non-transform-skip range [-10,7] and transform-skip
 // range [-6,6], so [-10,7] overall.
 //
 // The -10 endpoint: CU::checkAllowedSbt (UnitTools.cpp) permits a vertical
 // SBT half-split at luma CU width 8, the minimum SBT-eligible size, and
 // getSbtTuTiling (UnitPartitioner.cpp) applies that same split factor to
-// every component's own area, not just luma's. An 8-wide, 8-tall inter CU
-// in 4:2:0 has 4x4 chroma; halving that by SBT gives a 2x4 (or 4x2) chroma
-// residual TU -- already in realShapes below -- and a second SBT split (or
-// an 8x4 CU to begin with) halves the surviving chroma dimension again to
-// 2x2. At (log2(2)+log2(2))>>1 = 1 and QP_per's maximum (10 at 8-bit, 12 at
-// 10-bit), rightShift = 6 - (15-bitDepth-1) - QP_per bottoms out at -10.
+// every component's own area, not just luma's. An 8x4 (or 4x8) inter CU in
+// 4:2:0 has 4x2 (or 2x4) chroma -- already in realShapes below -- and a
+// single vertical- (or horizontal-) half SBT split halves that once more to
+// 2x2 (a 16x4 CU with a vertical-quarter SBT split reaches the same 2x2
+// chroma shape too). SBT cannot recurse into a second split of an
+// already-SBT-split TU (Partitioner::canSplit only allows an SBT split at
+// currTrDepth==0), so one SBT split on an already-narrow chroma dimension
+// is the only way to reach 2x2. At (log2(2)+log2(2))>>1 = 1 and QP_per's
+// maximum (10 at 8-bit, 12 at 10-bit), rightShift = 6 - (15-bitDepth-1) -
+// QP_per bottoms out at -10.
 //
 // inputMaximum tracks rightShift at that endpoint too: the call site's
 // input clip depth d = min(16, 25+rightShift) is 16 (inputMaximum=32767)
 // for rightShift in [-9,7], but drops to 15 (inputMaximum=16383) at
 // rightShift==-10 -- see realInputMaximumFor(). Overflow check for the full
-// range: at rightShift==-10, |q*scale| <= 16383*102 < 2^21, and the left
-// shift by 10 stays under 2^31-1. For rightShift in [-9,7] the same bound
-// holds a fortiori with inputMaximum=32767 (|q*scale| <= 32767*102 < 2^22,
-// shifted by at most 9). int32 lanes never overflow.
+// range: clip(q, -inputMaximum-1, inputMaximum) admits the asymmetric
+// minimum -inputMaximum-1, so at rightShift==-10, |q*scale| <=
+// 16384*102 < 2^21, and the left shift by 10 stays under 2^31-1. For
+// rightShift in [-9,7] the same argument holds a fortiori with
+// inputMaximum=32767 (|q*scale| <= 32768*102 < 2^22, shifted by at most 9).
+// int32 lanes never overflow.
 static constexpr int kMinRealRightShift = -10;
 static constexpr int kMaxRealRightShift = 7;
 
@@ -3929,7 +3935,7 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
 
   // Random sweep across the real call-site domain: shapes reachable via
   // ordinary (power-of-two) transforms, ISP-degenerate 1xN/Nx1 blocks, and
-  // 4:2:0 chroma narrow 2xN/Nx2 blocks (including the SBT-quartered 2x2
+  // 4:2:0 chroma narrow 2xN/Nx2 blocks (including the SBT-halved 2x2
   // case -- see kMinRealRightShift above); scale from the real table;
   // rightShift from the domain derived above.
   static const std::pair<int, int> realShapes[] = {
@@ -3955,7 +3961,9 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
   }
 
   // Directed cases, still inside the real domain, asserted.
-  const int directedShifts[] = { kMinRealRightShift, -1, 0, 1, kMaxRealRightShift };
+  // kMinRealRightShift+1 (-9) is the boundary where inputMaximum switches
+  // back from 16383 to the ordinary 32767 -- worth its own directed point.
+  const int directedShifts[] = { kMinRealRightShift, kMinRealRightShift + 1, -1, 0, 1, kMaxRealRightShift };
   for( int width : { 1, 2, 4, 8, 16, 32, 64 } )
   {
     for( int height : { 1, 2, 4 } )
@@ -4006,23 +4014,55 @@ static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
     }
   }
 
-  // Directed real-domain boundary case: an 8-wide inter CU's SBT-quartered
-  // 2x2 chroma residual TU (see kMinRealRightShift above) at QP_per's
-  // maximum drives rightShift to -10, which is also the only real-domain
-  // value where inputMaximum drops below 32767 -- to 16383. This is the
-  // production combination the [-9,7]/32767-only assumption used to miss;
-  // exercise the kernel's input-clamp branch right at that real boundary,
-  // not just the synthetic inputMaximum==100 case above.
+  // Directed real-domain boundary case: an 8x4 (or 4x8) inter CU's
+  // single-half-SBT-split 2x2 chroma residual TU (see kMinRealRightShift
+  // above) at QP_per's maximum drives rightShift to -10, which is also the
+  // only real-domain value where inputMaximum drops below 32767 -- to
+  // 16383. This is the production combination the [-9,7]/32767-only
+  // assumption used to miss; exercise the kernel's input-clamp branch right
+  // at that real boundary, not just the synthetic inputMaximum==100 case
+  // above. scale is capped at 57 here, not the table's overall max of 102:
+  // QP_per's maximum only happens at baseQp's own clipped maximum (63 at
+  // 8-bit, 75 at 10-bit), which limits QP_rem -- and so g_invQuantScales's
+  // column index -- to 0..3, and a square 2x2 shape takes the
+  // no-sqrt-adjustment row ({40,45,51,57}), whose largest entry is 57.
   {
-    const int width = 2, height = 2, scale = 64, rightShift = kMinRealRightShift;
+    const int width = 2, height = 2, scale = 57, rightShift = kMinRealRightShift;
     const int inputMaximum = realInputMaximumFor( rightShift );
     CHECK( inputMaximum != 16383, "expected the real rightShift=-10 call site to clip at 16383" );
-    for( TCoeffSig q : { TCoeffSig( 16382 ), TCoeffSig( 16383 ), TCoeffSig( 16384 ), TCoeffSig( -16384 ),
-                        TCoeffSig( -16385 ), TCoeffSig( -16386 ), TCoeffSig( 32767 ), TCoeffSig( -32768 ) } )
+    for( TCoeffSig q : { TCoeffSig( 0 ), TCoeffSig( 1 ), TCoeffSig( -1 ), TCoeffSig( 16382 ), TCoeffSig( 16383 ),
+                        TCoeffSig( 16384 ), TCoeffSig( -16384 ), TCoeffSig( -16385 ), TCoeffSig( -16386 ),
+                        TCoeffSig( 32767 ), TCoeffSig( -32768 ) } )
     {
       std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, width, q, false );
       passed = run_one( width - 1, height - 1, scale, coeff, width, rightShift, inputMaximum, kRealTransformMaximum,
                         "2x2 SBT chroma input-clip q=" + std::to_string( q ) ) &&
+               passed;
+    }
+  }
+
+  // Deterministic rounding tie, checked against a hand-computed expected
+  // value rather than just scalar-vs-optimized equivalence (which run_one
+  // alone gives): rightShift>0's rounding add-then-shift can round a tie
+  // either up or down depending on the implementation, so pin one down.
+  // scale=45, rightShift=1: v = (q*scale + (1<<(rightShift-1))) >> rightShift.
+  // q=1: (45+1)>>1 = 23. q=-1: (-45+1)>>1 = -44>>1 = -22 (exact, no
+  // further rounding ambiguity since -44 is even).
+  {
+    const int width = 1, height = 1, scale = 45, rightShift = 1;
+    const int inputMaximum = realInputMaximumFor( rightShift );
+    for( const auto& kv : std::vector<std::pair<TCoeffSig, TCoeff>>{ { 1, 23 }, { -1, -22 } } )
+    {
+      const TCoeffSig q        = kv.first;
+      const TCoeff    expected = kv.second;
+      std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, width, q, false );
+      TCoeff outRef = 0;
+      ref->xDeQuant( width - 1, height - 1, scale, coeff.data(), width, &outRef, rightShift, inputMaximum,
+                     kRealTransformMaximum );
+      CHECK( outRef != expected, "rounding-tie q=" + std::to_string( q ) + " expected " +
+                                      std::to_string( expected ) + " got " + std::to_string( outRef ) );
+      passed = run_one( width - 1, height - 1, scale, coeff, width, rightShift, inputMaximum, kRealTransformMaximum,
+                        "rounding-tie q=" + std::to_string( q ) ) &&
                passed;
     }
   }

--- a/test/vvenc_unit_test/vvenc_unit_test.cpp
+++ b/test/vvenc_unit_test/vvenc_unit_test.cpp
@@ -3840,13 +3840,189 @@ static bool check_needRdoq( Quant* ref, Quant* opt, unsigned num_cases )
   return passed;
 }
 
+// Quant::dequant's !enableScalingLists path (Quant.cpp) always passes
+// inputMaximum == transformMaximum == 32767: maxLog2TrDynamicRange is a
+// fixed 15 (Slice.h), so transformMaximum = (1<<15)-1 unconditionally, and
+// the input clip depth d = min(16, 25+rightShift) is always 16 (see
+// kMinRealRightShift below), so inputMaximum = (1<<16>>1)-1 = 32767 too.
+static constexpr int kRealInputMaximum     = 32767;
+static constexpr TCoeff kRealTransformMaximum = 32767;
+
+// rightShift = IQUANT_SHIFT(6) - ((isTransformSkip?0:iTransformShift) + QP_per).
+// iTransformShift = 15 - bitDepth - ((log2(w)+log2(h))>>1) - (sqrtAdj?1:0)
+// (Quant.h/Quant.cpp), with bitDepth in {8,10} and QP_per bounded by baseQp's
+// clip to [0, 63+6*(bitDepth-8)] (Quant.cpp). Over the reachable ordinary
+// (power-of-two, 4..64) and ISP-degenerate (1x16/1x32/1x64 and mirrored)
+// shapes this gives non-transform-skip range [-9,7] and transform-skip range
+// [-6,6], so [-9,7] overall. Overflow check for that range: |q*scale| <=
+// 32767*102 < 2^22, and left-shifting that by the largest reachable
+// magnitude (9, from rightShift=-9) stays under 2^31-1, so int32 lanes
+// never overflow.
+static constexpr int kMinRealRightShift = -9;
+static constexpr int kMaxRealRightShift = 7;
+
+static bool check_dequant( Quant* ref, Quant* opt, unsigned num_cases )
+{
+  std::cout << "Testing Quant::dequant\n";
+
+  DimensionGenerator rng;
+  InputGenerator<TCoeffSig> coeffGen{ 16 }; // matches the real +-2^15 quantized-coefficient range
+
+  // g_invQuantScales values (Rom.cpp), both rows flattened: always positive, always < 2^15.
+  static const std::vector<int> invQuantScales{ 40, 45, 51, 57, 64, 72, 80, 90, 102 };
+
+  auto run_one = [&]( int maxX, int maxY, int scale, const std::vector<TCoeffSig>& coeff, size_t stride,
+                       int rightShift, int inputMaximum, TCoeff transformMaximum, const std::string& label ) -> bool {
+    const int width  = maxX + 1;
+    const int height = maxY + 1;
+    std::ostringstream sstm;
+    sstm << "Quant::dequant " << label << " w=" << width << " h=" << height << " scale=" << scale
+         << " rightShift=" << rightShift << " inputMaximum=" << inputMaximum
+         << " transformMaximum=" << transformMaximum;
+
+    std::vector<TCoeff> outRef( (size_t)width * height );
+    std::vector<TCoeff> outOpt( (size_t)width * height );
+    ref->xDeQuant( maxX, maxY, scale, coeff.data(), stride, outRef.data(), rightShift, inputMaximum, transformMaximum );
+    opt->xDeQuant( maxX, maxY, scale, coeff.data(), stride, outOpt.data(), rightShift, inputMaximum, transformMaximum );
+    return compare_values_2d( sstm.str(), outRef.data(), outOpt.data(), height, width );
+  };
+
+  // Builds a coefficient buffer sized exactly to what a (maxX,maxY,stride) call
+  // addresses -- no trailing slack -- so a genuine tight-buffer over-read (the
+  // kind that would trip up ASan) isn't hidden behind extra padding.
+  auto makeTightBuffer = [&]( int maxX, int maxY, size_t stride, TCoeffSig fillVal, bool useGen ) -> std::vector<TCoeffSig> {
+    std::vector<TCoeffSig> buf( (size_t)maxY * stride + ( maxX + 1 ) );
+    for( int y = 0; y <= maxY; y++ )
+      for( int x = 0; x <= maxX; x++ )
+        buf[y * stride + x] = useGen ? coeffGen() : fillVal;
+    return buf;
+  };
+
+  bool passed = true;
+
+  // Random sweep across the real call-site domain: shapes reachable via
+  // ordinary (power-of-two) transforms, ISP-degenerate 1xN/Nx1 blocks, and
+  // 4:2:0 chroma narrow 2xN/Nx2 blocks; scale from the real table;
+  // rightShift from the domain derived above.
+  static const std::pair<int, int> realShapes[] = {
+    { 4, 4 },   { 4, 8 },   { 8, 4 },   { 8, 8 },   { 8, 16 },  { 16, 8 },  { 16, 16 }, { 16, 32 },
+    { 32, 16 }, { 32, 32 }, { 32, 64 }, { 64, 32 }, { 64, 64 }, { 1, 16 },  { 1, 32 },  { 1, 64 },
+    { 16, 1 },  { 32, 1 },  { 64, 1 },  { 2, 4 },   { 4, 2 },   { 2, 8 },   { 8, 2 },   { 2, 16 },
+    { 16, 2 },  { 2, 32 },  { 32, 2 },
+  };
+
+  for( unsigned n = 0; n < num_cases; n++ )
+  {
+    const std::pair<int, int>& shape = realShapes[rng.get( 0, (unsigned)( sizeof( realShapes ) / sizeof( realShapes[0] ) ) - 1 )];
+    const int    w          = shape.first;
+    const int    h          = shape.second;
+    const int    scale      = rng.getOneOf( invQuantScales );
+    const int    rightShift = (int)rng.get( 0, kMaxRealRightShift - kMinRealRightShift ) + kMinRealRightShift;
+    const size_t stride     = w;
+
+    std::vector<TCoeffSig> coeff = makeTightBuffer( w - 1, h - 1, stride, 0, /*useGen=*/true );
+    passed = run_one( w - 1, h - 1, scale, coeff, stride, rightShift, kRealInputMaximum, kRealTransformMaximum,
+                      "random" ) &&
+             passed;
+  }
+
+  // Directed cases, still inside the real domain, asserted.
+  const int directedShifts[] = { kMinRealRightShift, -1, 0, 1, kMaxRealRightShift };
+  for( int width : { 1, 2, 4, 8, 16, 32, 64 } )
+  {
+    for( int height : { 1, 4 } )
+    {
+      for( int scale : { 40, 64, 102 } ) // table extremes plus a power-of-two middle value
+      {
+        for( int rightShift : directedShifts )
+        {
+          const size_t stride = width;
+
+          // all-zero
+          {
+            std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, false );
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+                              kRealTransformMaximum, "all-zero" ) &&
+                     passed;
+          }
+          // extremes: all at the max/min representable quantized coefficient
+          for( TCoeffSig extreme : { TCoeffSig( 32767 ), TCoeffSig( -32768 ) } )
+          {
+            std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, extreme, false );
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+                              kRealTransformMaximum, "all-extreme " + std::to_string( extreme ) ) &&
+                     passed;
+          }
+          // alternating sign, filled across the whole block
+          {
+            std::vector<TCoeffSig> coeff( (size_t)height * stride, TCoeffSig( 0 ) );
+            for( size_t i = 0; i < coeff.size(); i++ )
+              coeff[i] = ( i & 1 ) ? TCoeffSig( -32768 ) : TCoeffSig( 32767 );
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+                              kRealTransformMaximum, "alternating-sign" ) &&
+                     passed;
+          }
+          // isolated non-zero at the last lane of the second 4-lane store
+          // (the width>=8 dispatch branch's high-half vst1q_s32)
+          if( width >= 8 )
+          {
+            std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, false );
+            coeff[7] = TCoeffSig( -32768 );
+            passed = run_one( width - 1, height - 1, scale, coeff, stride, rightShift, kRealInputMaximum,
+                              kRealTransformMaximum, "isolated pos=7" ) &&
+                     passed;
+          }
+        }
+      }
+    }
+  }
+
+  // Function-domain edge case, not a real call-site value: an inputMaximum
+  // below the real 32767 (real call sites always pass 32767, since the input
+  // clip depth is always 16 in-domain -- see kMinRealRightShift above), so
+  // this is the only way to exercise the input-clamp branch of the kernel
+  // at all. Coefficients just below/at/above the clip boundary, both signs.
+  {
+    const int inputMaximum = 100;
+    const int width = 4, height = 2, scale = 64, rightShift = 1;
+    for( TCoeffSig q : { TCoeffSig( 99 ), TCoeffSig( 100 ), TCoeffSig( 101 ), TCoeffSig( -100 ), TCoeffSig( -101 ),
+                        TCoeffSig( -102 ) } )
+    {
+      std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, width, q, false );
+      passed = run_one( width - 1, height - 1, scale, coeff, width, rightShift, inputMaximum, kRealTransformMaximum,
+                        "input-clip q=" + std::to_string( q ) ) &&
+               passed;
+    }
+  }
+
+  // Function-domain edge case, not a real call-site value: piQCfStride
+  // always equals width at real call sites (Quant::dequant's coefficient
+  // buffer, from TransformUnit::getCoeffs, is always tightly packed; see
+  // Buffer.h's AreaBuf stride). This exercises the row-start address
+  // arithmetic (piQCoef + y*piQCfStride) with a stride wider than the row
+  // it addresses, for every width-dispatch branch including width==1.
+  for( int width : { 1, 2, 4, 8, 16, 32, 64 } )
+  {
+    const int    height = 4;
+    const size_t stride = width + 3;
+    std::vector<TCoeffSig> coeff = makeTightBuffer( width - 1, height - 1, stride, 0, /*useGen=*/true );
+    passed = run_one( width - 1, height - 1, 64, coeff, stride, 2, kRealInputMaximum, kRealTransformMaximum,
+                      "padded-stride" ) &&
+             passed;
+  }
+
+  return passed;
+}
+
 static bool test_Quant()
 {
   Quant ref( /*other=*/nullptr, /*useScalingLists=*/false, /*enableOpt=*/false );
   Quant opt( /*other=*/nullptr, /*useScalingLists=*/false, /*enableOpt=*/true );
 
   unsigned num_cases = NUM_CASES;
-  return check_needRdoq( &ref, &opt, num_cases );
+  bool     passed    = check_needRdoq( &ref, &opt, num_cases );
+  passed             = check_dequant( &ref, &opt, num_cases ) && passed;
+  return passed;
 }
 #endif // ENABLE_SIMD_OPT_QUANT
 


### PR DESCRIPTION
Follow-up to #723, continuing the ARM SIMD porting stream tracked in #711. Second of the three functions in `QuantX86.h` (`NeedRdoqSIMD`, `DeQuantCoreSIMD`, `QuantCoreSIMD`); `QuantCoreSIMD` is the remaining follow-up.

## Change
`Quant::xDeQuant` dequantizes a full transform block: for each coefficient, it clips to `[-inputMaximum-1, inputMaximum]`, multiplies by `scale`, rounds and shifts by `rightShift` (a rounded right shift if positive, an unrounded left shift otherwise), and clips the result to `[-transformMaximum-1, transformMaximum]`.

A single `vrshlq_s32` with a per-lane shift count of `-rightShift` reproduces both scalar branches exactly -- SRSHL's rounded-right-shift semantics for a negative count match the scalar's `(v + (1<<(rightShift-1))) >> rightShift`, and its plain-left-shift semantics for a non-negative count match the scalar's unrounded `<< -rightShift` -- so the kernel has no branch on `rightShift`'s sign at all. `TCoeffSig` is 16-bit and `TCoeff`/`Intermediate_Int` are 32-bit, so one widening multiply (`vmull_n_s16`) into 32-bit lanes is enough. Only ARMv7-available intrinsics are used, since upstream still builds and CI-checks 32-bit Arm.

Real call sites (`Quant::dequant`'s `!enableScalingLists` path) pass a width (`maxX+1`) of 1 (degenerate ISP blocks), 2 (narrow chroma or ISP luma sub-partitions), 4, or a multiple of eight (ordinary transform sizes up to 64) -- never 3, 5, 6, or 7. Each width dispatches to an exactly-sized tight load/store.

The directed width-1 test case exposed a pre-existing bug in `DeQuantCoreSIMD`: its `maxX==0` branch shares a vector load/store with `maxX==1`, reading 6 bytes and writing 12 bytes past what a tightly allocated width-1 row owns. Fixed in the first commit (confirmed with ASan: the old code aborts with a heap-buffer-overflow on a tight buffer, the fixed code doesn't; the encodes described below, compared coefficient-for-coefficient, were otherwise bit-identical before and after this fix -- only the out-of-bounds access is removed). The Neon kernel doesn't repeat the bug.

`xDeQuant` moved from `private` to `public`, mirroring `xNeedRdoq` from #723, so the unit test can construct a scalar-only reference `Quant` instance and call it directly.

## Testing
`Quant` unit test compares scalar vs optimized output exactly, covering:
- a random sweep independently sampling shape, scale, and `rightShift` from the sets each is reachable over (shapes: ordinary transforms, ISP-degenerate 1xN/Nx1 blocks, and narrow 2xN/Nx2 blocks including 2x2 -- an SBT-halved chroma residual TU at an 8x4/4x8 inter CU; `rightShift`: `[-10,7]`, the full range `getTransformShift()`/`IQUANT_SHIFT` can produce over that domain per `Quant.cpp`) -- a conservative cross-product covering the reachable domain rather than only the exact (shape, rightShift) pairs a real encode would jointly produce
- directed cases for every width-dispatch branch (1/2/4/8/16/32/64): all-zero, representable extremes both signs, alternating sign, an isolated last-lane value in the width>=8 branch's second store
- the input-clamp branch: `inputMaximum` is 32767 for `rightShift >= -9`, but real call sites do reach `inputMaximum == 16383` at the domain's `rightShift == -10` endpoint (the 2x2 SBT-chroma case above) -- a directed case exercises exactly that real combination, in addition to a synthetic smaller-`inputMaximum` case for the clamp branch's general behavior
- a padded-stride case (also function-domain only: `piQCfStride` always equals width at real call sites)
- directed width==1 cases at heights 3, 5, 6, and 7 (crossing the width==1 NEON path's batch-of-4-rows/scalar-tail boundary added below), each with a tight and a padded stride, using distinct small alternating-sign coefficients per row so a lane-to-row mixup can't hide behind saturation

Verified bit-exact against scalar via encodes with `--DepQuant 0` (forces the ordinary dequant path; confirmed with a call counter that this hits `xDeQuant` ~343k times, all non-transform-skip) and `--TransformSkip 1` (forces transform-skip blocks to occur; confirmed ~21k `xDeQuant` calls, all transform-skip), at both 8- and 10-bit. Full unit test suite passed on both ARM and x86 (SIMDe), including under ASan with tightly allocated buffers for every width, and against a 32-bit Arm build -- against the kernel as of the first two commits.

Re-run against the current head (including the width==1/clamp restructuring below and the added boundary tests) under `-fsanitize=address,undefined` with the same tightly allocated buffers: the suite completes with no reported ASan/UBSan finding tracing to `Quant_neon.cpp` or `Quant.cpp`; a handful of pre-existing UBSan diagnostics unrelated to this PR remain elsewhere in the codebase (a generic test helper template, and NEON kernels in `MCTF_neon.h`, `InterPred_neon.cpp`, `AffineGradientSearch_neon.cpp`, `InterpolationFilter_neon.cpp`).

## Performance
Microbenchmark on Apple Silicon (clang -O3): a fixed-parameter kernel benchmark, not an end-to-end encoder measurement. Each shape times 200k calls with a fixed `scale=64`, `rightShift=2`, `inputMaximum=transformMaximum=32767`, a tight input stride, and reused input/output buffers, against the generic scalar `DeQuantCore` reference (not a width-1-specialized scalar loop) -- called through volatile function pointers (matching the real dispatch pattern -- `xDeQuant` is a function-pointer member, never inlined at the real call site). Table values are the median of 9 per-trial timing ratios, rerun 3x to check variance; updated after addressing review feedback below (loop structure, input clamping):

| shape | scalar/new speedup |
|---|---|
| 4x4 | ~5.1-5.2x |
| 8x8 | ~1.3x |
| 16x16 | ~1.3x |
| 32x32 | ~1.4x |
| 64x64 | ~1.4x |
| 1x16 | ~4.1-4.2x |
| 1x64 | ~5.6-5.7x |
| 2x8 | ~3.7-3.8x |
| 2x32 | ~3.4-4.5x across rerun medians (noisiest shape measured) |

The new kernel is faster than the generic scalar reference on every measured shape. Against the previous (pre-review-feedback) Neon version, 16x16-64x64 improved by roughly 1.24x-1.34x and 8x8/2x8 by roughly 1.05x-1.08x from the combined loop-structure-plus-clamping restructuring below (the benchmark doesn't isolate either change's individual contribution); width==1 (1x16, 1x64) showed the largest relative old-to-new improvement, roughly 1.9x-2.4x, from batching four rows per multiply/shift/store instead of one.



